### PR TITLE
Switch CLI flag to --cli

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -10,13 +10,13 @@ Using the MCP tools is the preferred method for refactoring large files where ma
 Before performing any refactoring, you need to load a solution:
 
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test load-solution ./RefactorMCP.sln
+dotnet run --project RefactorMCP.ConsoleApp -- --cli load-solution ./RefactorMCP.sln
 ```
 
-### Test Mode Usage
-All examples use the test mode syntax:
+### CLI Mode Usage
+All examples use the CLI syntax:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test <command> [arguments]
+dotnet run --project RefactorMCP.ConsoleApp -- --cli <command> [arguments]
 ```
 
 ## 1. Extract Method
@@ -43,7 +43,7 @@ public int Calculate(int a, int b)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   "22:9-25:34" \
@@ -86,7 +86,7 @@ public double GetAverage()
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-field \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-field \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   "35:16-35:58" \
@@ -119,7 +119,7 @@ public string FormatResult(int value)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-variable \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-variable \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   "41:50-41:65" \
@@ -157,7 +157,7 @@ public void SetFormat(string newFormat)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test make-field-readonly \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli make-field-readonly \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   format
@@ -191,7 +191,7 @@ public string FormatResult(int value)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-parameter \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-parameter \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   40 \
@@ -222,7 +222,7 @@ public string GetFormattedNumber(int number)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-parameters \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-static-with-parameters \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   GetFormattedNumber
@@ -251,7 +251,7 @@ public string GetFormattedNumber(int number)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-instance \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-static-with-instance \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   GetFormattedNumber \
@@ -281,7 +281,7 @@ public string GetFormattedNumber(int number)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-extension-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   GetFormattedNumber
@@ -313,7 +313,7 @@ public static string FormatCurrency(decimal amount)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test move-static-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-static-method \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   FormatCurrency \
@@ -346,7 +346,7 @@ public int Multiply(int x, int y, int unusedParam)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test safe-delete-parameter \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli safe-delete-parameter \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   Multiply \
@@ -368,7 +368,7 @@ public int Multiply(int x, int y)
 ### Example
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test load-solution "./RefactorMCP.sln"
+dotnet run --project RefactorMCP.ConsoleApp -- --cli load-solution "./RefactorMCP.sln"
 ```
 
 **Expected Output**:
@@ -383,7 +383,7 @@ Successfully loaded solution 'RefactorMCP.sln' with 2 projects: RefactorMCP.Cons
 ### Example
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test unload-solution "./RefactorMCP.sln"
+dotnet run --project RefactorMCP.ConsoleApp -- --cli unload-solution "./RefactorMCP.sln"
 ```
 
 **Expected Output**:
@@ -398,7 +398,7 @@ Unloaded solution 'RefactorMCP.sln' from cache
 ### Example
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test clear-solution-cache
+dotnet run --project RefactorMCP.ConsoleApp -- --cli clear-solution-cache
 ```
 
 **Expected Output**:
@@ -413,7 +413,7 @@ Cleared all cached solutions
 ### Example
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test list-tools
+dotnet run --project RefactorMCP.ConsoleApp -- --cli list-tools
 ```
 
 **Output**:
@@ -443,7 +443,7 @@ safe-delete - Safely delete a field, parameter, or variable (TODO)
 ### Example
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test version
+dotnet run --project RefactorMCP.ConsoleApp -- --cli version
 ```
 
 **Expected Output**:
@@ -527,13 +527,13 @@ You can perform multiple refactorings in sequence:
 
 ```bash
 # First, extract a method
-dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method "./RefactorMCP.sln" "./MyFile.cs" "10:5-15:20" "ExtractedMethod"
+dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method "./RefactorMCP.sln" "./MyFile.cs" "10:5-15:20" "ExtractedMethod"
 
 # Then, make a field readonly
-dotnet run --project RefactorMCP.ConsoleApp -- --test make-field-readonly "./RefactorMCP.sln" "./MyFile.cs" 25
+dotnet run --project RefactorMCP.ConsoleApp -- --cli make-field-readonly "./RefactorMCP.sln" "./MyFile.cs" 25
 
 # Finally, introduce a variable
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-variable "./RefactorMCP.sln" "./MyFile.cs" "30:10-30:35" "tempValue"
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-variable "./RefactorMCP.sln" "./MyFile.cs" "30:10-30:35" "tempValue"
 ```
 
 ### Working with Different Projects
@@ -541,8 +541,8 @@ If your solution has multiple projects, make sure to specify the correct file pa
 
 ```bash
 # For a file in the main project
-dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method "./RefactorMCP.sln" "./RefactorMCP.ConsoleApp/MyFile.cs" "10:5-15:20" "ExtractedMethod"
+dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method "./RefactorMCP.sln" "./RefactorMCP.ConsoleApp/MyFile.cs" "10:5-15:20" "ExtractedMethod"
 
 # For a file in the test project  
-dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method "./RefactorMCP.sln" "./RefactorMCP.Tests/TestFile.cs" "5:1-8:10" "TestMethod"
+dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method "./RefactorMCP.sln" "./RefactorMCP.Tests/TestFile.cs" "5:1-8:10" "TestMethod"
 ``` 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -6,26 +6,26 @@ Using these tools through the MCP interface is the preferred approach for refact
 
 ```bash
 # Help
-dotnet run --project RefactorMCP.ConsoleApp -- --test
+dotnet run --project RefactorMCP.ConsoleApp -- --cli
 
 # List all tools
-dotnet run --project RefactorMCP.ConsoleApp -- --test list-tools
+dotnet run --project RefactorMCP.ConsoleApp -- --cli list-tools
 
 # Load solution (not required)
-dotnet run --project RefactorMCP.ConsoleApp -- --test load-solution ./RefactorMCP.sln
+dotnet run --project RefactorMCP.ConsoleApp -- --cli load-solution ./RefactorMCP.sln
 # Unload solution when done
-dotnet run --project RefactorMCP.ConsoleApp -- --test unload-solution ./RefactorMCP.sln
+dotnet run --project RefactorMCP.ConsoleApp -- --cli unload-solution ./RefactorMCP.sln
 # Clear all cached solutions
-dotnet run --project RefactorMCP.ConsoleApp -- --test clear-solution-cache
+dotnet run --project RefactorMCP.ConsoleApp -- --cli clear-solution-cache
 # Show version information
-dotnet run --project RefactorMCP.ConsoleApp -- --test version
+dotnet run --project RefactorMCP.ConsoleApp -- --cli version
 ```
 
 ## Refactoring Commands
 
 ### Extract Method
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   "startLine:startCol-endLine:endCol" \
@@ -34,7 +34,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method \
 
 ### Introduce Field
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-field \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-field \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   "startLine:startCol-endLine:endCol" \
@@ -44,7 +44,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-field \
 
 ### Introduce Variable
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-variable \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-variable \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   "startLine:startCol-endLine:endCol" \
@@ -53,7 +53,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-variable \
 
 ### Make Field Readonly
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test make-field-readonly \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli make-field-readonly \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   fieldName
@@ -61,7 +61,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test make-field-readonly \
 
 ### Convert To Extension Method
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-extension-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   methodName
@@ -69,7 +69,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-extension-metho
 
 ### Safe Delete Parameter
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test safe-delete-parameter \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli safe-delete-parameter \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   MethodName \
@@ -78,7 +78,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test safe-delete-parameter \
 
 ### Introduce Parameter
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-parameter \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-parameter \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   methodName \
@@ -88,7 +88,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-parameter \
 
 ### Convert to Static with Parameters
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-parameters \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-static-with-parameters \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   methodName
@@ -96,7 +96,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-par
 
 ### Convert to Static with Instance
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-instance \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-static-with-instance \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   methodName \
@@ -105,7 +105,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-ins
 
 ### Move Static Method
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test move-static-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-static-method \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   methodName \
@@ -115,7 +115,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test move-static-method \
 
 ### Move Instance Method
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test move-instance-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   "SourceClass" \
@@ -127,7 +127,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test move-instance-method \
 
 ### Convert To Extension Method
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-extension-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   methodName
@@ -169,41 +169,41 @@ private string format = "Currency";
 
 ```bash
 # Extract validation logic into method
-dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" "22:9-25:10" "ValidateInputs"
 
 # Create field from calculation
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-field \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-field \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" "35:16-35:58" "_averageValue" "private"
 
 # Extract complex expression to variable
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-variable \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-variable \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" "41:50-41:65" "processedValue"
 
 # Make format field readonly
-dotnet run --project RefactorMCP.ConsoleApp -- --test make-field-readonly \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli make-field-readonly \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" format
 
 # Convert method to extension
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-extension-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" GetFormattedNumber
 
 # Introduce parameter from expression
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-parameter \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-parameter \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" Calculate "41:50-41:65" "processedValue"
 
 # Convert method to static with parameters
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-parameters \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-static-with-parameters \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" GetFormattedNumber
 
 # Convert method to static with instance
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-instance \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-static-with-instance \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" GetFormattedNumber "calculator"
 # Move static method to MathUtilities
-dotnet run --project RefactorMCP.ConsoleApp -- --test move-static-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-static-method \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" FormatCurrency MathUtilities
 # Convert method to extension
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-extension-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" GetFormattedNumber
 ```
 

--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ Run as an MCP server for integration with AI assistants:
 dotnet run --project RefactorMCP.ConsoleApp
 ```
 
-### Test Mode (CLI)
+### CLI Mode
 
-Use the `--test` flag for direct command-line testing:
+Use the `--cli` flag for direct command-line testing:
 
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test <command> [arguments]
+dotnet run --project RefactorMCP.ConsoleApp -- --cli <command> [arguments]
 ```
 
 #### Available Test Commands
@@ -193,13 +193,13 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test <command> [arguments]
 
 ```bash
 # List available tools
-dotnet run --project RefactorMCP.ConsoleApp -- --test list-tools
+dotnet run --project RefactorMCP.ConsoleApp -- --cli list-tools
 
 # Load a solution (not required)
-dotnet run --project RefactorMCP.ConsoleApp -- --test load-solution ./RefactorMCP.sln
+dotnet run --project RefactorMCP.ConsoleApp -- --cli load-solution ./RefactorMCP.sln
 
 # Extract a method (example range)
-dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   "22:9-25:34" \
@@ -208,7 +208,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method \
 
 ```bash
 # Convert instance method to extension
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-extension-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   GetFormattedNumber
@@ -244,7 +244,7 @@ public int Calculate(int a, int b)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method \
   "./RefactorMCP.sln" "./MyFile.cs" "3:5-6:6" "ValidateInputs"
 ```
 
@@ -279,7 +279,7 @@ public double GetAverage()
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-field \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-field \
   "./RefactorMCP.sln" "./MyFile.cs" "3:12-3:54" "_averageValue" "private"
 ```
 
@@ -305,7 +305,7 @@ public string FormatResult(int value)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-parameter \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-parameter \
   "./RefactorMCP.sln" "./MyFile.cs" 40 "41:50-41:65" "processedValue"
 ```
 
@@ -329,7 +329,7 @@ public string GetFormattedNumber(int number)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-parameters \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-static-with-parameters \
   "./RefactorMCP.sln" "./MyFile.cs" GetFormattedNumber
 ```
 
@@ -353,7 +353,7 @@ public string GetFormattedNumber(int number)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test convert-to-static-with-instance \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-static-with-instance \
   "./RefactorMCP.sln" "./MyFile.cs" GetFormattedNumber "calculator"
 ```
 
@@ -377,7 +377,7 @@ public int Multiply(int x, int y, int unusedParam)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test safe-delete-parameter \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli safe-delete-parameter \
   "./RefactorMCP.Tests/ExampleCode.cs" "Multiply" "unusedParam" "./RefactorMCP.sln"
 ```
 
@@ -401,7 +401,7 @@ public static string FormatCurrency(decimal amount)
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --test move-static-method \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-static-method \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   "FormatCurrency" \
@@ -466,10 +466,10 @@ The examples use the sample code in [RefactorMCP.Tests/ExampleCode.cs](./Refacto
 dotnet test
 
 # Test specific refactoring tool
-dotnet run --project RefactorMCP.ConsoleApp -- --test <tool-name> [args]
+dotnet run --project RefactorMCP.ConsoleApp -- --cli <tool-name> [args]
 
 # Load test solution for debugging
-dotnet run --project RefactorMCP.ConsoleApp -- --test load-solution ./RefactorMCP.sln
+dotnet run --project RefactorMCP.ConsoleApp -- --cli load-solution ./RefactorMCP.sln
 ```
 
 ## Error Handling

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -12,9 +12,9 @@ using System.ComponentModel;
 using System.Text;
 
 // Parse command line arguments
