### PR TITLE
Fix CI build by building before tests

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -14,4 +14,5 @@ jobs:
         with:
           dotnet-version: '9.0.x'
       - run: dotnet restore
+      - run: dotnet build --no-restore
       - run: dotnet test --no-build --verbosity normal


### PR DESCRIPTION
## Summary
- run `dotnet build` before running tests in CI

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity normal` *(fails: RefactorMCP.Tests.RefactoringToolsTests.SafeDeleteParameter_RemovesParameter)*

------
https://chatgpt.com/codex/tasks/task_e_684809298a6c8327ba3e7a97ab7f2064