### PR TITLE
Add property-based move method test

### DIFF
--- a/RefactorMCP.Tests/RoslynTransformationTests.cs
+++ b/RefactorMCP.Tests/RoslynTransformationTests.cs
@@ -316,6 +316,32 @@ class ValidationService
     }
 
     [Fact]
+    public void MoveInstanceMethodInSource_PropertyTargetExists()
+    {
+        var input = @"class TaskProcessor
+{
+    void RunTask()
+    {
+    }
+}
+class TaskRunner
+{
+}";
+        var expected = @"class TaskProcessor
+{
+    private TaskRunner Runner { get; set; }
+}
+class TaskRunner
+{
+    public void RunTask()
+    {
+    }
+}";
+        var output = RefactoringTools.MoveInstanceMethodInSource(input, "TaskProcessor", "RunTask", "TaskRunner", "Runner", "property");
+        Assert.Equal(expected, output.Trim());
+    }
+
+    [Fact]
     public void MoveStaticMethodInSource_MovesMethod()
     {
         var input = @"class UtilityHelper


### PR DESCRIPTION
## Summary
- add `MoveInstanceMethodInSource_PropertyTargetExists` test verifying `property` access member type

## Testing
- `dotnet format --no-restore --verbosity diag`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6849ce4bccac832790e54c89adba583c