-if (args.Length > 0 && args[0] == "--test")
+if (args.Length > 0 && args[0] == "--cli")
 {
-    await RunTestMode(args);
+    await RunCliMode(args);
     return;
 }
 
@@ -32,11 +32,11 @@ builder.Services
 
 await builder.Build().RunAsync();
 
-static async Task RunTestMode(string[] args)
+static async Task RunCliMode(string[] args)
 {
     if (args.Length < 2)
     {
-        ShowTestModeHelp();
+        ShowCliHelp();
         return;
     }
 
@@ -60,7 +60,7 @@ static async Task RunTestMode(string[] args)
             "safe-delete-variable" => await TestSafeDeleteVariable(args),
             "version" => ShowVersionInfo(),
             "list-tools" => ListAvailableTools(),
-            _ => $"Unknown command: {command}. Use --test list-tools to see available commands."
+            _ => $"Unknown command: {command}. Use --cli list-tools to see available commands."
         };
 
         Console.WriteLine(result);
@@ -72,10 +72,10 @@ static async Task RunTestMode(string[] args)
     }
 }
 
-static void ShowTestModeHelp()
+static void ShowCliHelp()
 {
-    Console.WriteLine("RefactorMCP Test Mode");
-    Console.WriteLine("Usage: RefactorMCP.ConsoleApp --test <command> [arguments]");
+    Console.WriteLine("RefactorMCP CLI Mode");
+    Console.WriteLine("Usage: RefactorMCP.ConsoleApp --cli <command> [arguments]");
     Console.WriteLine();
     Console.WriteLine("Available commands:");
     Console.WriteLine("  list-tools                                    - List all available refactoring tools");
@@ -95,12 +95,12 @@ static void ShowTestModeHelp()
     Console.WriteLine("  move-instance-method <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [solutionPath]");
     Console.WriteLine();
     Console.WriteLine("Examples:");
-    Console.WriteLine("  --test load-solution ./MySolution.sln");
-    Console.WriteLine("  --test extract-method ./MyFile.cs \"10:5-15:20\" \"ExtractedMethod\"");
-    Console.WriteLine("  --test extract-method ./MyFile.cs \"10:5-15:20\" \"ExtractedMethod\" ./MySolution.sln");
-    Console.WriteLine("  --test introduce-field ./MyFile.cs \"12:10-12:25\" \"_myField\" \"private\"");
-    Console.WriteLine("  --test make-field-readonly ./MyFile.cs 15");
-    Console.WriteLine("  --test version");
+    Console.WriteLine("  --cli load-solution ./MySolution.sln");
+    Console.WriteLine("  --cli extract-method ./MyFile.cs \"10:5-15:20\" \"ExtractedMethod\"");
+    Console.WriteLine("  --cli extract-method ./MyFile.cs \"10:5-15:20\" \"ExtractedMethod\" ./MySolution.sln");
+    Console.WriteLine("  --cli introduce-field ./MyFile.cs \"12:10-12:25\" \"_myField\" \"private\"");
+    Console.WriteLine("  --cli make-field-readonly ./MyFile.cs 15");
+    Console.WriteLine("  --cli version");
     Console.WriteLine();
     Console.WriteLine("Range format: \"startLine:startColumn-endLine:endColumn\" (1-based)");
     Console.WriteLine("Note: Solution path is optional. When omitted, single file mode is used with limited semantic analysis.");
@@ -134,7 +134,7 @@ static string ListAvailableTools()
 static async Task<string> TestLoadSolution(string[] args)
 {
     if (args.Length < 3)
-        return "Error: Missing solution path. Usage: --test load-solution <solutionPath>";
+        return "Error: Missing solution path. Usage: --cli load-solution <solutionPath>";
 
     var solutionPath = args[2];
     return await RefactoringTools.LoadSolution(solutionPath);
@@ -143,7 +143,7 @@ static async Task<string> TestLoadSolution(string[] args)
 static async Task<string> TestExtractMethod(string[] args)
 {
     if (args.Length < 5)
-        return "Error: Missing arguments. Usage: --test extract-method <filePath> <range> <methodName> [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli extract-method <filePath> <range> <methodName> [solutionPath]";
 
     var filePath = args[2];
     var range = args[3];
@@ -156,7 +156,7 @@ static async Task<string> TestExtractMethod(string[] args)
 static async Task<string> TestIntroduceField(string[] args)
 {
     if (args.Length < 5)
-        return "Error: Missing arguments. Usage: --test introduce-field <filePath> <range> <fieldName> [accessModifier] [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli introduce-field <filePath> <range> <fieldName> [accessModifier] [solutionPath]";
 
     var filePath = args[2];
     var range = args[3];
@@ -170,7 +170,7 @@ static async Task<string> TestIntroduceField(string[] args)
 static async Task<string> TestIntroduceVariable(string[] args)
 {
     if (args.Length < 5)
-        return "Error: Missing arguments. Usage: --test introduce-variable <filePath> <range> <variableName> [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli introduce-variable <filePath> <range> <variableName> [solutionPath]";
 
     var filePath = args[2];
     var range = args[3];
@@ -183,7 +183,7 @@ static async Task<string> TestIntroduceVariable(string[] args)
 static async Task<string> TestMakeFieldReadonly(string[] args)
 {
     if (args.Length < 4)
-        return "Error: Missing arguments. Usage: --test make-field-readonly <filePath> <fieldName> [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli make-field-readonly <filePath> <fieldName> [solutionPath]";
 
     var filePath = args[2];
     var fieldName = args[3];
@@ -195,7 +195,7 @@ static async Task<string> TestMakeFieldReadonly(string[] args)
 static string TestUnloadSolution(string[] args)
 {
     if (args.Length < 3)
-        return "Error: Missing solution path. Usage: --test unload-solution <solutionPath>";
+        return "Error: Missing solution path. Usage: --cli unload-solution <solutionPath>";
 
     var solutionPath = args[2];
     return RefactoringTools.UnloadSolution(solutionPath);
@@ -214,7 +214,7 @@ static string ShowVersionInfo()
 static async Task<string> TestConvertToExtensionMethod(string[] args)
 {
     if (args.Length < 4)
-        return "Error: Missing arguments. Usage: --test convert-to-extension-method <filePath> <methodName> [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli convert-to-extension-method <filePath> <methodName> [solutionPath]";
 
     var filePath = args[2];
     var methodName = args[3];
@@ -226,7 +226,7 @@ static async Task<string> TestConvertToExtensionMethod(string[] args)
 static async Task<string> TestSafeDeleteField(string[] args)
 {
     if (args.Length < 4)
-        return "Error: Missing arguments. Usage: --test safe-delete-field <filePath> <fieldName> [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli safe-delete-field <filePath> <fieldName> [solutionPath]";
 
     var filePath = args[2];
     var fieldName = args[3];
@@ -238,7 +238,7 @@ static async Task<string> TestSafeDeleteField(string[] args)
 static async Task<string> TestSafeDeleteMethod(string[] args)
 {
     if (args.Length < 4)
-        return "Error: Missing arguments. Usage: --test safe-delete-method <filePath> <methodName> [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli safe-delete-method <filePath> <methodName> [solutionPath]";
 
     var filePath = args[2];
     var methodName = args[3];
@@ -250,7 +250,7 @@ static async Task<string> TestSafeDeleteMethod(string[] args)
 static async Task<string> TestSafeDeleteParameter(string[] args)
 {
     if (args.Length < 5)
-        return "Error: Missing arguments. Usage: --test safe-delete-parameter <filePath> <methodName> <parameterName> [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli safe-delete-parameter <filePath> <methodName> <parameterName> [solutionPath]";
 
     var filePath = args[2];
     var methodName = args[3];
@@ -263,7 +263,7 @@ static async Task<string> TestSafeDeleteParameter(string[] args)
 static async Task<string> TestSafeDeleteVariable(string[] args)
 {
     if (args.Length < 4)
-        return "Error: Missing arguments. Usage: --test safe-delete-variable <filePath> <range> [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli safe-delete-variable <filePath> <range> [solutionPath]";
 
     var filePath = args[2];
     var range = args[3];

--- a/RefactorMCP.Tests/TEST_SUMMARY.md
+++ b/RefactorMCP.Tests/TEST_SUMMARY.md
@@ -62,7 +62,7 @@ dotnet test RefactorMCP.Tests/RefactorMCP.Tests.csproj \
 
 ## Manual Testing
 
-For thorough testing of the refactoring functionality, use the CLI test mode:
+For thorough testing of the refactoring functionality, use the CLI mode:
 
 ```bash
 # Build and test with actual files
@@ -70,8 +70,8 @@ dotnet build RefactorMCP.ConsoleApp/RefactorMCP.ConsoleApp.csproj
 
 # Test with existing example file
 cd RefactorMCP.ConsoleApp
-dotnet run -- --test load-solution ../RefactorMCP.sln
-dotnet run -- --test extract-method ../RefactorMCP.sln ../RefactorMCP.Tests/ExampleCode.cs "22:9-25:10" "ValidateInputs"
+dotnet run -- --cli load-solution ../RefactorMCP.sln
+dotnet run -- --cli extract-method ../RefactorMCP.sln ../RefactorMCP.Tests/ExampleCode.cs "22:9-25:10" "ValidateInputs"
 ```
 
 ## Future Improvements

--- a/RefactorMCP.Tests/UnitTest1.cs
+++ b/RefactorMCP.Tests/UnitTest1.cs
@@ -500,7 +500,7 @@ public class TestClass
     }
 }
 
-// Integration tests for the CLI test mode
+// Integration tests for the CLI mode
 public class CliIntegrationTests
 {
     private static string GetSolutionPath()

--- a/SINGLE_FILE_MODE.md
+++ b/SINGLE_FILE_MODE.md
@@ -83,16 +83,16 @@ The refactoring engine automatically detects which mode to use:
 
 ```bash
 # Extract Method (Single File Mode)
-dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method ./MyFile.cs "10:5-15:20" "ExtractedMethod"
+dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method ./MyFile.cs "10:5-15:20" "ExtractedMethod"
 
 # Extract Method (Solution Mode)  
-dotnet run --project RefactorMCP.ConsoleApp -- --test extract-method ./MyFile.cs "10:5-15:20" "ExtractedMethod" ./MySolution.sln
+dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method ./MyFile.cs "10:5-15:20" "ExtractedMethod" ./MySolution.sln
 
 # Introduce Variable (Single File Mode)
-dotnet run --project RefactorMCP.ConsoleApp -- --test introduce-variable ./MyFile.cs "12:10-12:25" "myVariable"
+dotnet run --project RefactorMCP.ConsoleApp -- --cli introduce-variable ./MyFile.cs "12:10-12:25" "myVariable"
 
 # Make Field Readonly (Single File Mode)
-dotnet run --project RefactorMCP.ConsoleApp -- --test make-field-readonly ./MyFile.cs 15
+dotnet run --project RefactorMCP.ConsoleApp -- --cli make-field-readonly ./MyFile.cs 15
 ```
 
 ### MCP Tool Calls
@@ -142,13 +142,13 @@ If you were using the old parameter order, update your calls:
 
 ```bash
 # OLD
---test extract-method ./MySolution.sln ./MyFile.cs "10:5-15:20" "ExtractedMethod"
+--cli extract-method ./MySolution.sln ./MyFile.cs "10:5-15:20" "ExtractedMethod"
 
 # NEW (Solution Mode)  
---test extract-method ./MyFile.cs "10:5-15:20" "ExtractedMethod" ./MySolution.sln
+--cli extract-method ./MyFile.cs "10:5-15:20" "ExtractedMethod" ./MySolution.sln
 
 # NEW (Single File Mode)
---test extract-method ./MyFile.cs "10:5-15:20" "ExtractedMethod"
+--cli extract-method ./MyFile.cs "10:5-15:20" "ExtractedMethod"
 ```
 
 ### For MCP Clients


### PR DESCRIPTION
## Summary
- rename `--test` CLI flag to `--cli`
- adjust help text and method names
- update docs and examples to show `--cli` usage

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68482714bde88327bb4257eb70aaa464