### PR TITLE
Add analysis prompt

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -451,6 +451,23 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli version
 Version: 1.0.0.0 (Build 2024-01-01 00:00:00Z)
 ```
 
+## 13. Analyze Refactoring Opportunities
+
+**Purpose**: Prompt the server to inspect a file for smells such as long methods, long parameter lists, large classes, or unused members.
+
+### Example
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli analyze-refactoring-opportunities "./RefactorMCP.Tests/ExampleCode.cs" "./RefactorMCP.sln"
+```
+
+**Expected Output**:
+```
+Suggestions:
+- Method 'UnusedHelper' appears unused -> safe-delete-method
+- Field 'deprecatedCounter' appears unused -> safe-delete-field
+```
+
 ## Range Format
 
 All refactoring commands that require selecting code use the range format:

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -67,6 +67,14 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method
   methodName
 ```
 
+### Analyze Refactoring Opportunities
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli analyze-refactoring-opportunities \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  "./RefactorMCP.sln"
+```
+Prompt the server to analyze the file and suggest possible refactorings such as extract-method or safe-delete-method.
+
 ### Safe Delete Parameter
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --cli safe-delete-parameter \

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Model Context Protocol (MCP) server providing automated refactoring tools for 
 - **Solution Mode**: Full semantic analysis with cross-project dependencies
 - **Single File Mode**: Fast refactoring for simple transformations without solution loading
 - **Comprehensive Refactoring Tools**: Extract methods, introduce variables/fields, make fields readonly, convert methods to extension methods, and more
+- **Analysis Prompt**: Inspect code for long methods, large classes, long parameter lists, unused methods or fields
 - **MCP Compatible**: Works with any MCP-compatible client
 - **Preferred for Large Files**: Invoking these tools via MCP is recommended for large code files
 
