### PR TITLE
Adopt McpException for error handling

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
@@ -1,4 +1,5 @@
 using ModelContextProtocol.Server;
+using ModelContextProtocol;
 using System.ComponentModel;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -30,7 +31,7 @@ public static partial class RefactoringTools
         }
         catch (Exception ex)
         {
-            return $"Error converting to extension method: {ex.Message}";
+            throw new McpException($"Error converting to extension method: {ex.Message}", ex);
         }
     }
 
@@ -43,12 +44,12 @@ public static partial class RefactoringTools
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            return $"Error: No method named '{methodName}' found";
+            return ThrowMcpException($"Error: No method named '{methodName}' found");
 
         var semanticModel = await document.GetSemanticModelAsync();
         var classDecl = method.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
         if (classDecl == null)
-            return $"Error: Method '{methodName}' is not inside a class";
+            return ThrowMcpException($"Error: Method '{methodName}' is not inside a class");
 
         var className = classDecl.Identifier.ValueText;
         var extClassName = extensionClass ?? className + "Extensions";
@@ -120,7 +121,7 @@ public static partial class RefactoringTools
     private static async Task<string> ConvertToExtensionMethodSingleFile(string filePath, string methodName, string? extensionClass)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
+            return ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
@@ -130,11 +131,11 @@ public static partial class RefactoringTools
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            return $"Error: No method named '{methodName}' found";
+            return ThrowMcpException($"Error: No method named '{methodName}' found");
 
         var classDecl = method.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
         if (classDecl == null)
-            return $"Error: Method '{methodName}' is not inside a class";
+            return ThrowMcpException($"Error: Method '{methodName}' is not inside a class");
 
         var className = classDecl.Identifier.ValueText;
         var extClassName = extensionClass ?? className + "Extensions";

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
@@ -1,4 +1,5 @@
 using ModelContextProtocol.Server;
+using ModelContextProtocol;
 using System.ComponentModel;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -32,7 +33,7 @@ public static partial class RefactoringTools
         }
         catch (Exception ex)
         {
-            return $"Error converting method to static: {ex.Message}";
+            throw new McpException($"Error converting method to static: {ex.Message}", ex);
         }
     }
 
@@ -46,16 +47,16 @@ public static partial class RefactoringTools
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            return $"Error: No method named '{methodName}' found";
+            return ThrowMcpException($"Error: No method named '{methodName}' found");
 
         var semanticModel = await document.GetSemanticModelAsync();
         var typeDecl = method.Ancestors().OfType<TypeDeclarationSyntax>().FirstOrDefault();
         if (typeDecl == null)
-            return $"Error: Method '{methodName}' is not inside a type";
+            return ThrowMcpException($"Error: Method '{methodName}' is not inside a type");
 
         var typeSymbol = semanticModel!.GetDeclaredSymbol(typeDecl) as INamedTypeSymbol;
         if (typeSymbol == null)
-            return $"Error: Unable to determine containing type";
+            return ThrowMcpException($"Error: Unable to determine containing type");
 
         var parameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier(instanceParameterName))
             .WithType(SyntaxFactory.ParseTypeName(typeSymbol.ToDisplayString()));
@@ -97,7 +98,7 @@ public static partial class RefactoringTools
     private static async Task<string> ConvertToStaticWithInstanceSingleFile(string filePath, string methodName, string instanceParameterName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
+            return ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
@@ -107,11 +108,11 @@ public static partial class RefactoringTools
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            return $"Error: No method named '{methodName}' found";
+            return ThrowMcpException($"Error: No method named '{methodName}' found");
 
         var classDecl = method.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
         if (classDecl == null)
-            return $"Error: Method '{methodName}' is not inside a class";
+            return ThrowMcpException($"Error: Method '{methodName}' is not inside a class");
 
         var parameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier(instanceParameterName))
             .WithType(SyntaxFactory.ParseTypeName(classDecl.Identifier.ValueText));

--- a/RefactorMCP.ConsoleApp/Tools/LoadSolution.cs
+++ b/RefactorMCP.ConsoleApp/Tools/LoadSolution.cs
@@ -1,4 +1,5 @@
 using ModelContextProtocol.Server;
