### PR TITLE
Fix ExtractMethodInSource test range

### DIFF
--- a/RefactorMCP.Tests/RoslynTransformationTests.cs
+++ b/RefactorMCP.Tests/RoslynTransformationTests.cs
@@ -169,7 +169,7 @@ public static class StringProcessorExtensions
         Assert.Equal(expected, output.Trim());
     }
 
-    [Fact(Skip = "ExtractMethod implementation needs debugging for this test case")]
+    [Fact]
     public void ExtractMethodInSource_CreatesMethod()
     {
         var input = @"class MessageHandler
@@ -193,7 +193,7 @@ public static class StringProcessorExtensions
     }
 }
 ";
-        var output = RefactoringTools.ExtractMethodInSource(input, "5:9-5:46", "DisplayProcessingMessage");
+        var output = RefactoringTools.ExtractMethodInSource(input, "5:9-5:49", "DisplayProcessingMessage");
         Assert.Equal(expected, output);
     }
 


### PR DESCRIPTION
## Summary
- fix selection range for ExtractMethodInSource
- enable the test for single-file Extract Method

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6849ce4850e48327978f49082d894308