### PR TITLE
Share AdhocWorkspace across tools

### DIFF
--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -461,8 +461,7 @@ public static partial class RefactoringTools
             }
         }
 
-        var workspace = new AdhocWorkspace();
-        var formatted = Formatter.Format(newRoot, workspace);
+        var formatted = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formatted.ToFullString());
 
         return $"Successfully converted method '{methodName}' to extension method in {filePath} (single file mode)";

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
@@ -149,8 +149,7 @@ public static partial class RefactoringTools
         updatedMethod = updatedMethod.WithModifiers(modifiers);
 
         var newRoot = syntaxRoot.ReplaceNode(method, updatedMethod);
-        var workspace = new AdhocWorkspace();
-        var formatted = Formatter.Format(newRoot, workspace);
+        var formatted = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formatted.ToFullString());
 
         return $"Successfully converted method '{methodName}' to static with instance parameter in {filePath} (single file mode)";

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
@@ -185,8 +185,7 @@ public static partial class RefactoringTools
             .WithParameterList(parameterList);
 
         var newRoot = syntaxRoot.ReplaceNode(method, updatedMethod);
-        var workspace = new AdhocWorkspace();
-        var formattedRoot = Formatter.Format(newRoot, workspace);
+        var formattedRoot = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formattedRoot.ToFullString());
 
         return $"Successfully converted method '{methodName}' to static with parameters in {filePath} (single file mode)";

--- a/RefactorMCP.ConsoleApp/Tools/ExtractMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ExtractMethod.cs
@@ -184,8 +184,7 @@ public static partial class RefactoringTools
         }
 
         // Format and write back to file
-        var workspace = new AdhocWorkspace();
-        var formattedRoot = Formatter.Format(newRoot, workspace);
+        var formattedRoot = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formattedRoot.ToFullString());
 
         return $"Successfully extracted method '{methodName}' from {selectionRange} in {filePath} (single file mode)";

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
@@ -164,8 +164,7 @@ public static partial class RefactoringTools
         }
 
         // Format and write back to file
-        var workspace = new AdhocWorkspace();
-        var formattedRoot = Formatter.Format(newRoot, workspace);
+        var formattedRoot = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formattedRoot.ToFullString());
 
         return $"Successfully introduced {accessModifier} field '{fieldName}' from {selectionRange} in {filePath} (single file mode)";

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
@@ -86,8 +86,7 @@ public static partial class RefactoringTools
         var newRoot = syntaxRoot.ReplaceNode(method, newMethod);
         newRoot = newRoot.ReplaceNode(selectedExpression, SyntaxFactory.IdentifierName(parameterName));
 
-        var workspace = new AdhocWorkspace();
-        var formattedRoot = Formatter.Format(newRoot, workspace);
+        var formattedRoot = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formattedRoot.ToFullString());
 
         return $"Successfully introduced parameter '{parameterName}' from {selectionRange} in method '{methodName}' in {filePath} (single file mode)";

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceVariable.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceVariable.cs
@@ -147,8 +147,7 @@ public static partial class RefactoringTools
         }
 
         // Format and write back to file
-        var workspace = new AdhocWorkspace();
-        var formattedRoot = Formatter.Format(newRoot, workspace);
+        var formattedRoot = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formattedRoot.ToFullString());
 
         return $"Successfully introduced variable '{variableName}' from {selectionRange} in {filePath} (single file mode)";

--- a/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
@@ -192,8 +192,7 @@ public static partial class RefactoringTools
                     var newRoot = syntaxRoot.ReplaceNode(containingClass, updatedClass);
 
                     // Format and write back to file
-                    var workspace = new AdhocWorkspace();
-                    var formattedRoot = Formatter.Format(newRoot, workspace);
+                    var formattedRoot = Formatter.Format(newRoot, SharedWorkspace);
                     await File.WriteAllTextAsync(filePath, formattedRoot.ToFullString());
 
                     return $"Successfully made field '{fieldName}' readonly and moved initialization to constructors in {filePath}";
@@ -205,8 +204,7 @@ public static partial class RefactoringTools
             var newRoot = syntaxRoot.ReplaceNode(fieldDeclaration, newFieldDeclaration);
 
             // Format and write back to file
-            var workspace = new AdhocWorkspace();
-            var formattedRoot = Formatter.Format(newRoot, workspace);
+            var formattedRoot = Formatter.Format(newRoot, SharedWorkspace);
             await File.WriteAllTextAsync(filePath, formattedRoot.ToFullString());
 
             return $"Successfully made field '{fieldName}' readonly in {filePath} (single file mode)";

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
@@ -138,8 +138,7 @@ public static partial class RefactoringTools
         var newTargetClass = targetClassDecl.AddMembers(updatedMethod.WithLeadingTrivia());
 
         var newRoot = syntaxRoot.ReplaceNode(originClass, newOriginClass).ReplaceNode(targetClassDecl, newTargetClass);