@@ -188,6 +189,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli <command> [arguments]
 - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFile]` - Move a static method to another class
 - `move-instance-method <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [solutionPath]` - Move an instance method to another class
 - `version` - Show build version and timestamp
+- `analyze-refactoring-opportunities <filePath> [solutionPath]` - Prompt for refactoring suggestions (long methods, long parameter lists, unused code)
 
 #### Quick Start Example
 

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -28,7 +28,8 @@ builder.Logging.AddConsole(consoleLogOptions =>
 builder.Services
     .AddMcpServer()
     .WithStdioServerTransport()
-    .WithToolsFromAssembly();
+    .WithToolsFromAssembly()
+    .WithPromptsFromAssembly();
 
 await builder.Build().RunAsync();
 
@@ -62,6 +63,7 @@ static async Task RunCliMode(string[] args)
         ["safe-delete-method"] = TestSafeDeleteMethod,
         ["safe-delete-parameter"] = TestSafeDeleteParameter,
         ["safe-delete-variable"] = TestSafeDeleteVariable,
+        ["analyze-refactoring-opportunities"] = TestAnalyzeRefactoringOpportunities,
         ["list-tools"] = _ => Task.FromResult(ListAvailableTools()),
         ["version"] = _ => Task.FromResult(ShowVersionInfo())
     };
@@ -97,6 +99,7 @@ static void ShowCliHelp()
     foreach (var tool in toolsList)
         Console.WriteLine($"  {tool}");
     Console.WriteLine("  list-tools - List all available refactoring tools");
+    Console.WriteLine("  analyze-refactoring-opportunities <filePath> [solutionPath] - Analyze code for potential refactorings");
 
     Console.WriteLine();
     Console.WriteLine("Examples:");
@@ -105,6 +108,7 @@ static void ShowCliHelp()
     Console.WriteLine("  --cli extract-method ./MyFile.cs \"10:5-15:20\" \"ExtractedMethod\" ./MySolution.sln");
     Console.WriteLine("  --cli introduce-field ./MyFile.cs \"12:10-12:25\" \"_myField\" \"private\"");
     Console.WriteLine("  --cli make-field-readonly ./MyFile.cs 15");
+    Console.WriteLine("  --cli analyze-refactoring-opportunities ./MyFile.cs ./MySolution.sln");
     Console.WriteLine("  --cli version");
     Console.WriteLine();
     Console.WriteLine("Range format: \"startLine:startColumn-endLine:endColumn\" (1-based)");
@@ -278,6 +282,17 @@ static async Task<string> TestSafeDeleteVariable(string[] args)
     return await RefactoringTools.SafeDeleteVariable(filePath, range, solutionPath);
 }
 
+static async Task<string> TestAnalyzeRefactoringOpportunities(string[] args)
+{
+    if (args.Length < 3)
+        return "Error: Missing arguments. Usage: --cli analyze-refactoring-opportunities <filePath> [solutionPath]";
+
+    var filePath = args[2];
+    var solutionPath = args.Length > 3 ? args[3] : null;
+
+    return await RefactoringTools.AnalyzeRefactoringOpportunities(filePath, solutionPath);
+}
+
 static async Task<string> TestConvertToStaticWithParameters(string[] args)
 {
     if (args.Length < 4)
@@ -361,6 +376,7 @@ static async Task<string> TestTransformSetterToInit(string[] args)
 }
 
 [McpServerToolType]
+[McpServerPromptType]
 public static partial class RefactoringTools
 {
 }

--- a/RefactorMCP.ConsoleApp/Tools/AnalyzeRefactoringOpportunities.cs
+++ b/RefactorMCP.ConsoleApp/Tools/AnalyzeRefactoringOpportunities.cs
@@ -1,0 +1,152 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using System.ComponentModel;
+
+public static partial class RefactoringTools
+{
+    [McpServerPrompt, Description("Analyze a C# file for refactoring opportunities like long methods or unused code")]
+    public static async Task<string> AnalyzeRefactoringOpportunities(
+        [Description("Path to the C# file")] string filePath,
+        [Description("Path to the solution file (.sln) - optional for cross-file analysis")] string? solutionPath = null)
+    {
+        try
+        {
+            SyntaxTree syntaxTree;
+            SemanticModel? model = null;
+            Solution? solution = null;
+            Document? document = null;
+
+            if (solutionPath != null)
+            {
+                solution = await GetOrLoadSolution(solutionPath);
+                document = GetDocumentByPath(solution, filePath);
+                if (document != null)
+                {
+                    syntaxTree = await document.GetSyntaxTreeAsync() ?? CSharpSyntaxTree.ParseText(await File.ReadAllTextAsync(filePath));
+                    model = await document.GetSemanticModelAsync();
+                }
+                else
+                {
+                    syntaxTree = CSharpSyntaxTree.ParseText(await File.ReadAllTextAsync(filePath));
+                    model = null;
+                }
+            }
+            else
+            {
+                syntaxTree = CSharpSyntaxTree.ParseText(await File.ReadAllTextAsync(filePath));
+            }
+
+            var root = await syntaxTree.GetRootAsync();
+            var suggestions = new List<string>();
+
+            foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
+            {
+                var span = syntaxTree.GetLineSpan(method.Span);
+                var lines = span.EndLinePosition.Line - span.StartLinePosition.Line + 1;
+                if (lines > 30)
+                    suggestions.Add($"Method '{method.Identifier}' is {lines} lines long -> consider extract-method");
+
+                var parameters = method.ParameterList.Parameters.Count;
+                if (parameters >= 5)
+                    suggestions.Add($"Method '{method.Identifier}' has {parameters} parameters -> consider introducing parameter object");
+
+                if (!method.Modifiers.Any(SyntaxKind.StaticKeyword) && model != null)
+                {
+                    var accessesInstance = method.DescendantNodes()
+                        .Any(n => n is ThisExpressionSyntax ||
+                                  n is MemberAccessExpressionSyntax ma &&
+                                      model.GetSymbolInfo(ma).Symbol is { IsStatic: false });
+                    if (!accessesInstance)
+                        suggestions.Add($"Method '{method.Identifier}' does not access instance state -> convert-to-static-with-parameters");
+                }
+            }
+
+            foreach (var cls in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
+            {
+                var members = cls.Members.Count;
+                var span = syntaxTree.GetLineSpan(cls.Span);
+                var lines = span.EndLinePosition.Line - span.StartLinePosition.Line + 1;
+                if (members > 15 || lines > 300)
+                    suggestions.Add($"Class '{cls.Identifier}' is large ({members} members) -> consider splitting or move-method");
+            }
+
+            if (model != null)
+            {
+                var methods = root.DescendantNodes().OfType<MethodDeclarationSyntax>();
+                foreach (var method in methods)
+                {
+                    if (method.Modifiers.Any(SyntaxKind.PublicKeyword))
+                        continue;
+
+                    var symbol = model.GetDeclaredSymbol(method) as IMethodSymbol;
+                    if (symbol != null)
+                    {
+                        var refs = await SymbolFinder.FindReferencesAsync(symbol, solution!);
+                        if (refs.All(r => r.Locations.All(l => l.Location.SourceSpan == method.Identifier.Span)))
+                            suggestions.Add($"Method '{method.Identifier}' appears unused -> safe-delete-method");
+                    }
+                }
+
+                var fields = root.DescendantNodes().OfType<FieldDeclarationSyntax>();
+                foreach (var field in fields)
+                {
+                    foreach (var variable in field.Declaration.Variables)
+                    {
+                        var symbol = model.GetDeclaredSymbol(variable) as IFieldSymbol;
+                        if (symbol != null)
+                        {
+                            var refs = await SymbolFinder.FindReferencesAsync(symbol, solution!);
+                            if (refs.All(r => r.Locations.All(l => l.Location.SourceSpan == variable.Identifier.Span)))
+                                suggestions.Add($"Field '{variable.Identifier}' appears unused -> safe-delete-field");
+                        }
+                    }
+                }
+            }
+            else
+            {
+                // Simple unused code detection in single-file mode
+                var methods = root.DescendantNodes().OfType<MethodDeclarationSyntax>();
+                foreach (var method in methods)
+                {
+                    if (method.Modifiers.Any(SyntaxKind.PublicKeyword))
+                        continue;
+
+                    var identifier = method.Identifier.ValueText;
+                    var invocations = root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                        .Select(inv => inv.Expression)
+                        .OfType<IdentifierNameSyntax>()
+                        .Count(id => id.Identifier.ValueText == identifier);
+                    if (invocations == 0)
+                        suggestions.Add($"Method '{identifier}' appears unused -> safe-delete-method");
+                }
+
+                // Simple unused field detection in single-file mode
+                var fields = root.DescendantNodes().OfType<FieldDeclarationSyntax>();
+                foreach (var field in fields)
+                {
+                    foreach (var variable in field.Declaration.Variables)
+                    {
+                        var identifier = variable.Identifier.ValueText;
+                        var references = root.DescendantNodes().OfType<IdentifierNameSyntax>()
+                            .Count(id => id.Identifier.ValueText == identifier);
+                        if (references <= 1)
+                            suggestions.Add($"Field '{identifier}' appears unused -> safe-delete-field");
+                    }
+                }
+            }
+
+            if (suggestions.Count == 0)
+                return "No obvious refactoring opportunities detected";
+
+            return "Suggestions:\n" + string.Join("\n", suggestions);
+        }
+        catch (Exception ex)
+        {
+            throw new McpException($"Error analyzing file: {ex.Message}", ex);
+        }
+    }
+}

--- a/RefactorMCP.Tests/AnalyzeRefactoringOpportunitiesTests.cs
+++ b/RefactorMCP.Tests/AnalyzeRefactoringOpportunitiesTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class AnalyzeRefactoringOpportunitiesTests : IDisposable
+{
+    private static readonly string SolutionPath = GetSolutionPath();
+    private static readonly string ExampleFilePath = Path.Combine(Path.GetDirectoryName(SolutionPath)!, "RefactorMCP.Tests", "ExampleCode.cs");
+    private readonly string _originalDir = Directory.GetCurrentDirectory();
+
+    public void Dispose()
+    {
+        Directory.SetCurrentDirectory(_originalDir);
+    }
+
+    private static string GetSolutionPath()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        var dir = new DirectoryInfo(currentDir);
+        while (dir != null)
+        {
+            var sln = Path.Combine(dir.FullName, "RefactorMCP.sln");
+            if (File.Exists(sln)) return sln;
+            dir = dir.Parent;
+        }
+        return "./RefactorMCP.sln";
+    }
+
+    [Fact]
+    public async Task AnalyzeExampleCode_ReturnsSuggestions()
+    {
+        await RefactoringTools.LoadSolution(SolutionPath);
+        var result = await RefactoringTools.AnalyzeRefactoringOpportunities(ExampleFilePath, SolutionPath);
+        Assert.Contains("safe-delete-field", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("safe-delete-method", result, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/RefactorMCP.Tests/PerformanceTests.cs
+++ b/RefactorMCP.Tests/PerformanceTests.cs
@@ -63,7 +63,7 @@ public class PerformanceTests
     public async Task ExtractMethod_LargeFile_CompletesInReasonableTime()
     {
         // Arrange
-        var testFile = Path.Combine(TestOutputPath, "LargeFileTest.cs");
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "LargeFileTest.cs"));
         await CreateLargeTestFile(testFile);
         await RefactoringTools.LoadSolution(SolutionPath);
 
@@ -89,7 +89,7 @@ public class PerformanceTests
     public async Task MultipleRefactorings_Sequential_AllComplete()
     {
         // Arrange
-        var testFile = Path.Combine(TestOutputPath, "MultipleRefactoringsTest.cs");
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MultipleRefactoringsTest.cs"));
         await CreateTestFileForMultipleRefactorings(testFile);
         await RefactoringTools.LoadSolution(SolutionPath);
 
@@ -157,7 +157,7 @@ public class PerformanceTests
     public async Task MemoryUsage_MultipleOperations_DoesNotLeak()
     {
         // Arrange
-        var testFile = Path.Combine(TestOutputPath, "MemoryTest.cs");
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MemoryTest.cs"));
         await CreateTestFileForMultipleRefactorings(testFile);
         await RefactoringTools.LoadSolution(SolutionPath);
 


### PR DESCRIPTION
## Summary
- convert `AnalyzeRefactoringOpportunities` to a prompt
- register prompts in the server and CLI
- document new prompt usage across docs
- detect long parameter lists and unused methods
- fix test directories and maintain working directory between tests

## Testing
- `dotnet format -v diag`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68499df175208327b8100ac051dc73de