### PR TITLE
Implement safe delete refactoring

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -298,6 +298,36 @@ public static class CalculatorExtensions
 }
 ```
 
+## 9. Safe Delete Parameter
+
+**Purpose**: Remove an unused method parameter and update call sites.
+
+### Example
+**Before** (in `ExampleCode.cs` line 74):
+```csharp
+public int Multiply(int x, int y, int unusedParam)
+{
+    return x * y; // unusedParam can be safely deleted
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test safe-delete-parameter \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  Multiply \
+  unusedParam
+```
+
+**After**:
+```csharp
+public int Multiply(int x, int y)
+{
+    return x * y;
+}
+```
+
 ## 6. Load Solution (Utility Command)
 
 **Purpose**: Load and validate a solution file before performing refactorings.

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -65,6 +65,15 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-extension-metho
   lineNumber
 ```
 
+### Safe Delete Parameter
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test safe-delete-parameter \
+  "./RefactorMCP.sln" \
+  "./path/to/file.cs" \
+  MethodName \
+  parameterName
+```
+
 ### Introduce Parameter
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-parameter \

--- a/README.md
+++ b/README.md
@@ -362,6 +362,30 @@ public static string GetFormattedNumber(Calculator calculator, int number)
 }
 ```
 
+### 6. Safe Delete Parameter
+
+**Before**:
+```csharp
+public int Multiply(int x, int y, int unusedParam)
+{
+    return x * y;
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --test safe-delete-parameter \
+  "./RefactorMCP.Tests/ExampleCode.cs" "Multiply" "unusedParam" "./RefactorMCP.sln"
+```
+
+**After**:
+```csharp
+public int Multiply(int x, int y)
+{
+    return x * y;
+}
+```
+
 ## Complete Examples
 
 See [EXAMPLES.md](./EXAMPLES.md) for comprehensive examples of all refactoring tools, including:

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -54,6 +54,10 @@ static async Task RunTestMode(string[] args)
             "unload-solution" => TestUnloadSolution(args),
             "clear-solution-cache" => ClearCacheCommand(),
             "convert-to-extension-method" => await TestConvertToExtensionMethod(args),
+            "safe-delete-field" => await TestSafeDeleteField(args),
+            "safe-delete-method" => await TestSafeDeleteMethod(args),
+            "safe-delete-parameter" => await TestSafeDeleteParameter(args),
+            "safe-delete-variable" => await TestSafeDeleteVariable(args),
             "list-tools" => ListAvailableTools(),
             _ => $"Unknown command: {command}. Use --test list-tools to see available commands."
         };
@@ -82,6 +86,10 @@ static void ShowTestModeHelp()
     Console.WriteLine("  introduce-variable <filePath> <range> <variableName> [solutionPath]");
     Console.WriteLine("  make-field-readonly <filePath> <fieldLine> [solutionPath]");
     Console.WriteLine("  convert-to-extension-method <filePath> <methodLine> [solutionPath]");
+    Console.WriteLine("  safe-delete-field <filePath> <fieldName> [solutionPath]");
+    Console.WriteLine("  safe-delete-method <filePath> <methodName> [solutionPath]");
+    Console.WriteLine("  safe-delete-parameter <filePath> <methodName> <parameterName> [solutionPath]");
+    Console.WriteLine("  safe-delete-variable <filePath> <range> [solutionPath]");
     Console.WriteLine();
     Console.WriteLine("Examples:");
     Console.WriteLine("  --test load-solution ./MySolution.sln");
@@ -110,7 +118,10 @@ static string ListAvailableTools()
         "move-static-method - Move a static method to another class (TODO)",
         "move-instance-method - Move an instance method to another class (TODO)",
         "transform-setter-to-init - Convert property setter to init-only setter (TODO)",
-        "safe-delete - Safely delete a field, parameter, or variable (TODO)"
+        "safe-delete-field - Safely delete an unused field",
+        "safe-delete-method - Safely delete an unused method",
+        "safe-delete-parameter - Safely delete an unused parameter",
+        "safe-delete-variable - Safely delete a local variable"
     };
 
     return "Available refactoring tools:\n" + string.Join("\n", tools);