+using ModelContextProtocol;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.Extensions.Caching.Memory;
@@ -16,7 +17,7 @@ public static partial class RefactoringTools
         {
             if (!File.Exists(solutionPath))
             {
-                return $"Error: Solution file not found at {solutionPath}";
+                return ThrowMcpException($"Error: Solution file not found at {solutionPath}");
             }
             Directory.SetCurrentDirectory(Path.GetDirectoryName(solutionPath)!);
 
@@ -36,7 +37,7 @@ public static partial class RefactoringTools
         }
         catch (Exception ex)
         {
-            return $"Error loading solution: {ex.Message}";
+            throw new McpException($"Error loading solution: {ex.Message}", ex);
         }
     }
 }

--- a/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
@@ -1,4 +1,5 @@
 using ModelContextProtocol.Server;
+using ModelContextProtocol;
 using System.ComponentModel;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -33,7 +34,7 @@ public static partial class RefactoringTools
         }
         catch (Exception ex)
         {
-            return $"Error: {ex.Message}";
+            throw new McpException($"Error: {ex.Message}", ex);
         }
     }
 
@@ -47,7 +48,7 @@ public static partial class RefactoringTools
             .FirstOrDefault(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == fieldName));
 
         if (fieldDeclaration == null)
-            return $"Error: No field named '{fieldName}' found";
+            return ThrowMcpException($"Error: No field named '{fieldName}' found");
 
         // Add readonly modifier
         var readonlyModifier = SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword);
@@ -127,7 +128,7 @@ public static partial class RefactoringTools
     private static async Task<string> MakeFieldReadonlySingleFile(string filePath, string fieldName)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
+            return ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
@@ -137,7 +138,7 @@ public static partial class RefactoringTools
             .FirstOrDefault(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == fieldName));
 
         if (fieldDeclaration == null)
-            return $"Error: No field named '{fieldName}' found";
+            return ThrowMcpException($"Error: No field named '{fieldName}' found");
 
         // Add readonly modifier
         var readonlyModifier = SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword);

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
@@ -1,4 +1,5 @@
 using ModelContextProtocol.Server;
+using ModelContextProtocol;
 using System.ComponentModel;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -18,13 +19,13 @@ public static partial class RefactoringTools
             .OfType<ClassDeclarationSyntax>()
             .FirstOrDefault(c => c.Identifier.ValueText == sourceClass);
         if (originClass == null)
-            return $"Error: Source class '{sourceClass}' not found";
+            return ThrowMcpException($"Error: Source class '{sourceClass}' not found");
 
         var method = originClass.Members
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            return $"Error: No method named '{methodName}' found";
+            return ThrowMcpException($"Error: No method named '{methodName}' found");
 
         var targetClassDecl = syntaxRoot.DescendantNodes()
             .OfType<ClassDeclarationSyntax>()
@@ -93,7 +94,7 @@ public static partial class RefactoringTools
     private static async Task<string> MoveInstanceMethodSingleFile(string filePath, string sourceClass, string methodName, string targetClass, string accessMemberName, string accessMemberType, string? targetFilePath)
     {
         if (!File.Exists(filePath))
-            return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
+            return ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
@@ -103,13 +104,13 @@ public static partial class RefactoringTools
             .OfType<ClassDeclarationSyntax>()
             .FirstOrDefault(c => c.Identifier.ValueText == sourceClass);
         if (originClass == null)
-            return $"Error: Source class '{sourceClass}' not found";
+            return ThrowMcpException($"Error: Source class '{sourceClass}' not found");
 
         var method = originClass.Members
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            return $"Error: No method named '{methodName}' found";
+            return ThrowMcpException($"Error: No method named '{methodName}' found");
 
         var targetClassDecl = syntaxRoot.DescendantNodes()
             .OfType<ClassDeclarationSyntax>()
@@ -236,7 +237,7 @@ public static partial class RefactoringTools
         try
         {
             if (!File.Exists(filePath))
-                return $"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})";
+                return ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
 
             var sourceText = await File.ReadAllTextAsync(filePath);
             var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
@@ -251,7 +252,7 @@ public static partial class RefactoringTools
                 .FirstOrDefault(m => m.Identifier.ValueText == methodName &&
                                     m.Modifiers.Any(SyntaxKind.StaticKeyword));
             if (method == null)
-                return $"Error: Static method '{methodName}' not found";
+                return ThrowMcpException($"Error: Static method '{methodName}' not found");
 
             var targetPath = targetFilePath ?? Path.Combine(Path.GetDirectoryName(filePath)!, $"{targetClass}.cs");
             var sameFile = targetPath == filePath;
@@ -320,7 +321,7 @@ public static partial class RefactoringTools
         }
         catch (Exception ex)
         {
-            return $"Error moving static method: {ex.Message}";
+            throw new McpException($"Error moving static method: {ex.Message}", ex);
         }
     }
     [McpServerTool, Description("Move an instance method to another class (preferred for large C# file refactoring)")]
