### PR TITLE
Fix CLI command coverage

### DIFF
--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -62,14 +62,15 @@ static async Task RunCliMode(string[] args)
         ["safe-delete-method"] = TestSafeDeleteMethod,
         ["safe-delete-parameter"] = TestSafeDeleteParameter,
         ["safe-delete-variable"] = TestSafeDeleteVariable,
-        ["list-tools"] = _ => Task.FromResult(ListAvailableTools())
+        ["list-tools"] = _ => Task.FromResult(ListAvailableTools()),
+        ["version"] = _ => Task.FromResult(ShowVersionInfo())
     };
 
     try
     {
         if (!handlers.TryGetValue(command, out var handler))
         {
-            Console.WriteLine($"Unknown command: {command}. Use --test list-tools to see available commands.");
+            Console.WriteLine($"Unknown command: {command}. Use --cli list-tools to see available commands.");
             return;
         }
 
@@ -280,7 +281,7 @@ static async Task<string> TestSafeDeleteVariable(string[] args)
 static async Task<string> TestConvertToStaticWithParameters(string[] args)
 {
     if (args.Length < 4)
-        return "Error: Missing arguments. Usage: --test convert-to-static-with-parameters <filePath> <methodName> [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli convert-to-static-with-parameters <filePath> <methodName> [solutionPath]";
 
     var filePath = args[2];
     var methodName = args[3];
@@ -292,7 +293,7 @@ static async Task<string> TestConvertToStaticWithParameters(string[] args)
 static async Task<string> TestConvertToStaticWithInstance(string[] args)
 {
     if (args.Length < 4)
-        return "Error: Missing arguments. Usage: --test convert-to-static-with-instance <filePath> <methodName> [instanceParamName] [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli convert-to-static-with-instance <filePath> <methodName> [instanceParamName] [solutionPath]";
 
     var filePath = args[2];
     var methodName = args[3];
@@ -305,7 +306,7 @@ static async Task<string> TestConvertToStaticWithInstance(string[] args)
 static async Task<string> TestIntroduceParameter(string[] args)
 {
     if (args.Length < 6)
-        return "Error: Missing arguments. Usage: --test introduce-parameter <filePath> <methodName> <range> <parameterName> [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli introduce-parameter <filePath> <methodName> <range> <parameterName> [solutionPath]";
 
     var filePath = args[2];
     var methodName = args[3];
@@ -319,7 +320,7 @@ static async Task<string> TestIntroduceParameter(string[] args)
 static async Task<string> TestMoveStaticMethod(string[] args)
 {
     if (args.Length < 6)
-        return "Error: Missing arguments. Usage: --test move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]";
+        return "Error: Missing arguments. Usage: --cli move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]";
 
     var solutionPath = args[2];
     var filePath = args[3];
@@ -333,7 +334,7 @@ static async Task<string> TestMoveStaticMethod(string[] args)
 static async Task<string> TestMoveInstanceMethod(string[] args)
 {
     if (args.Length < 7)
-        return "Error: Missing arguments. Usage: --test move-instance-method <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli move-instance-method <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [solutionPath]";
 
     var filePath = args[2];
     var sourceClass = args[3];
@@ -349,7 +350,7 @@ static async Task<string> TestMoveInstanceMethod(string[] args)
 static async Task<string> TestTransformSetterToInit(string[] args)
 {
     if (args.Length < 4)
-        return "Error: Missing arguments. Usage: --test transform-setter-to-init <filePath> <propertyName> [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli transform-setter-to-init <filePath> <propertyName> [solutionPath]";
 
     var filePath = args[2];
     var propertyName = args[3];

--- a/RefactorMCP.Tests/UnitTest1.cs
+++ b/RefactorMCP.Tests/UnitTest1.cs
@@ -536,28 +536,51 @@ public class CliIntegrationTests
     public async Task CliTestMode_AllToolsListed_ReturnsExpectedTools()
     {
         // Test that all expected tools are available
-        var expectedTools = new[]
+        var expectedCommands = new[]
         {
+            "list-tools",
             "load-solution",
             "extract-method",
             "introduce-field",
             "introduce-variable",
             "make-field-readonly",
+            "unload-solution",
+            "clear-solution-cache",
+            "convert-to-extension-method",
+            "convert-to-static-with-parameters",
+            "convert-to-static-with-instance",
+            "introduce-parameter",
+            "move-static-method",
+            "move-instance-method",
+            "transform-setter-to-init",
+            "safe-delete-field",
+            "safe-delete-method",
+            "safe-delete-parameter",
+            "safe-delete-variable",
             "version"
         };
 
-        // Verify RefactoringTools class has all the expected methods
-        var type = typeof(RefactoringTools);
-        var methods = type.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
+        var refactoringMethods = typeof(RefactoringTools)
+            .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);
 
-        foreach (var tool in expectedTools)
+        foreach (var command in expectedCommands)
         {
-            var methodName = tool.Replace("-", "")
-                .Split('-')
-                .Select(word => char.ToUpper(word[0]) + word[1..])
-                .Aggregate((a, b) => a + b);
+            if (command == "list-tools")
+            {
+                var progType = typeof(RefactoringTools).Assembly.GetType("Program");
+                Assert.NotNull(progType);
+                var progMethod = progType!.GetMethods(System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+                    .FirstOrDefault(m => m.Name.Contains("ListAvailableTools"));
+                Assert.NotNull(progMethod);
+                continue;
+            }
 
-            var method = methods.FirstOrDefault(m => m.Name.Equals(methodName, StringComparison.OrdinalIgnoreCase));
+            var pascal = string.Concat(command
+                .Split('-')
+                .Select(w => char.ToUpper(w[0]) + w[1..]));
+
+            var method = refactoringMethods.FirstOrDefault(m =>
+                m.Name.Equals(pascal, StringComparison.OrdinalIgnoreCase));
             Assert.NotNull(method);
         }
     }


### PR DESCRIPTION
## Summary
- update CLI handlers in `Program.cs`
- correct CLI usage messages
- add version handler
- extend `CliIntegrationTests` to cover all CLI commands
- fix reflection lookup for CLI coverage test

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68482b60f6188327903bfadba9ff36de