@@ -203,6 +214,55 @@ static async Task<string> TestConvertToExtensionMethod(string[] args)
     var solutionPath = args.Length > 4 ? args[4] : null;
 
     return await RefactoringTools.ConvertToExtensionMethod(filePath, methodLine, null, solutionPath);
+}
+
+static async Task<string> TestSafeDeleteField(string[] args)
+{
+    if (args.Length < 4)
+        return "Error: Missing arguments. Usage: --test safe-delete-field <filePath> <fieldName> [solutionPath]";
+
+    var filePath = args[2];
+    var fieldName = args[3];
+    var solutionPath = args.Length > 4 ? args[4] : null;
+
+    return await RefactoringTools.SafeDeleteField(filePath, fieldName, solutionPath);
+}
+
+static async Task<string> TestSafeDeleteMethod(string[] args)
+{
+    if (args.Length < 4)
+        return "Error: Missing arguments. Usage: --test safe-delete-method <filePath> <methodName> [solutionPath]";
+
+    var filePath = args[2];
+    var methodName = args[3];
+    var solutionPath = args.Length > 4 ? args[4] : null;
+
+    return await RefactoringTools.SafeDeleteMethod(filePath, methodName, solutionPath);
+}
+
+static async Task<string> TestSafeDeleteParameter(string[] args)
+{
+    if (args.Length < 5)
+        return "Error: Missing arguments. Usage: --test safe-delete-parameter <filePath> <methodName> <parameterName> [solutionPath]";
+
+    var filePath = args[2];
+    var methodName = args[3];
+    var parameterName = args[4];
+    var solutionPath = args.Length > 5 ? args[5] : null;
+
+    return await RefactoringTools.SafeDeleteParameter(filePath, methodName, parameterName, solutionPath);
+}
+
+static async Task<string> TestSafeDeleteVariable(string[] args)
+{
+    if (args.Length < 4)
+        return "Error: Missing arguments. Usage: --test safe-delete-variable <filePath> <range> [solutionPath]";
+
+    var filePath = args[2];
+    var range = args[3];
+    var solutionPath = args.Length > 4 ? args[4] : null;
+
+    return await RefactoringTools.SafeDeleteVariable(filePath, range, solutionPath);
 }
 
 [McpServerToolType]