@@ -351,7 +352,7 @@ public static partial class RefactoringTools
         }
         catch (Exception ex)
         {
-            return $"Error moving instance method: {ex.Message}";
+            throw new McpException($"Error moving instance method: {ex.Message}", ex);
         }
     }
 }

--- a/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
@@ -1,4 +1,5 @@
 using ModelContextProtocol.Server;
+using ModelContextProtocol;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.Extensions.Caching.Memory;
@@ -46,5 +47,10 @@ public static partial class RefactoringTools
                int.TryParse(startParts[1], out startColumn) &&
                int.TryParse(endParts[0], out endLine) &&
                int.TryParse(endParts[1], out endColumn);
+    }
+
+    private static string ThrowMcpException(string message)
+    {
+        throw new McpException(message);
     }
 }

--- a/RefactorMCP.Tests/UnitTest1.cs
+++ b/RefactorMCP.Tests/UnitTest1.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using ModelContextProtocol;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -71,10 +72,8 @@ public class RefactoringToolsTests : IDisposable
     public async Task LoadSolution_InvalidPath_ReturnsError()
     {
         // Act
-        var result = await RefactoringTools.LoadSolution("./NonExistent.sln");
-
-        // Assert
-        Assert.Contains("Error: Solution file not found", result);
+        await Assert.ThrowsAsync<McpException>(async () =>
+            await RefactoringTools.LoadSolution("./NonExistent.sln"));
     }
 
     [Fact]
@@ -114,15 +113,12 @@ public class RefactoringToolsTests : IDisposable
         await RefactoringTools.LoadSolution(SolutionPath);
 
         // Act
-        var result = await RefactoringTools.ExtractMethod(
-            ExampleFilePath,
-            "invalid-range",
-            "TestMethod",
-            SolutionPath
-        );
-
-        // Assert
-        Assert.Contains("Error: Invalid selection range format", result);
+        await Assert.ThrowsAsync<McpException>(async () =>
+            await RefactoringTools.ExtractMethod(
+                ExampleFilePath,
+                "invalid-range",
+                "TestMethod",
+                SolutionPath));
     }
 
     [Fact]
@@ -242,14 +238,11 @@ public class RefactoringToolsTests : IDisposable
         await RefactoringTools.LoadSolution(SolutionPath);
 
         // Act
-        var result = await RefactoringTools.MakeFieldReadonly(
-            ExampleFilePath,
-            "nonexistent",
-            SolutionPath
-        );
-
-        // Assert
-        Assert.Contains("Error:", result);
+        await Assert.ThrowsAsync<McpException>(async () =>
+            await RefactoringTools.MakeFieldReadonly(
+                ExampleFilePath,
+                "nonexistent",
+                SolutionPath));
     }
 
     [Fact]
@@ -259,15 +252,12 @@ public class RefactoringToolsTests : IDisposable
         await RefactoringTools.LoadSolution(SolutionPath);
 
         // Act
-        var result = await RefactoringTools.ExtractMethod(
-            "./NonExistent.cs",
-            "1:1-2:2",
-            "TestMethod",
-            SolutionPath
-        );
-
-        // Assert
-        Assert.Contains("Error: File", result);
+        await Assert.ThrowsAsync<McpException>(async () =>
+            await RefactoringTools.ExtractMethod(
+                "./NonExistent.cs",
+                "1:1-2:2",
+                "TestMethod",
+                SolutionPath));
     }
 
     [Theory]
@@ -281,15 +271,12 @@ public class RefactoringToolsTests : IDisposable
         await RefactoringTools.LoadSolution(SolutionPath);
 
         // Act
-        var result = await RefactoringTools.ExtractMethod(
-            ExampleFilePath,
-            range,
-            methodName,
-            SolutionPath
-        );
-
-        // Assert
-        Assert.Contains("Error: Invalid selection range format", result);
+        await Assert.ThrowsAsync<McpException>(async () =>
+            await RefactoringTools.ExtractMethod(
+                ExampleFilePath,
+                range,
+                methodName,
+                SolutionPath));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- use `McpException` to signal errors in all refactoring tools
- add helper `ThrowMcpException`
- update tests to expect `McpException`
- fix example file paths

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68499641a55883278f7eccdbc31d6b70