### PR TITLE
Add docs for new refactoring tools

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -174,7 +174,97 @@ public Calculator(string op)
 // SetFormat method would need to be removed or refactored since field is now readonly
 ```
 
-## 5. Load Solution (Utility Command)
+## 5. Introduce Parameter
+
+**Purpose**: Extract an expression into a new method parameter.
+
+### Example
+**Before** (in `ExampleCode.cs` line 41):
+```csharp
+public string FormatResult(int value)
+{
+    return $"The calculation result is: {value * 2 + 10}";
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-parameter \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  40 \
+  "41:50-41:65" \
+  "processedValue"
+```
+
+**After**:
+```csharp
+public string FormatResult(int value, int processedValue)
+{
+    return $"The calculation result is: {processedValue}";
+}
+```
+
+## 6. Convert to Static with Parameters
+
+**Purpose**: Convert an instance method to static by turning field and property usages into parameters.
+
+### Example
+**Before** (in `ExampleCode.cs` line 46):
+```csharp
+public string GetFormattedNumber(int number)
+{
+    return $"{operatorSymbol}: {number}";
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-parameters \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  46
+```
+
+**After**:
+```csharp
+public static string GetFormattedNumber(string operatorSymbol, int number)
+{
+    return $"{operatorSymbol}: {number}";
+}
+```
+
+## 7. Convert to Static with Instance
+
+**Purpose**: Convert an instance method to static and add an explicit instance parameter for member access.
+
+### Example
+**Before** (same as previous example):
+```csharp
+public string GetFormattedNumber(int number)
+{
+    return $"{operatorSymbol}: {number}";
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-instance \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  46 \
+  "calculator"
+```
+
+**After**:
+```csharp
+public static string GetFormattedNumber(Calculator calculator, int number)
+{
+    return $"{calculator.operatorSymbol}: {number}";
+}
+```
+
+## 8. Load Solution (Utility Command)
 
 **Purpose**: Load and validate a solution file before performing refactorings.
 
@@ -189,7 +279,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test load-solution "./RefactorM
 Successfully loaded solution 'RefactorMCP.sln' with 2 projects: RefactorMCP.ConsoleApp, RefactorMCP.Tests
 ```
 
-## 6. List Tools (Utility Command)
+## 9. List Tools (Utility Command)
 
 **Purpose**: Display all available refactoring tools and their status.
 
@@ -202,18 +292,18 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test list-tools
 **Output**:
 ```
 Available refactoring tools:
-load-solution - Load a solution file for refactoring operations
-extract-method - Extract selected code into a new method
-introduce-field - Create a new field from selected code
-introduce-variable - Create a new variable from selected code
-make-field-readonly - Make a field readonly and move initialization to constructors
-introduce-parameter - Create a new parameter from selected code (TODO)
-convert-to-static-with-parameters - Transform instance method to static (TODO)
-convert-to-static-with-instance - Transform instance method to static with instance parameter (TODO)
-move-static-method - Move a static method to another class (TODO)
-move-instance-method - Move an instance method to another class (TODO)
-transform-setter-to-init - Convert property setter to init-only setter (TODO)
-safe-delete - Safely delete a field, parameter, or variable (TODO)
+    load-solution - Load a solution file for refactoring operations
+    extract-method - Extract selected code into a new method
+    introduce-field - Create a new field from selected code
+    introduce-variable - Create a new variable from selected code
+    make-field-readonly - Make a field readonly and move initialization to constructors
+    introduce-parameter - Create a new parameter from selected code
+    convert-to-static-with-parameters - Transform instance method to static
+    convert-to-static-with-instance - Transform instance method to static with instance parameter
+    move-static-method - Move a static method to another class (TODO)
+    move-instance-method - Move an instance method to another class (TODO)
+    transform-setter-to-init - Convert property setter to init-only setter (TODO)
+    safe-delete - Safely delete a field, parameter, or variable (TODO)
 ```
 
 ## Range Format

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -51,6 +51,33 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test make-field-readonly \
   lineNumber
 ```
 
+### Introduce Parameter
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-parameter \
+  "./RefactorMCP.sln" \
+  "./path/to/file.cs" \
+  methodLine \
+  "startLine:startCol-endLine:endCol" \
+  "parameterName"
+```
+
+### Convert to Static with Parameters
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-parameters \
+  "./RefactorMCP.sln" \
+  "./path/to/file.cs" \
+  methodLine
+```
+
+### Convert to Static with Instance
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-instance \
+  "./RefactorMCP.sln" \
+  "./path/to/file.cs" \
+  methodLine \
+  "instanceName"
+```
+
 ## Range Format
 
 `"startLine:startColumn-endLine:endColumn"`
@@ -76,6 +103,9 @@ return numbers.Sum() / (double)numbers.Count;
 // Line 41: Introduce Variable example
 return $"The calculation result is: {value * 2 + 10}";
 
+// Line 46: Convert To Static example
+return $"{operatorSymbol}: {number}";
+
 // Line 50: Make Field Readonly example
 private string format = "Currency";
 ```
@@ -98,6 +128,18 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-variable \
 # Make format field readonly
 dotnet run --project RefactorMCP.ConsoleApp -- --test make-field-readonly \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" 50
+
+# Introduce parameter from expression
+dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-parameter \
+  "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" 40 "41:50-41:65" "processedValue"
+
+# Convert method to static with parameters
+dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-parameters \
+  "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" 46
+
+# Convert method to static with instance
+dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-instance \
+  "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" 46 "calculator"
 ```
 
 ## Common Errors

--- a/README.md
+++ b/README.md
@@ -176,6 +176,9 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test <command> [arguments]
 - `introduce-field <solutionPath> <filePath> <range> <fieldName> [accessModifier]` - Create field from expression
 - `introduce-variable <solutionPath> <filePath> <range> <variableName>` - Create variable from expression
 - `make-field-readonly <solutionPath> <filePath> <fieldLine>` - Make field readonly
+- `introduce-parameter <solutionPath> <filePath> <methodLine> <range> <parameterName>` - Create parameter from expression
+- `convert-to-static-with-parameters <solutionPath> <filePath> <methodLine>` - Convert instance method to static with parameters
+- `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
 
 #### Quick Start Example
 
@@ -270,6 +273,78 @@ private double _averageValue = numbers.Sum() / (double)numbers.Count;
 public double GetAverage()
 {
     return _averageValue;
+}
+```
+
+### 3. Introduce Parameter
+
+**Before**:
+```csharp
+public string FormatResult(int value)
+{
+    return $"The calculation result is: {value * 2 + 10}";
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-parameter \
+  "./RefactorMCP.sln" "./MyFile.cs" 40 "41:50-41:65" "processedValue"
+```
+
+**After**:
+```csharp
+public string FormatResult(int value, int processedValue)
+{
+    return $"The calculation result is: {processedValue}";
+}
+```
+
+### 4. Convert to Static with Parameters
+
+**Before**:
+```csharp
+public string GetFormattedNumber(int number)
+{
+    return $"{operatorSymbol}: {number}";
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-parameters \
+  "./RefactorMCP.sln" "./MyFile.cs" 46
+```
+
+**After**:
+```csharp
+public static string GetFormattedNumber(string operatorSymbol, int number)
+{
+    return $"{operatorSymbol}: {number}";
+}
+```
+
+### 5. Convert to Static with Instance
+
+**Before**:
+```csharp
+public string GetFormattedNumber(int number)
+{
+    return $"{operatorSymbol}: {number}";
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-instance \
+  "./RefactorMCP.sln" "./MyFile.cs" 46 "calculator"
+```
+
+**After**:
+```csharp
+public static string GetFormattedNumber(Calculator calculator, int number)
+{
+    return $"{calculator.operatorSymbol}: {number}";
 }
 ```
 


### PR DESCRIPTION
## Summary
- document convert-to-static-with-parameters, convert-to-static-with-instance, introduce-parameter
- expand quick reference usage and examples
- add comprehensive examples for new tools

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_6847f2dd748883278848d3c6c42fa130