### PR TITLE
Clarify C# scope in MCP docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Coding Agents Guidelines
 
-This repository implements a Model Context Protocol (MCP) server that exposes refactoring tools as **agents**. When adding new agents or modifying existing ones, follow these guidelines.
+This repository implements a Model Context Protocol (MCP) server that exposes **C#** refactoring tools as **agents**. When adding new agents or modifying existing ones, follow these guidelines.
 
 ## Creating a New Agent
 

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2,7 +2,7 @@
 
 This document provides comprehensive examples for all refactoring tools available in RefactorMCP. Each example shows the before/after code and the exact CLI commands to perform the refactoring.
 
-Using the MCP tools is the preferred method for refactoring large files where manual edits become cumbersome.
+Using the MCP tools is the preferred method for refactoring large C# files where manual edits become cumbersome.
 
 ## Getting Started
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # RefactorMCP Quick Reference
 
-Using these tools through the MCP interface is the preferred approach for refactoring, especially when dealing with large files.
+Using these tools through the MCP interface is the preferred approach for refactoring **C# code**, especially when dealing with large files.
 
 ## Basic Commands
 

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 public static partial class RefactoringTools
 {
-    [McpServerTool, Description("Transform instance method to static by adding instance parameter (preferred for large-file refactoring)")]
+    [McpServerTool, Description("Transform instance method to static by adding instance parameter (preferred for large C# file refactoring)")]
     public static async Task<string> ConvertToStaticWithInstance(
         [Description("Path to the C# file")] string filePath,
         [Description("Name of the method to convert")] string methodName,

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 public static partial class RefactoringTools
 {
-    [McpServerTool, Description("Transform instance method to static by converting dependencies to parameters (preferred for large-file refactoring)")]
+    [McpServerTool, Description("Transform instance method to static by converting dependencies to parameters (preferred for large C# file refactoring)")]
     public static async Task<string> ConvertToStaticWithParameters(
         [Description("Path to the C# file")] string filePath,
         [Description("Name of the method to convert")] string methodName,

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
@@ -91,7 +91,7 @@ public static partial class RefactoringTools
 
         return $"Successfully introduced parameter '{parameterName}' from {selectionRange} in method '{methodName}' in {filePath} (single file mode)";
     }
-    [McpServerTool, Description("Create a new parameter from selected code (preferred for large-file refactoring)")]
+    [McpServerTool, Description("Create a new parameter from selected code (preferred for large C# file refactoring)")]
     public static async Task<string> IntroduceParameter(
         [Description("Path to the C# file")] string filePath,
         [Description("Name of the method to add parameter to")] string methodName,

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
@@ -144,7 +144,7 @@ public static partial class RefactoringTools
         return $"Successfully moved instance method to {targetClass} in {filePath} (single file mode)";
     }
 
-    [McpServerTool, Description("Move a static method to another class (preferred for large-file refactoring)")]
+    [McpServerTool, Description("Move a static method to another class (preferred for large C# file refactoring)")]
     public static async Task<string> MoveStaticMethod(
         [Description("Path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file containing the method")] string filePath,
@@ -225,7 +225,7 @@ public static partial class RefactoringTools
             return $"Error moving static method: {ex.Message}";
         }
     }
-    [McpServerTool, Description("Move an instance method to another class (preferred for large-file refactoring)")]
+    [McpServerTool, Description("Move an instance method to another class (preferred for large C# file refactoring)")]
     public static async Task<string> MoveInstanceMethod(
         [Description("Path to the C# file containing the method")] string filePath,
         [Description("Name of the source class containing the method")] string sourceClass,

--- a/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Formatting;
 
 public static partial class RefactoringTools
 {
-    [McpServerTool, Description("Safely delete an unused field (preferred for large-file refactoring)")]
+    [McpServerTool, Description("Safely delete an unused field (preferred for large C# file refactoring)")]
     public static async Task<string> SafeDeleteField(
         [Description("Path to the C# file")] string filePath,
         [Description("Name of the field to delete")] string fieldName,
@@ -35,7 +35,7 @@ public static partial class RefactoringTools
         }
     }
 
-    [McpServerTool, Description("Safely delete an unused method (preferred for large-file refactoring)")]
+    [McpServerTool, Description("Safely delete an unused method (preferred for large C# file refactoring)")]
     public static async Task<string> SafeDeleteMethod(
         [Description("Path to the C# file")] string filePath,
         [Description("Name of the method to delete")] string methodName,

--- a/RefactorMCP.ConsoleApp/Tools/TransformSetterToInit.cs
+++ b/RefactorMCP.ConsoleApp/Tools/TransformSetterToInit.cs
@@ -8,7 +8,7 @@ using Microsoft.CodeAnalysis.Text;
 
 public static partial class RefactoringTools
 {
-    [McpServerTool, Description("Convert property setter to init-only setter (preferred for large-file refactoring)")]
+    [McpServerTool, Description("Convert property setter to init-only setter (preferred for large C# file refactoring)")]
     public static async Task<string> TransformSetterToInit(
         [Description("Path to the C# file")] string filePath,
         [Description("Name of the property to transform")] string propertyName,

--- a/SINGLE_FILE_MODE.md
+++ b/SINGLE_FILE_MODE.md
@@ -2,7 +2,7 @@
 
 RefactorMCP now supports **Single File Mode** - a fast refactoring option that works without requiring a solution file. This mode provides direct syntax tree manipulation for simple refactoring operations.
 
-For large files, the MCP-based tools remain the preferred approach because they handle extensive edits more reliably.
+For large **C#** files, the MCP-based tools remain the preferred approach because they handle extensive edits more reliably.
 
 ## Overview
 

--- a/functionality.md
+++ b/functionality.md
@@ -1,6 +1,6 @@
 # RefactorMCP
 
-A Model Context Protocol (MCP) server providing automated refactoring tools for code transformation. 
+A Model Context Protocol (MCP) server providing automated refactoring tools for C# code transformation.
 
 Using:
 - Microsoft.CodeAnalysis.CSharp (4.14.0), 


### PR DESCRIPTION
## Summary
- clarify that the MCP server provides **C#** refactoring tools in AGENTS docs
- specify "C# code transformation" in functionality overview
- mention C# explicitly in quick reference, examples, and single file docs
- highlight C# in tool descriptions for large file refactoring

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet test --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_684844788dcc8327960f1f16c79e7b18