### PR TITLE
Support new file option in MoveInstanceMethod

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -116,13 +116,14 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-static-method \
 ### Move Instance Method
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \
-  "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   "SourceClass" \
   "MethodName" \
   "TargetClass" \
   "memberName" \
-  "field"
+  "field" \
+  "./optional/target.cs" \
+  "./RefactorMCP.sln"
 ```
 
 ### Convert To Extension Method

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli <command> [arguments]
 - `convert-to-static-with-parameters <solutionPath> <filePath> <methodLine>` - Convert instance method to static with parameters
 - `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
 - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFile]` - Move a static method to another class
-- `move-instance-method <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [solutionPath]` - Move an instance method to another class
+- `move-instance-method <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [targetFile] [solutionPath]` - Move an instance method to another class
 - `version` - Show build version and timestamp
 
 #### Quick Start Example

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -334,7 +334,7 @@ static async Task<string> TestMoveStaticMethod(string[] args)
 static async Task<string> TestMoveInstanceMethod(string[] args)
 {
     if (args.Length < 7)
-        return "Error: Missing arguments. Usage: --cli move-instance-method <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [solutionPath]";
+        return "Error: Missing arguments. Usage: --cli move-instance-method <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [targetFile] [solutionPath]";
 
     var filePath = args[2];
     var sourceClass = args[3];
@@ -342,9 +342,10 @@ static async Task<string> TestMoveInstanceMethod(string[] args)
     var targetClass = args[5];
     var accessMember = args[6];
     var memberType = args.Length > 7 ? args[7] : "field";
-    var solutionPath = args.Length > 8 ? args[8] : null;
+    var targetFile = args.Length > 8 ? args[8] : null;
+    var solutionPath = args.Length > 9 ? args[9] : null;
 
-    return await RefactoringTools.MoveInstanceMethod(filePath, sourceClass, methodName, targetClass, accessMember, memberType, solutionPath);
+    return await RefactoringTools.MoveInstanceMethod(filePath, sourceClass, methodName, targetClass, accessMember, memberType, targetFile, solutionPath);
 }
 
 static async Task<string> TestTransformSetterToInit(string[] args)

--- a/RefactorMCP.Tests/UnitTest1.cs
+++ b/RefactorMCP.Tests/UnitTest1.cs
@@ -394,12 +394,39 @@ public class RefactoringToolsTests : IDisposable
             "Logger",
             "_logger",
             "field",
+            null,
             SolutionPath
         );
 
         Assert.Contains("Successfully moved instance method", result);
 
         // File modification verification skipped
+    }
+
+    [Fact]
+    public async Task MoveInstanceMethod_NewFile_CreatesFile()
+    {
+        await RefactoringTools.LoadSolution(SolutionPath);
+        var sourceFile = Path.Combine(TestOutputPath, "MoveInstanceMethodNewFile.cs");
+        await CreateTestFile(sourceFile, GetSampleCodeForMoveInstanceMethod());
+        var targetFile = Path.Combine(TestOutputPath, "LoggerNew.cs");
+
+        var result = await RefactoringTools.MoveInstanceMethod(
+            sourceFile,
+            "Calculator",
+            "LogOperation",
+            "Logger",
+            "_logger",
+            "field",
+            targetFile,
+            SolutionPath
+        );
+
+        Assert.Contains("Successfully moved instance method", result);
+        Assert.True(File.Exists(targetFile));
+        var newContent = await File.ReadAllTextAsync(targetFile);
+        Assert.Contains("LogOperation", newContent);
+        Assert.Contains("using System;", newContent);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- allow `MoveInstanceMethod` to move methods into new files
- copy necessary `using` statements when creating a new file
- update CLI argument handling
- document new parameter in README and QUICK_REFERENCE
- add regression test for moving to a new file

## Testing
- `dotnet format --no-restore`
- `dotnet test -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6849607c5f388327aaecd43a531eac48