### PR TITLE
Fix test output paths

### DIFF
--- a/RefactorMCP.Tests/ExampleValidationTests.cs
+++ b/RefactorMCP.Tests/ExampleValidationTests.cs
@@ -12,7 +12,11 @@ namespace RefactorMCP.Tests;
 public class ExampleValidationTests : IDisposable
 {
     private static readonly string SolutionPath = GetSolutionPath();
-    private const string TestOutputPath = "./RefactorMCP.Tests/TestOutput/Examples";
+    private static readonly string TestOutputPath =
+        Path.Combine(Path.GetDirectoryName(SolutionPath)!,
+            "RefactorMCP.Tests",
+            "TestOutput",
+            "Examples");
 
     public ExampleValidationTests()
     {

--- a/RefactorMCP.Tests/PerformanceTests.cs
+++ b/RefactorMCP.Tests/PerformanceTests.cs
@@ -14,7 +14,11 @@ public class PerformanceTests
 {
     private readonly ITestOutputHelper _output;
     private static readonly string SolutionPath = GetSolutionPath();
-    private const string TestOutputPath = "./RefactorMCP.Tests/TestOutput/Performance";
+    private static readonly string TestOutputPath =
+        Path.Combine(Path.GetDirectoryName(SolutionPath)!,
+            "RefactorMCP.Tests",
+            "TestOutput",
+            "Performance");
 
     public PerformanceTests(ITestOutputHelper output)
     {


### PR DESCRIPTION
## Summary
- use absolute paths in `PerformanceTests`
- use absolute paths in `ExampleValidationTests`

## Testing
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68499bcd5bc88327a489f40037329c7e