--- a/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
@@ -1,17 +1,390 @@
 using ModelContextProtocol.Server;
 using System.ComponentModel;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Formatting;
 
 public static partial class RefactoringTools
 {
-    [McpServerTool, Description("Safely delete a field, parameter, or variable with dependency warnings (preferred for large-file refactoring)")]
-    public static async Task<string> SafeDelete(
-        [Description("Path to the solution file (.sln)")] string solutionPath,
+    [McpServerTool, Description("Safely delete an unused field (preferred for large-file refactoring)")]
+    public static async Task<string> SafeDeleteField(
         [Description("Path to the C# file")] string filePath,
-        [Description("Line number of the element to delete")] int targetLine,
-        [Description("Type of element (field, parameter, variable)")] string elementType)
+        [Description("Name of the field to delete")] string fieldName,
+        [Description("Path to the solution file (.sln) - optional for single file mode")] string? solutionPath = null)
     {
-        // TODO: Implement safe delete refactoring using Roslyn
-        return $"Safe delete {elementType} at line {targetLine} in {filePath} - Implementation in progress";
+        try
+        {
+            if (solutionPath != null)
+            {
+                var solution = await GetOrLoadSolution(solutionPath);
+                var document = GetDocumentByPath(solution, filePath);
+                if (document != null)
+                    return await SafeDeleteFieldWithSolution(document, fieldName);
+
+                return await SafeDeleteFieldSingleFile(filePath, fieldName);
+            }
+
+            return await SafeDeleteFieldSingleFile(filePath, fieldName);
+        }
+        catch (Exception ex)
+        {
+            return $"Error deleting field: {ex.Message}";
+        }
+    }
+
+    [McpServerTool, Description("Safely delete an unused method (preferred for large-file refactoring)")]
+    public static async Task<string> SafeDeleteMethod(
+        [Description("Path to the C# file")] string filePath,
+        [Description("Name of the method to delete")] string methodName,
+        [Description("Path to the solution file (.sln) - optional for single file mode")] string? solutionPath = null)
+    {
+        try
+        {
+            if (solutionPath != null)
+            {
+                var solution = await GetOrLoadSolution(solutionPath);
+                var document = GetDocumentByPath(solution, filePath);
+                if (document != null)
+                    return await SafeDeleteMethodWithSolution(document, methodName);
+
+                return await SafeDeleteMethodSingleFile(filePath, methodName);
+            }
+
+            return await SafeDeleteMethodSingleFile(filePath, methodName);
+        }
+        catch (Exception ex)
+        {
+            return $"Error deleting method: {ex.Message}";
+        }
+    }
+
+    [McpServerTool, Description("Safely delete an unused parameter from a method")]
+    public static async Task<string> SafeDeleteParameter(
+        [Description("Path to the C# file")] string filePath,
+        [Description("Name of the method containing the parameter")] string methodName,
+        [Description("Name of the parameter to delete")] string parameterName,
+        [Description("Path to the solution file (.sln) - optional for single file mode")] string? solutionPath = null)
+    {
+        try
+        {
+            if (solutionPath != null)
+            {
+                var solution = await GetOrLoadSolution(solutionPath);
+                var document = GetDocumentByPath(solution, filePath);
+                if (document != null)
+                    return await SafeDeleteParameterWithSolution(document, methodName, parameterName);
+
+                return await SafeDeleteParameterSingleFile(filePath, methodName, parameterName);
+            }
+
+            return await SafeDeleteParameterSingleFile(filePath, methodName, parameterName);
+        }
+        catch (Exception ex)
+        {
+            return $"Error deleting parameter: {ex.Message}";
+        }
+    }
+
+    [McpServerTool, Description("Safely delete a local variable using a line range")]
+    public static async Task<string> SafeDeleteVariable(
+        [Description("Path to the C# file")] string filePath,
+        [Description("Range of the variable declaration in format 'startLine:startCol-endLine:endCol'")] string selectionRange,
+        [Description("Path to the solution file (.sln) - optional for single file mode")] string? solutionPath = null)
+    {
+        try
+        {
+            if (solutionPath != null)
+            {
+                var solution = await GetOrLoadSolution(solutionPath);
+                var document = GetDocumentByPath(solution, filePath);
+                if (document != null)
+                    return await SafeDeleteVariableWithSolution(document, selectionRange);
+
+                return await SafeDeleteVariableSingleFile(filePath, selectionRange);
+            }
+
+            return await SafeDeleteVariableSingleFile(filePath, selectionRange);
+        }
+        catch (Exception ex)
+        {
+            return $"Error deleting variable: {ex.Message}";
+        }
+    }
+
+    private static async Task<string> SafeDeleteFieldWithSolution(Document document, string fieldName)
+    {
+        var root = await document.GetSyntaxRootAsync();
+        var field = root!.DescendantNodes()
+            .OfType<FieldDeclarationSyntax>()
+            .FirstOrDefault(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == fieldName));
+        if (field == null)
+            return $"Error: Field '{fieldName}' not found";
+
+        var variable = field.Declaration.Variables.First(v => v.Identifier.ValueText == fieldName);
+        var semanticModel = await document.GetSemanticModelAsync();
+        var symbol = semanticModel!.GetDeclaredSymbol(variable) as IFieldSymbol;
+        var refs = await SymbolFinder.FindReferencesAsync(symbol!, document.Project.Solution);
+        var count = refs.SelectMany(r => r.Locations).Count() - 1;
+        if (count > 0)
+            return $"Error: Field '{fieldName}' is referenced {count} time(s)";
+
+        SyntaxNode newRoot;
+        if (field.Declaration.Variables.Count == 1)
+            newRoot = root.RemoveNode(field, SyntaxRemoveOptions.KeepNoTrivia);
+        else
+        {
+            var newDecl = field.Declaration.WithVariables(SyntaxFactory.SeparatedList(field.Declaration.Variables.Where(v => v.Identifier.ValueText != fieldName)));
+            newRoot = root.ReplaceNode(field, field.WithDeclaration(newDecl));
+        }
+
+        var formatted = Formatter.Format(newRoot, document.Project.Solution.Workspace);
+        var newDoc = document.WithSyntaxRoot(formatted);
+        var text = await newDoc.GetTextAsync();
+        await File.WriteAllTextAsync(document.FilePath!, text.ToString());
+        return $"Successfully deleted field '{fieldName}' in {document.FilePath}";
+    }
+
+    private static async Task<string> SafeDeleteFieldSingleFile(string filePath, string fieldName)
+    {
+        if (!File.Exists(filePath))
+            return $"Error: File {filePath} not found";
+
+        var sourceText = await File.ReadAllTextAsync(filePath);
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        var root = await tree.GetRootAsync();
+        var field = root.DescendantNodes()
+            .OfType<FieldDeclarationSyntax>()
+            .FirstOrDefault(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == fieldName));
+        if (field == null)
+            return $"Error: Field '{fieldName}' not found";
+
+        var references = root.DescendantNodes().OfType<IdentifierNameSyntax>().Count(id => id.Identifier.ValueText == fieldName);
+        if (references > 1)
+            return $"Error: Field '{fieldName}' is referenced";
+
+        SyntaxNode newRoot;
+        if (field.Declaration.Variables.Count == 1)
+            newRoot = root.RemoveNode(field, SyntaxRemoveOptions.KeepNoTrivia);
+        else
+        {
+            var newDecl = field.Declaration.WithVariables(SyntaxFactory.SeparatedList(field.Declaration.Variables.Where(v => v.Identifier.ValueText != fieldName)));
+            newRoot = root.ReplaceNode(field, field.WithDeclaration(newDecl));
+        }
+
+        var workspace = new AdhocWorkspace();
+        var formatted = Formatter.Format(newRoot, workspace);
+        await File.WriteAllTextAsync(filePath, formatted.ToFullString());
+        return $"Successfully deleted field '{fieldName}' in {filePath} (single file mode)";
+    }
+
+    private static async Task<string> SafeDeleteMethodWithSolution(Document document, string methodName)
+    {
+        var root = await document.GetSyntaxRootAsync();
+        var method = root!.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            return $"Error: Method '{methodName}' not found";
+
+        var semanticModel = await document.GetSemanticModelAsync();
+        var symbol = semanticModel!.GetDeclaredSymbol(method)!;
+        var refs = await SymbolFinder.FindReferencesAsync(symbol, document.Project.Solution);
+        var count = refs.SelectMany(r => r.Locations).Count() - 1;
+        if (count > 0)
+            return $"Error: Method '{methodName}' is referenced {count} time(s)";
+
+        var newRoot = root.RemoveNode(method, SyntaxRemoveOptions.KeepNoTrivia);
+        var formatted = Formatter.Format(newRoot, document.Project.Solution.Workspace);
+        var newDoc = document.WithSyntaxRoot(formatted);
+        var text = await newDoc.GetTextAsync();
+        await File.WriteAllTextAsync(document.FilePath!, text.ToString());
+        return $"Successfully deleted method '{methodName}' in {document.FilePath}";
+    }
+
+    private static async Task<string> SafeDeleteMethodSingleFile(string filePath, string methodName)
+    {
+        if (!File.Exists(filePath))
+            return $"Error: File {filePath} not found";
+
+        var sourceText = await File.ReadAllTextAsync(filePath);
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        var root = await tree.GetRootAsync();
+        var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            return $"Error: Method '{methodName}' not found";
+
+        var references = root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Count(inv => inv.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == methodName);
+        if (references > 0)
+            return $"Error: Method '{methodName}' is referenced";
+
+        var newRoot = root.RemoveNode(method, SyntaxRemoveOptions.KeepNoTrivia);
+        var workspace = new AdhocWorkspace();
+        var formatted = Formatter.Format(newRoot, workspace);
+        await File.WriteAllTextAsync(filePath, formatted.ToFullString());
+        return $"Successfully deleted method '{methodName}' in {filePath} (single file mode)";
+    }
+
+    private static async Task<string> SafeDeleteParameterWithSolution(Document document, string methodName, string parameterName)
+    {
+        var root = await document.GetSyntaxRootAsync();
+        var method = root!.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            return $"Error: Method '{methodName}' not found";
+
+        var parameter = method.ParameterList.Parameters.FirstOrDefault(p => p.Identifier.ValueText == parameterName);
+        if (parameter == null)
+            return $"Error: Parameter '{parameterName}' not found";
+
+        var semanticModel = await document.GetSemanticModelAsync();
+        var methodSymbol = semanticModel!.GetDeclaredSymbol(method)!;
+        var paramIndex = method.ParameterList.Parameters.IndexOf(parameter);
+
+        var refs = await SymbolFinder.FindReferencesAsync(methodSymbol, document.Project.Solution);
+        foreach (var location in refs.SelectMany(r => r.Locations))
+        {
+            if (!location.Location.IsInSource) continue;
+            var refDoc = document.Project.Solution.GetDocument(location.Location.SourceTree)!;
+            var refRoot = await refDoc.GetSyntaxRootAsync();
+            var node = refRoot!.FindNode(location.Location.SourceSpan);
+            if (node is IdentifierNameSyntax && node.Parent is InvocationExpressionSyntax invocation)
+            {
+                if (paramIndex < invocation.ArgumentList.Arguments.Count)
+                {
+                    var newArgs = invocation.ArgumentList.Arguments.RemoveAt(paramIndex);
+                    var newInv = invocation.WithArgumentList(invocation.ArgumentList.WithArguments(newArgs));
+                    refRoot = refRoot.ReplaceNode(invocation, newInv);
+                    var formattedRoot = Formatter.Format(refRoot, refDoc.Project.Solution.Workspace);
+                    var newRefDoc = refDoc.WithSyntaxRoot(formattedRoot);
+                    var newText = await newRefDoc.GetTextAsync();
+                    await File.WriteAllTextAsync(refDoc.FilePath!, newText.ToString());
+                }
+            }
+        }
+
+        var newMethod = method.WithParameterList(method.ParameterList.WithParameters(method.ParameterList.Parameters.Remove(parameter)));
+        var newRoot = root.ReplaceNode(method, newMethod);
+        var formatted = Formatter.Format(newRoot, document.Project.Solution.Workspace);
+        var newDoc = document.WithSyntaxRoot(formatted);
+        var text = await newDoc.GetTextAsync();
+        await File.WriteAllTextAsync(document.FilePath!, text.ToString());
+        return $"Successfully deleted parameter '{parameterName}' from method '{methodName}' in {document.FilePath}";
+    }
+
+    private static async Task<string> SafeDeleteParameterSingleFile(string filePath, string methodName, string parameterName)
+    {
+        if (!File.Exists(filePath))
+            return $"Error: File {filePath} not found";
+
+        var sourceText = await File.ReadAllTextAsync(filePath);
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        var root = await tree.GetRootAsync();
+        var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            return $"Error: Method '{methodName}' not found";
+
+        var parameter = method.ParameterList.Parameters.FirstOrDefault(p => p.Identifier.ValueText == parameterName);
+        if (parameter == null)
+            return $"Error: Parameter '{parameterName}' not found";
+
+        var paramIndex = method.ParameterList.Parameters.IndexOf(parameter);
+        var invocations = root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == methodName);
+
+        foreach (var invocation in invocations)
+        {
+            if (paramIndex < invocation.ArgumentList.Arguments.Count)
+            {
+                var newArgs = invocation.ArgumentList.Arguments.RemoveAt(paramIndex);
+                var newInv = invocation.WithArgumentList(invocation.ArgumentList.WithArguments(newArgs));
+                root = root.ReplaceNode(invocation, newInv);
+            }
+        }
+
+        var newMethod = method.WithParameterList(method.ParameterList.WithParameters(method.ParameterList.Parameters.Remove(parameter)));
+        root = root.ReplaceNode(method, newMethod);
+        var workspace = new AdhocWorkspace();
+        var formatted = Formatter.Format(root, workspace);
+        await File.WriteAllTextAsync(filePath, formatted.ToFullString());
+        return $"Successfully deleted parameter '{parameterName}' from method '{methodName}' in {filePath} (single file mode)";
+    }
+
+    private static async Task<string> SafeDeleteVariableWithSolution(Document document, string selectionRange)
+    {
+        var text = await document.GetTextAsync();
+        var root = await document.GetSyntaxRootAsync();
+        if (!TryParseRange(selectionRange, out var sl, out var sc, out var el, out var ec))
+            return "Error: Invalid selection range format";
+
+        var start = text.Lines[sl - 1].Start + sc - 1;
+        var end = text.Lines[el - 1].Start + ec - 1;
+        var span = TextSpan.FromBounds(start, end);
+        var variable = root!.DescendantNodes(span).OfType<VariableDeclaratorSyntax>().FirstOrDefault();
+        if (variable == null)
+            return "Error: No variable declaration found in range";
+
+        var semanticModel = await document.GetSemanticModelAsync();
+        var symbol = semanticModel!.GetDeclaredSymbol(variable)!;
+        var refs = await SymbolFinder.FindReferencesAsync(symbol, document.Project.Solution);
+        var count = refs.SelectMany(r => r.Locations).Count() - 1;
+        if (count > 0)
+            return $"Error: Variable '{variable.Identifier.ValueText}' is referenced {count} time(s)";
+
+        var statement = variable.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>();
+        SyntaxNode newRoot;
+        if (statement!.Declaration.Variables.Count == 1)
+            newRoot = root.RemoveNode(statement, SyntaxRemoveOptions.KeepNoTrivia);
+        else
+        {
+            var newDecl = statement.Declaration.WithVariables(SyntaxFactory.SeparatedList(statement.Declaration.Variables.Where(v => v != variable)));
+            newRoot = root.ReplaceNode(statement, statement.WithDeclaration(newDecl));
+        }
+
+        var formatted = Formatter.Format(newRoot, document.Project.Solution.Workspace);
+        var newDoc = document.WithSyntaxRoot(formatted);
+        var newText = await newDoc.GetTextAsync();
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        return $"Successfully deleted variable '{variable.Identifier.ValueText}' in {document.FilePath}";
+    }
+
+    private static async Task<string> SafeDeleteVariableSingleFile(string filePath, string selectionRange)
+    {
+        if (!File.Exists(filePath))
+            return $"Error: File {filePath} not found";
+
+        var sourceText = await File.ReadAllTextAsync(filePath);
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        var root = await tree.GetRootAsync();
+        var lines = SourceText.From(sourceText).Lines;
+        if (!TryParseRange(selectionRange, out var sl, out var sc, out var el, out var ec))
+            return "Error: Invalid selection range format";
+
+        var start = lines[sl - 1].Start + sc - 1;
+        var end = lines[el - 1].Start + ec - 1;
+        var span = TextSpan.FromBounds(start, end);
+        var variable = root.DescendantNodes(span).OfType<VariableDeclaratorSyntax>().FirstOrDefault();
+        if (variable == null)
+            return "Error: No variable declaration found in range";
+
+        var name = variable.Identifier.ValueText;
+        var references = root.DescendantNodes().OfType<IdentifierNameSyntax>().Count(id => id.Identifier.ValueText == name);
+        if (references > 1)
+            return $"Error: Variable '{name}' is referenced";
+
+        var statement = variable.FirstAncestorOrSelf<LocalDeclarationStatementSyntax>();
+        SyntaxNode newRoot;
+        if (statement!.Declaration.Variables.Count == 1)
+            newRoot = root.RemoveNode(statement, SyntaxRemoveOptions.KeepNoTrivia);
+        else
+        {
+            var newDecl = statement.Declaration.WithVariables(SyntaxFactory.SeparatedList(statement.Declaration.Variables.Where(v => v != variable)));
+            newRoot = root.ReplaceNode(statement, statement.WithDeclaration(newDecl));
+        }
+
+        var workspace = new AdhocWorkspace();
+        var formatted = Formatter.Format(newRoot, workspace);
+        await File.WriteAllTextAsync(filePath, formatted.ToFullString());
+        return $"Successfully deleted variable '{name}' in {filePath} (single file mode)";
     }
 }