-        var workspace = new AdhocWorkspace();
-        var formatted = Formatter.Format(newRoot, workspace);
+        var formatted = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formatted.ToFullString());
 
         return $"Successfully moved instance method to {targetClass} in {filePath} (single file mode)";
@@ -208,12 +207,11 @@ public static partial class RefactoringTools
                 targetRoot = targetRoot.ReplaceNode(targetClassDecl, newTarget);
             }
 
-            var workspace = new AdhocWorkspace();
-            var formattedTarget = Formatter.Format(targetRoot, workspace);
+            var formattedTarget = Formatter.Format(targetRoot, SharedWorkspace);
 
             if (!sameFile)
             {
-                var formattedSource = Formatter.Format(newSourceRoot, workspace);
+                var formattedSource = Formatter.Format(newSourceRoot, SharedWorkspace);
                 await File.WriteAllTextAsync(filePath, formattedSource.ToFullString());
             }
 

--- a/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
@@ -2,12 +2,18 @@ using ModelContextProtocol.Server;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.Extensions.Caching.Memory;
+using System;
 
 
 
 public static partial class RefactoringTools
 {
     private static MemoryCache _solutionCache = new(new MemoryCacheOptions());
+
+    private static readonly Lazy<AdhocWorkspace> _workspace =
+        new(() => new AdhocWorkspace());
+
+    internal static AdhocWorkspace SharedWorkspace => _workspace.Value;
 
     private static async Task<Solution> GetOrLoadSolution(string solutionPath)
     {

--- a/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
@@ -174,8 +174,7 @@ public static partial class RefactoringTools
             newRoot = root.ReplaceNode(field, field.WithDeclaration(newDecl));
         }
 
-        var workspace = new AdhocWorkspace();
-        var formatted = Formatter.Format(newRoot, workspace);
+        var formatted = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formatted.ToFullString());
         return $"Successfully deleted field '{fieldName}' in {filePath} (single file mode)";
     }
@@ -220,8 +219,7 @@ public static partial class RefactoringTools
             return $"Error: Method '{methodName}' is referenced";
 
         var newRoot = root.RemoveNode(method, SyntaxRemoveOptions.KeepNoTrivia);
-        var workspace = new AdhocWorkspace();
-        var formatted = Formatter.Format(newRoot, workspace);
+        var formatted = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formatted.ToFullString());
         return $"Successfully deleted method '{methodName}' in {filePath} (single file mode)";
     }
@@ -304,8 +302,7 @@ public static partial class RefactoringTools
 
         var newMethod = method.WithParameterList(method.ParameterList.WithParameters(method.ParameterList.Parameters.Remove(parameter)));
         root = root.ReplaceNode(method, newMethod);
-        var workspace = new AdhocWorkspace();
-        var formatted = Formatter.Format(root, workspace);
+        var formatted = Formatter.Format(root, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formatted.ToFullString());
         return $"Successfully deleted parameter '{parameterName}' from method '{methodName}' in {filePath} (single file mode)";
     }
@@ -382,8 +379,7 @@ public static partial class RefactoringTools
             newRoot = root.ReplaceNode(statement, statement.WithDeclaration(newDecl));
         }
 
-        var workspace = new AdhocWorkspace();
-        var formatted = Formatter.Format(newRoot, workspace);
+        var formatted = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formatted.ToFullString());
         return $"Successfully deleted variable '{name}' in {filePath} (single file mode)";
     }

--- a/RefactorMCP.ConsoleApp/Tools/TransformSetterToInit.cs
+++ b/RefactorMCP.ConsoleApp/Tools/TransformSetterToInit.cs
@@ -88,8 +88,7 @@ public static partial class RefactoringTools
         var newProperty = property.ReplaceNode(setter, initAccessor);
 
         var newRoot = syntaxRoot.ReplaceNode(property, newProperty);
-        var workspace = new AdhocWorkspace();
-        var formatted = Formatter.Format(newRoot, workspace);
+        var formatted = Formatter.Format(newRoot, SharedWorkspace);
         await File.WriteAllTextAsync(filePath, formatted.ToFullString());
 
         return $"Successfully converted setter to init for '{propertyName}' in {filePath} (single file mode)";


### PR DESCRIPTION
## Summary
- add a lazy `AdhocWorkspace` to `RefactoringTools`
- reuse the shared workspace in all single-file refactorings

## Testing
- `dotnet format --verify-no-changes --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684813b37ca48327a0dae2eb869915e9