### PR TITLE
Add MoveInstanceMethod property new class test

### DIFF
--- a/RefactorMCP.Tests/RoslynTransformationTests.cs
+++ b/RefactorMCP.Tests/RoslynTransformationTests.cs
@@ -444,6 +444,35 @@ public class Logger
     }
 
     [Fact]
+    public void MoveInstanceMethodInSource_CreatesTargetClassWithProperty()
+    {
+        var input = @"class Calculator
+{
+    void Compute()
+    {
+    }
+}";
+        var expected = @"class Calculator
+{
+    private Logger Logger { get; set; }
+
+    void Compute()
+    {
+        Logger.Compute();
+    }
+}
+
+public class Logger
+{
+    public void Compute()
+    {
+    }
+}";
+        var output = RefactoringTools.MoveInstanceMethodInSource(input, "Calculator", "Compute", "Logger", "Logger", "property");
+        Assert.Equal(expected, output.Trim());
+    }
+
+    [Fact]
     public void MoveStaticMethodInSource_MovesMethod()
     {
         var input = @"class UtilityHelper


### PR DESCRIPTION
## Summary
- cover moving instance method to a new class using a property in RoslynTransformationTests

## Testing
- `dotnet format --no-restore`
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6849e98e06348327a7c0d02f0c1d923f