--- a/RefactorMCP.Tests/ExampleCode.cs
+++ b/RefactorMCP.Tests/ExampleCode.cs
@@ -23,7 +23,7 @@ namespace RefactorMCP.Tests.Examples
             {
                 throw new ArgumentException("Negative numbers not allowed");
             }
-            
+
             var result = a + b;
             numbers.Add(result);
             Console.WriteLine($"Result: {result}");
@@ -77,6 +77,12 @@ namespace RefactorMCP.Tests.Examples
             return x * y; // unusedParam can be safely deleted
         }
 
+        // Example for Safe Delete - unused method and variable
+        private void UnusedHelper()
+        {
+            int tempValue = 0; // tempValue can be safely deleted
+        }
+
         // Example field that might be safe to delete
         private int deprecatedCounter = 0; // Not used anywhere
     }
@@ -96,4 +102,4 @@ namespace RefactorMCP.Tests.Examples
             Console.WriteLine($"[LOG] {message}");
         }
     }
-} 
+}

--- a/RefactorMCP.Tests/ExampleValidationTests.cs
+++ b/RefactorMCP.Tests/ExampleValidationTests.cs
@@ -136,6 +136,25 @@ public class ExampleValidationTests : IDisposable
     }
 
     [Fact]
+    public async Task Example_SafeDeleteParameter_UnusedParam_WorksAsDocumented()
+    {
+        var testFile = Path.Combine(TestOutputPath, "SafeDeleteParameter.cs");
+        await CreateTestFile(testFile, GetCalculatorCodeForSafeDelete());
+        await RefactoringTools.LoadSolution(SolutionPath);
+
+        var result = await RefactoringTools.SafeDeleteParameter(
+            testFile,
+            "Multiply",
+            "unusedParam",
+            SolutionPath
+        );
+
+        Assert.Contains("Successfully deleted parameter", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.DoesNotContain("unusedParam", fileContent);
+    }
+
+    [Fact]
     public async Task QuickReference_ExtractMethod_WorksAsDocumented()
     {
         // Test the quick reference example
@@ -282,6 +301,12 @@ public int Calculate(int a, int b)
 
     // Exact code from our ExampleCode.cs for Make Field Readonly
     private static string GetCalculatorCodeForMakeFieldReadonly()
+    {
+        return File.ReadAllText(Path.Combine(Path.GetDirectoryName(SolutionPath)!, "RefactorMCP.Tests", "ExampleCode.cs"));
+    }
+
+    // Exact code from our ExampleCode.cs for Safe Delete
+    private static string GetCalculatorCodeForSafeDelete()
     {
         return File.ReadAllText(Path.Combine(Path.GetDirectoryName(SolutionPath)!, "RefactorMCP.Tests", "ExampleCode.cs"));
     }

--- a/RefactorMCP.Tests/UnitTest1.cs
+++ b/RefactorMCP.Tests/UnitTest1.cs
@@ -373,6 +373,25 @@ public class RefactoringToolsTests : IDisposable
         // File modification verification skipped
     }
 
+    [Fact]
+    public async Task SafeDeleteParameter_RemovesParameter()
+    {
+        await RefactoringTools.LoadSolution(SolutionPath);
+        var testFile = Path.Combine(TestOutputPath, "SafeDeleteParam.cs");
+        await CreateTestFile(testFile, GetSampleCodeForSafeDelete());
+
+        var result = await RefactoringTools.SafeDeleteParameter(
+            testFile,
+            "Multiply",
+            "unusedParam",
+            SolutionPath
+        );
+
+        Assert.Contains("Successfully deleted parameter", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.DoesNotContain("unusedParam", fileContent);
+    }
+
     // Helper methods to create test files
     private static async Task CreateTestFile(string filePath, string content)
     {
@@ -437,6 +456,11 @@ public class TestClass
     }
 
     private static string GetSampleCodeForConvertToExtension()
+    {
+        return File.ReadAllText(Path.Combine(Path.GetDirectoryName(SolutionPath)!, "RefactorMCP.Tests", "ExampleCode.cs"));
+    }
+
+    private static string GetSampleCodeForSafeDelete()
     {
         return File.ReadAllText(Path.Combine(Path.GetDirectoryName(SolutionPath)!, "RefactorMCP.Tests", "ExampleCode.cs"));
     }


### PR DESCRIPTION
## Summary
- add UnusedHelper and temp variable in sample code
- implement SafeDelete* methods for fields, methods, parameters, and variables
- expose safe delete commands in CLI
- document safe delete in README, QUICK_REFERENCE, and EXAMPLES
- add tests covering safe delete parameter

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_684800548f3c8327afe74e0ef863a064