### PR TITLE
Update move-instance-method tool parameters

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -367,7 +367,7 @@ introduce-parameter - Create a new parameter from selected code (TODO)
 convert-to-static-with-parameters - Transform instance method to static (TODO)
 convert-to-static-with-instance - Transform instance method to static with instance parameter (TODO)
 move-static-method - Move a static method to another class (TODO)
-move-instance-method - Move an instance method to another class (TODO)
+move-instance-method - Move an instance method to another class
 transform-setter-to-init - Convert property setter to init-only setter (TODO)
 safe-delete - Safely delete a field, parameter, or variable (TODO)
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -90,6 +90,20 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-ins
   "./path/to/file.cs" \
   methodLine \
   "instanceName"
+```
+
+### Move Instance Method
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test move-instance-method \
+  "./RefactorMCP.sln" \
+  "./path/to/file.cs" \
+  "SourceClass" \
+  "MethodName" \
+  "TargetClass" \
+  "memberName" \
+  "field"
+```
+
 ### Convert To Extension Method
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-extension-method \

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test <command> [arguments]
 - `introduce-parameter <solutionPath> <filePath> <methodLine> <range> <parameterName>` - Create parameter from expression
 - `convert-to-static-with-parameters <solutionPath> <filePath> <methodLine>` - Convert instance method to static with parameters
 - `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
+- `move-instance-method <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [solutionPath]` - Move an instance method to another class
 
 #### Quick Start Example
 

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -82,6 +82,7 @@ static void ShowTestModeHelp()
     Console.WriteLine("  introduce-variable <filePath> <range> <variableName> [solutionPath]");
     Console.WriteLine("  make-field-readonly <filePath> <fieldLine> [solutionPath]");
     Console.WriteLine("  convert-to-extension-method <filePath> <methodLine> [solutionPath]");
+    Console.WriteLine("  move-instance-method <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [solutionPath]");
     Console.WriteLine();
     Console.WriteLine("Examples:");
     Console.WriteLine("  --test load-solution ./MySolution.sln");
@@ -108,7 +109,7 @@ static string ListAvailableTools()
         "convert-to-static-with-parameters - Transform instance method to static (TODO)",
         "convert-to-static-with-instance - Transform instance method to static with instance parameter (TODO)",
         "move-static-method - Move a static method to another class (TODO)",
-        "move-instance-method - Move an instance method to another class (TODO)",
+        "move-instance-method - Move an instance method to another class",
         "transform-setter-to-init - Convert property setter to init-only setter (TODO)",
         "safe-delete - Safely delete a field, parameter, or variable (TODO)"
     };
@@ -307,7 +308,7 @@ public static partial class RefactoringTools
             }
             else
             {
-                newRoot = newRoot.AddMembers(extensionClassDecl);
+                newRoot = ((CompilationUnitSyntax)newRoot).AddMembers(extensionClassDecl);
             }
         }
 
@@ -400,7 +401,7 @@ public static partial class RefactoringTools
             }
             else
             {
-                newRoot = newRoot.AddMembers(extensionClassDecl);
+                newRoot = ((CompilationUnitSyntax)newRoot).AddMembers(extensionClassDecl);
             }
         }
 

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
@@ -1,5 +1,6 @@
 using ModelContextProtocol.Server;
 using System.ComponentModel;
+using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -8,21 +9,21 @@ using Microsoft.CodeAnalysis.Text;
 
 public static partial class RefactoringTools
 {
-    private static async Task<string> MoveInstanceMethodWithSolution(Document document, int methodLine, string targetClass, string accessMemberName, string accessMemberType)
+    private static async Task<string> MoveInstanceMethodWithSolution(Document document, string sourceClass, string methodName, string targetClass, string accessMemberName, string accessMemberType)
     {
         var sourceText = await document.GetTextAsync();
         var syntaxRoot = await document.GetSyntaxRootAsync();
-        var textLines = sourceText.Lines;
-
-        var method = syntaxRoot!.DescendantNodes()
-            .OfType<MethodDeclarationSyntax>()
-            .FirstOrDefault(m => textLines.GetLineFromPosition(m.SpanStart).LineNumber + 1 == methodLine);
-        if (method == null)
-            return $"Error: No method found at line {methodLine}";
-
-        var originClass = method.Parent as ClassDeclarationSyntax;
+        var originClass = syntaxRoot!.DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .FirstOrDefault(c => c.Identifier.ValueText == sourceClass);
         if (originClass == null)
-            return $"Error: Method at line {methodLine} is not inside a class";
+            return $"Error: Source class '{sourceClass}' not found";
+
+        var method = originClass.Members
+            .OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            return $"Error: Method '{methodName}' not found in class '{sourceClass}'";
 
         var targetClassDecl = syntaxRoot.DescendantNodes()
             .OfType<ClassDeclarationSyntax>()
@@ -55,7 +56,14 @@ public static partial class RefactoringTools
             newOriginClass = newOriginClass.AddMembers(prop);
         }
 
-        var newTargetClass = targetClassDecl.AddMembers(method.WithLeadingTrivia());
+        var updatedMethod = method;
+        if (!method.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword)))
+        {
+            var mods = method.Modifiers.Where(m => !m.IsKind(SyntaxKind.PrivateKeyword) && !m.IsKind(SyntaxKind.ProtectedKeyword) && !m.IsKind(SyntaxKind.InternalKeyword));
+            updatedMethod = method.WithModifiers(SyntaxFactory.TokenList(mods).Add(SyntaxFactory.Token(SyntaxKind.PublicKeyword)));
+        }
+
+        var newTargetClass = targetClassDecl.AddMembers(updatedMethod.WithLeadingTrivia());
 
         var newRoot = syntaxRoot.ReplaceNode(originClass, newOriginClass).ReplaceNode(targetClassDecl, newTargetClass);
         var formatted = Formatter.Format(newRoot, document.Project.Solution.Workspace);
@@ -66,7 +74,7 @@ public static partial class RefactoringTools
         return $"Successfully moved instance method to {targetClass} in {document.FilePath}";
     }
 
-    private static async Task<string> MoveInstanceMethodSingleFile(string filePath, int methodLine, string targetClass, string accessMemberName, string accessMemberType)
+    private static async Task<string> MoveInstanceMethodSingleFile(string filePath, string sourceClass, string methodName, string targetClass, string accessMemberName, string accessMemberType)
     {
         if (!File.Exists(filePath))
             return $"Error: File {filePath} not found";
@@ -74,17 +82,17 @@ public static partial class RefactoringTools
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
         var syntaxRoot = await syntaxTree.GetRootAsync();
-        var textLines = SourceText.From(sourceText).Lines;
-
-        var method = syntaxRoot.DescendantNodes()
-            .OfType<MethodDeclarationSyntax>()
-            .FirstOrDefault(m => textLines.GetLineFromPosition(m.SpanStart).LineNumber + 1 == methodLine);
-        if (method == null)
-            return $"Error: No method found at line {methodLine}";
-
-        var originClass = method.Parent as ClassDeclarationSyntax;
+        var originClass = syntaxRoot.DescendantNodes()
+            .OfType<ClassDeclarationSyntax>()
+            .FirstOrDefault(c => c.Identifier.ValueText == sourceClass);
         if (originClass == null)
-            return $"Error: Method at line {methodLine} is not inside a class";
+            return $"Error: Source class '{sourceClass}' not found";
+
+        var method = originClass.Members
+            .OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            return $"Error: Method '{methodName}' not found in class '{sourceClass}'";
 
         var targetClassDecl = syntaxRoot.DescendantNodes()
             .OfType<ClassDeclarationSyntax>()
@@ -117,7 +125,14 @@ public static partial class RefactoringTools
             newOriginClass = newOriginClass.AddMembers(prop);
         }
 
-        var newTargetClass = targetClassDecl.AddMembers(method.WithLeadingTrivia());
+        var updatedMethod = method;
+        if (!method.Modifiers.Any(m => m.IsKind(SyntaxKind.PublicKeyword)))
+        {
+            var mods = method.Modifiers.Where(m => !m.IsKind(SyntaxKind.PrivateKeyword) && !m.IsKind(SyntaxKind.ProtectedKeyword) && !m.IsKind(SyntaxKind.InternalKeyword));
+            updatedMethod = method.WithModifiers(SyntaxFactory.TokenList(mods).Add(SyntaxFactory.Token(SyntaxKind.PublicKeyword)));
+        }
+
+        var newTargetClass = targetClassDecl.AddMembers(updatedMethod.WithLeadingTrivia());
 
         var newRoot = syntaxRoot.ReplaceNode(originClass, newOriginClass).ReplaceNode(targetClassDecl, newTargetClass);
         var workspace = new AdhocWorkspace();
@@ -141,7 +156,8 @@ public static partial class RefactoringTools
     [McpServerTool, Description("Move an instance method to another class (preferred for large-file refactoring)")]
     public static async Task<string> MoveInstanceMethod(
         [Description("Path to the C# file containing the method")] string filePath,
-        [Description("Line number of the instance method to move")] int methodLine,
+        [Description("Name of the source class containing the method")] string sourceClass,
+        [Description("Name of the method to move")] string methodName,
         [Description("Name of the target class")] string targetClass,
         [Description("Name for the access member")] string accessMemberName,
         [Description("Type of access member (field, property, variable)")] string accessMemberType = "field",
@@ -154,13 +170,13 @@ public static partial class RefactoringTools
                 var solution = await GetOrLoadSolution(solutionPath);
                 var document = GetDocumentByPath(solution, filePath);
                 if (document != null)
-                    return await MoveInstanceMethodWithSolution(document, methodLine, targetClass, accessMemberName, accessMemberType);
+                    return await MoveInstanceMethodWithSolution(document, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
 
                 // Fallback to single file mode when file isn't part of the solution
-                return await MoveInstanceMethodSingleFile(filePath, methodLine, targetClass, accessMemberName, accessMemberType);
+                return await MoveInstanceMethodSingleFile(filePath, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
             }
 
-            return await MoveInstanceMethodSingleFile(filePath, methodLine, targetClass, accessMemberName, accessMemberType);
+            return await MoveInstanceMethodSingleFile(filePath, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
         }
         catch (Exception ex)
         {

--- a/RefactorMCP.Tests/UnitTest1.cs
+++ b/RefactorMCP.Tests/UnitTest1.cs
@@ -361,7 +361,8 @@ public class RefactoringToolsTests : IDisposable
 
         var result = await RefactoringTools.MoveInstanceMethod(
             testFile,
-            69,
+            "Calculator",
+            "LogOperation",
             "Logger",
             "_logger",
             "field",


### PR DESCRIPTION
## Summary
- replace `methodLine` parameter with `sourceClass` and `methodName`
- ensure moved method is public
- document new command usage
- update unit test to use new API

## Testing
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6847ff0d298c83279f435110e977b008