### PR TITLE
Add working directory to file-not-found messages

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -494,7 +494,7 @@ To select `if (a < 0 || b < 0)` on line 3:
 
 1. **File not found**:
    ```
-   Error: File ./path/to/file.cs not found in solution
+   Error: File ./path/to/file.cs not found in solution (current dir: /your/working/dir)
    ```
 
 2. **Invalid range format**:

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -211,7 +211,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method
 
 | Error | Solution |
 |-------|----------|
-| File not found | Check file path relative to solution |
+| File not found | Check file path relative to solution. The error lists the current working directory |
 | Invalid range | Verify 1-based line:column format |
 | No extractable code | Select complete statements/expressions |
 | Solution not loaded | Run load-solution command first |

--- a/README.md
+++ b/README.md
@@ -476,7 +476,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli load-solution ./RefactorMCP
 
 Common error scenarios and solutions:
 
-- **File not found**: Ensure file paths are relative to solution directory
+- **File not found**: Ensure file paths are relative to the solution directory. The error message now includes the current working directory for reference.
 - **Invalid range**: Check 1-based line/column indexing
 - **No extractable code**: Verify selection contains valid statements/expressions
 - **Solution load failure**: Check .sln file path and project references

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
@@ -120,7 +120,7 @@ public static partial class RefactoringTools
     private static async Task<string> ConvertToExtensionMethodSingleFile(string filePath, string methodName, string? extensionClass)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
@@ -97,7 +97,7 @@ public static partial class RefactoringTools
     private static async Task<string> ConvertToStaticWithInstanceSingleFile(string filePath, string methodName, string instanceParameterName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
@@ -21,7 +21,7 @@ public static partial class RefactoringTools
                 var solution = await GetOrLoadSolution(solutionPath);
                 var document = GetDocumentByPath(solution, filePath);
                 if (document == null)
-                    return $"Error: File {filePath} not found in solution";
+                    return $"Error: File {filePath} not found in solution (current dir: {Directory.GetCurrentDirectory()})";
 
                 return await ConvertToStaticWithParametersWithSolution(document, methodName);
             }
@@ -119,7 +119,7 @@ public static partial class RefactoringTools
     private static async Task<string> ConvertToStaticWithParametersSingleFile(string filePath, string methodName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);

--- a/RefactorMCP.ConsoleApp/Tools/ExtractMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ExtractMethod.cs
@@ -112,7 +112,7 @@ public static partial class RefactoringTools
     private static async Task<string> ExtractMethodSingleFile(string filePath, string selectionRange, string methodName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
@@ -109,7 +109,7 @@ public static partial class RefactoringTools
     private static async Task<string> IntroduceFieldSingleFile(string filePath, string selectionRange, string fieldName, string accessModifier)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
@@ -53,7 +53,7 @@ public static partial class RefactoringTools
     private static async Task<string> IntroduceParameterSingleFile(string filePath, string methodName, string selectionRange, string parameterName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
@@ -106,7 +106,7 @@ public static partial class RefactoringTools
                 var solution = await GetOrLoadSolution(solutionPath);
                 var document = GetDocumentByPath(solution, filePath);
                 if (document == null)
-                    return $"Error: File {filePath} not found in solution";
+                    return $"Error: File {filePath} not found in solution (current dir: {Directory.GetCurrentDirectory()})";
 
                 return await IntroduceParameterWithSolution(document, methodName, selectionRange, parameterName);
             }

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceVariable.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceVariable.cs
@@ -97,7 +97,7 @@ public static partial class RefactoringTools
     private static async Task<string> IntroduceVariableSingleFile(string filePath, string selectionRange, string variableName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);

--- a/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
@@ -127,7 +127,7 @@ public static partial class RefactoringTools
     private static async Task<string> MakeFieldReadonlySingleFile(string filePath, string fieldName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
@@ -79,7 +79,7 @@ public static partial class RefactoringTools
     private static async Task<string> MoveInstanceMethodSingleFile(string filePath, string sourceClass, string methodName, string targetClass, string accessMemberName, string accessMemberType)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
@@ -155,7 +155,7 @@ public static partial class RefactoringTools
         try
         {
             if (!File.Exists(filePath))
-                return $"Error: File {filePath} not found";
+                return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
             var sourceText = await File.ReadAllTextAsync(filePath);
             var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);

--- a/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
@@ -150,7 +150,7 @@ public static partial class RefactoringTools
     private static async Task<string> SafeDeleteFieldSingleFile(string filePath, string fieldName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var tree = CSharpSyntaxTree.ParseText(sourceText);
@@ -204,7 +204,7 @@ public static partial class RefactoringTools
     private static async Task<string> SafeDeleteMethodSingleFile(string filePath, string methodName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var tree = CSharpSyntaxTree.ParseText(sourceText);
@@ -273,7 +273,7 @@ public static partial class RefactoringTools
     private static async Task<string> SafeDeleteParameterSingleFile(string filePath, string methodName, string parameterName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var tree = CSharpSyntaxTree.ParseText(sourceText);
@@ -348,7 +348,7 @@ public static partial class RefactoringTools
     private static async Task<string> SafeDeleteVariableSingleFile(string filePath, string selectionRange)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var tree = CSharpSyntaxTree.ParseText(sourceText);

--- a/RefactorMCP.ConsoleApp/Tools/TransformSetterToInit.cs
+++ b/RefactorMCP.ConsoleApp/Tools/TransformSetterToInit.cs
@@ -21,7 +21,7 @@ public static partial class RefactoringTools
                 var solution = await GetOrLoadSolution(solutionPath);
                 var document = GetDocumentByPath(solution, filePath);
                 if (document == null)
-                    return $"Error: File {filePath} not found in solution";
+                    return $"Error: File {filePath} not found in solution (current dir: {Directory.GetCurrentDirectory()})";
 
                 return await TransformSetterToInitWithSolution(document, propertyName);
             }
@@ -67,7 +67,7 @@ public static partial class RefactoringTools
     private static async Task<string> TransformSetterToInitSingleFile(string filePath, string propertyName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found";
+            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);


### PR DESCRIPTION
## Summary
- expand file-not-found messages to include current working directory
- document this new detail in README, QUICK_REFERENCE, and EXAMPLES

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_6848414f24108327a47bb29f3dba4f3c