### PR TITLE
Refactor tools into independent classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@ This repository implements a Model Context Protocol (MCP) server that exposes **
 
 ## Creating a New Agent
 
-1. Add a new static method in the `RefactorMCP.ConsoleApp/Tools/` directory as a partial class extension of `RefactoringTools`.
-2. Decorate the method with `[McpServerTool]` and include a `[Description]` for every parameter so clients can display helpful text.
+1. Add a new static class in the `RefactorMCP.ConsoleApp/Tools/` directory and decorate it with `[McpServerToolType]`.
+2. Inside that class, add a static method decorated with `[McpServerTool]` and include a `[Description]` for every parameter so clients can display helpful text.
 3. Keep method names concise and use `CamelCase`.
 4. For complex logic, extract helper functions rather than writing large methods.
 

--- a/README.md
+++ b/README.md
@@ -437,10 +437,11 @@ The examples use the sample code in [RefactorMCP.Tests/ExampleCode.cs](./Refacto
 
 ### Adding New Refactorings
 
-1. Add method to `RefactoringTools` class with `[McpServerTool]` attribute
-2. Implement using Roslyn SyntaxFactory and SyntaxNode manipulation
-3. Add test command handler in `RunTestMode` switch statement
-4. Update documentation and examples
+1. Create a new static class in `RefactorMCP.ConsoleApp/Tools/` and decorate it with `[McpServerToolType]`
+2. Add your refactoring method to that class with the `[McpServerTool]` attribute
+3. Implement using Roslyn SyntaxFactory and SyntaxNode manipulation
+4. Add a test command handler in `RunTestMode` switch statement
+5. Update documentation and examples
 
 ### Testing
 

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -117,8 +117,10 @@ static void ShowCliHelp()
 
 static string ListAvailableTools()
 {
-    var toolNames = typeof(RefactoringTools)
-        .GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+    var toolNames = System.Reflection.Assembly.GetExecutingAssembly()
+        .GetTypes()
+        .Where(t => t.GetCustomAttributes(typeof(McpServerToolTypeAttribute), false).Length > 0)
+        .SelectMany(t => t.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static))
         .Where(m => m.GetCustomAttributes(typeof(McpServerToolAttribute), false).Length > 0)
         .Select(m => ToKebabCase(m.Name))
         .OrderBy(n => n)
@@ -147,7 +149,7 @@ static async Task<string> TestLoadSolution(string[] args)
         return "Error: Missing solution path. Usage: --cli load-solution <solutionPath>";
 
     var solutionPath = args[2];
-    return await RefactoringTools.LoadSolution(solutionPath);
+    return await LoadSolutionTool.LoadSolution(solutionPath);
 }
 
 static async Task<string> TestExtractMethod(string[] args)
@@ -160,7 +162,7 @@ static async Task<string> TestExtractMethod(string[] args)
     var methodName = args[4];
     var solutionPath = args.Length > 5 ? args[5] : null;
 
-    return await RefactoringTools.ExtractMethod(filePath, range, methodName, solutionPath);
+    return await ExtractMethodTool.ExtractMethod(filePath, range, methodName, solutionPath);
 }
 
 static async Task<string> TestIntroduceField(string[] args)
@@ -174,7 +176,7 @@ static async Task<string> TestIntroduceField(string[] args)
     var accessModifier = args.Length > 5 ? args[5] : "private";
     var solutionPath = args.Length > 6 ? args[6] : null;
 
-    return await RefactoringTools.IntroduceField(filePath, range, fieldName, accessModifier, solutionPath);
+    return await IntroduceFieldTool.IntroduceField(filePath, range, fieldName, accessModifier, solutionPath);
 }
 
 static async Task<string> TestIntroduceVariable(string[] args)
@@ -187,7 +189,7 @@ static async Task<string> TestIntroduceVariable(string[] args)
     var variableName = args[4];
     var solutionPath = args.Length > 5 ? args[5] : null;
 
-    return await RefactoringTools.IntroduceVariable(filePath, range, variableName, solutionPath);
+    return await IntroduceVariableTool.IntroduceVariable(filePath, range, variableName, solutionPath);
 }
 
 static async Task<string> TestMakeFieldReadonly(string[] args)
@@ -199,7 +201,7 @@ static async Task<string> TestMakeFieldReadonly(string[] args)
     var fieldName = args[3];
     var solutionPath = args.Length > 4 ? args[4] : null;
 
-    return await RefactoringTools.MakeFieldReadonly(filePath, fieldName, solutionPath);
+    return await MakeFieldReadonlyTool.MakeFieldReadonly(filePath, fieldName, solutionPath);
 }
 
 static string TestUnloadSolution(string[] args)
@@ -208,17 +210,17 @@ static string TestUnloadSolution(string[] args)
         return "Error: Missing solution path. Usage: --cli unload-solution <solutionPath>";
 
     var solutionPath = args[2];
-    return RefactoringTools.UnloadSolution(solutionPath);
+    return UnloadSolutionTool.UnloadSolution(solutionPath);
 }
 
 static string ClearCacheCommand()
 {
-    return RefactoringTools.ClearSolutionCache();
+    return UnloadSolutionTool.ClearSolutionCache();
 }
 
 static string ShowVersionInfo()
 {
-    return RefactoringTools.Version();
+    return VersionTool.Version();
 }
 
 static async Task<string> TestConvertToExtensionMethod(string[] args)
@@ -230,7 +232,7 @@ static async Task<string> TestConvertToExtensionMethod(string[] args)
     var methodName = args[3];
     var solutionPath = args.Length > 4 ? args[4] : null;
 
-    return await RefactoringTools.ConvertToExtensionMethod(filePath, methodName, null, solutionPath);
+    return await ConvertToExtensionMethodTool.ConvertToExtensionMethod(filePath, methodName, null, solutionPath);
 }
 
 static async Task<string> TestSafeDeleteField(string[] args)
@@ -242,7 +244,7 @@ static async Task<string> TestSafeDeleteField(string[] args)
     var fieldName = args[3];
     var solutionPath = args.Length > 4 ? args[4] : null;
 
-    return await RefactoringTools.SafeDeleteField(filePath, fieldName, solutionPath);
+    return await SafeDeleteTool.SafeDeleteField(filePath, fieldName, solutionPath);
 }
 
 static async Task<string> TestSafeDeleteMethod(string[] args)
@@ -254,7 +256,7 @@ static async Task<string> TestSafeDeleteMethod(string[] args)
     var methodName = args[3];
     var solutionPath = args.Length > 4 ? args[4] : null;
 
-    return await RefactoringTools.SafeDeleteMethod(filePath, methodName, solutionPath);
+    return await SafeDeleteTool.SafeDeleteMethod(filePath, methodName, solutionPath);
 }
 
 static async Task<string> TestSafeDeleteParameter(string[] args)
@@ -267,7 +269,7 @@ static async Task<string> TestSafeDeleteParameter(string[] args)
     var parameterName = args[4];
     var solutionPath = args.Length > 5 ? args[5] : null;
 
-    return await RefactoringTools.SafeDeleteParameter(filePath, methodName, parameterName, solutionPath);
+    return await SafeDeleteTool.SafeDeleteParameter(filePath, methodName, parameterName, solutionPath);
 }
 
 static async Task<string> TestSafeDeleteVariable(string[] args)
@@ -279,7 +281,7 @@ static async Task<string> TestSafeDeleteVariable(string[] args)
     var range = args[3];
     var solutionPath = args.Length > 4 ? args[4] : null;
 
-    return await RefactoringTools.SafeDeleteVariable(filePath, range, solutionPath);
+    return await SafeDeleteTool.SafeDeleteVariable(filePath, range, solutionPath);
 }
 
 static async Task<string> TestAnalyzeRefactoringOpportunities(string[] args)
@@ -290,7 +292,7 @@ static async Task<string> TestAnalyzeRefactoringOpportunities(string[] args)
     var filePath = args[2];
     var solutionPath = args.Length > 3 ? args[3] : null;
 
-    return await RefactoringTools.AnalyzeRefactoringOpportunities(filePath, solutionPath);
+    return await AnalyzeRefactoringOpportunitiesTool.AnalyzeRefactoringOpportunities(filePath, solutionPath);
 }
 
 static async Task<string> TestConvertToStaticWithParameters(string[] args)
@@ -302,7 +304,7 @@ static async Task<string> TestConvertToStaticWithParameters(string[] args)
     var methodName = args[3];
     var solutionPath = args.Length > 4 ? args[4] : null;
 
-    return await RefactoringTools.ConvertToStaticWithParameters(filePath, methodName, solutionPath);
+    return await ConvertToStaticWithParametersTool.ConvertToStaticWithParameters(filePath, methodName, solutionPath);
 }
 
 static async Task<string> TestConvertToStaticWithInstance(string[] args)
@@ -315,7 +317,7 @@ static async Task<string> TestConvertToStaticWithInstance(string[] args)
     var instanceParam = args.Length > 4 ? args[4] : "instance";
     var solutionPath = args.Length > 5 ? args[5] : null;
 
-    return await RefactoringTools.ConvertToStaticWithInstance(filePath, methodName, instanceParam, solutionPath);
+    return await ConvertToStaticWithInstanceTool.ConvertToStaticWithInstance(filePath, methodName, instanceParam, solutionPath);
 }
 
 static async Task<string> TestIntroduceParameter(string[] args)
@@ -329,7 +331,7 @@ static async Task<string> TestIntroduceParameter(string[] args)
     var paramName = args[5];
     var solutionPath = args.Length > 6 ? args[6] : null;
 
-    return await RefactoringTools.IntroduceParameter(filePath, methodName, range, paramName, solutionPath);
+    return await IntroduceParameterTool.IntroduceParameter(filePath, methodName, range, paramName, solutionPath);
 }
 
 static async Task<string> TestMoveStaticMethod(string[] args)
@@ -343,7 +345,7 @@ static async Task<string> TestMoveStaticMethod(string[] args)
     var targetClass = args[5];
     var targetFilePath = args.Length > 6 ? args[6] : null;
 
-    return await RefactoringTools.MoveStaticMethod(solutionPath, filePath, methodName, targetClass, targetFilePath);
+    return await MoveMethodsTool.MoveStaticMethod(solutionPath, filePath, methodName, targetClass, targetFilePath);
 }
 
 static async Task<string> TestMoveInstanceMethod(string[] args)
@@ -360,7 +362,7 @@ static async Task<string> TestMoveInstanceMethod(string[] args)
     var solutionPath = args.Length > 8 ? args[8] : null;
     var targetFile = args.Length > 9 ? args[9] : null;
 
-    return await RefactoringTools.MoveInstanceMethod(filePath, sourceClass, methodName, targetClass, accessMember, memberType, solutionPath, targetFile);
+    return await MoveMethodsTool.MoveInstanceMethod(filePath, sourceClass, methodName, targetClass, accessMember, memberType, solutionPath, targetFile);
 }
 
 static async Task<string> TestTransformSetterToInit(string[] args)
@@ -372,11 +374,6 @@ static async Task<string> TestTransformSetterToInit(string[] args)
     var propertyName = args[3];
     var solutionPath = args.Length > 4 ? args[4] : null;
 
-    return await RefactoringTools.TransformSetterToInit(filePath, propertyName, solutionPath);
+    return await TransformSetterToInitTool.TransformSetterToInit(filePath, propertyName, solutionPath);
 }
 
-[McpServerToolType]
-[McpServerPromptType]
-public static partial class RefactoringTools
-{
-}

--- a/RefactorMCP.ConsoleApp/Tools/AnalyzeRefactoringOpportunities.cs
+++ b/RefactorMCP.ConsoleApp/Tools/AnalyzeRefactoringOpportunities.cs
@@ -6,7 +6,8 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using System.ComponentModel;
 
-public static partial class RefactoringTools
+[McpServerToolType, McpServerPromptType]
+public static class AnalyzeRefactoringOpportunitiesTool
 {
     [McpServerPrompt, Description("Analyze a C# file for refactoring opportunities like long methods or unused code")]
     public static async Task<string> AnalyzeRefactoringOpportunities(
@@ -20,8 +21,8 @@ public static partial class RefactoringTools
             Solution? solution = null;
             Document? document = null;
 
-            solution = await GetOrLoadSolution(solutionPath);
-            document = GetDocumentByPath(solution, filePath);
+            solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
+            document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
             if (document != null)
             {
                 syntaxTree = await document.GetSyntaxTreeAsync() ?? CSharpSyntaxTree.ParseText(await File.ReadAllTextAsync(filePath));

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
@@ -8,7 +8,8 @@ using Microsoft.CodeAnalysis.Formatting;
 using System.Linq;
 using System.Collections.Generic;
 
-public static partial class RefactoringTools
+[McpServerToolType]
+public static class ConvertToExtensionMethodTool
 {
     [McpServerTool, Description("Convert an instance method to an extension method in a static class")]
     public static async Task<string> ConvertToExtensionMethod(
@@ -19,8 +20,8 @@ public static partial class RefactoringTools
     {
         try
         {
-            var solution = await GetOrLoadSolution(solutionPath);
-            var document = GetDocumentByPath(solution, filePath);
+            var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
+            var document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
             if (document != null)
                 return await ConvertToExtensionMethodWithSolution(document, methodName, extensionClass);
 
@@ -41,12 +42,12 @@ public static partial class RefactoringTools
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            return ThrowMcpException($"Error: No method named '{methodName}' found");
+            return RefactoringHelpers.ThrowMcpException($"Error: No method named '{methodName}' found");
 
         var semanticModel = await document.GetSemanticModelAsync();
         var classDecl = method.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
         if (classDecl == null)
-            return ThrowMcpException($"Error: Method '{methodName}' is not inside a class");
+            return RefactoringHelpers.ThrowMcpException($"Error: Method '{methodName}' is not inside a class");
 
         var className = classDecl.Identifier.ValueText;
         var extClassName = extensionClass ?? className + "Extensions";
@@ -139,7 +140,7 @@ public static partial class RefactoringTools
     private static async Task<string> ConvertToExtensionMethodSingleFile(string filePath, string methodName, string? extensionClass)
     {
         if (!File.Exists(filePath))
-            return ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
+            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
 
         var sourceText = await File.ReadAllTextAsync(filePath);
         var newText = ConvertToExtensionMethodInSource(sourceText, methodName, extensionClass);
@@ -157,11 +158,11 @@ public static partial class RefactoringTools
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            return ThrowMcpException($"Error: No method named '{methodName}' found");
+            return RefactoringHelpers.ThrowMcpException($"Error: No method named '{methodName}' found");
 
         var classDecl = method.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
         if (classDecl == null)
-            return ThrowMcpException($"Error: Method '{methodName}' is not inside a class");
+            return RefactoringHelpers.ThrowMcpException($"Error: Method '{methodName}' is not inside a class");
 
         var className = classDecl.Identifier.ValueText;
         var extClassName = extensionClass ?? className + "Extensions";
@@ -249,7 +250,7 @@ public static partial class RefactoringTools
             }
         }
 
-        var formatted = Formatter.Format(newRoot, SharedWorkspace);
+        var formatted = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
         return formatted.ToFullString();
     }
 }

--- a/RefactorMCP.ConsoleApp/Tools/LoadSolution.cs
+++ b/RefactorMCP.ConsoleApp/Tools/LoadSolution.cs
@@ -7,7 +7,8 @@ using System.ComponentModel;
 using System.IO;
 
 
-public static partial class RefactoringTools
+[McpServerToolType]
+public static class LoadSolutionTool
 {
     [McpServerTool, Description("Load a solution file for refactoring operations and set the current directory to the solution directory")]
     public static async Task<string> LoadSolution(
@@ -17,11 +18,11 @@ public static partial class RefactoringTools
         {
             if (!File.Exists(solutionPath))
             {
-                return ThrowMcpException($"Error: Solution file not found at {solutionPath}");
+                return RefactoringHelpers.ThrowMcpException($"Error: Solution file not found at {solutionPath}");
             }
             Directory.SetCurrentDirectory(Path.GetDirectoryName(solutionPath)!);
 
-            if (_solutionCache.TryGetValue(solutionPath, out Solution? cached))
+            if (RefactoringHelpers.SolutionCache.TryGetValue(solutionPath, out Solution? cached))
             {
                 var cachedProjects = cached.Projects.Select(p => p.Name).ToList();
                 return $"Successfully loaded solution '{Path.GetFileName(solutionPath)}' with {cachedProjects.Count} projects: {string.Join(", ", cachedProjects)}";
@@ -30,7 +31,7 @@ public static partial class RefactoringTools
             using var workspace = MSBuildWorkspace.Create();
             var solution = await workspace.OpenSolutionAsync(solutionPath);
 
-            _solutionCache.Set(solutionPath, solution);
+            RefactoringHelpers.SolutionCache.Set(solutionPath, solution);
 
             var projects = solution.Projects.Select(p => p.Name).ToList();
             return $"Successfully loaded solution '{Path.GetFileName(solutionPath)}' with {projects.Count} projects: {string.Join(", ", projects)}";

--- a/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
@@ -7,31 +7,31 @@ using System;
 
 
 
-public static partial class RefactoringTools
+internal static class RefactoringHelpers
 {
-    private static MemoryCache _solutionCache = new(new MemoryCacheOptions());
+    internal static MemoryCache SolutionCache = new(new MemoryCacheOptions());
 
     private static readonly Lazy<AdhocWorkspace> _workspace =
         new(() => new AdhocWorkspace());
 
     internal static AdhocWorkspace SharedWorkspace => _workspace.Value;
 
-    private static async Task<Solution> GetOrLoadSolution(string solutionPath)
+    internal static async Task<Solution> GetOrLoadSolution(string solutionPath)
     {
 
-        if (_solutionCache.TryGetValue(solutionPath, out Solution? cachedSolution))
+        if (SolutionCache.TryGetValue(solutionPath, out Solution? cachedSolution))
         {
             Directory.SetCurrentDirectory(Path.GetDirectoryName(solutionPath)!);
             return cachedSolution!;
         }
         using var workspace = MSBuildWorkspace.Create();
         var solution = await workspace.OpenSolutionAsync(solutionPath);
-        _solutionCache.Set(solutionPath, solution);
+        SolutionCache.Set(solutionPath, solution);
         Directory.SetCurrentDirectory(Path.GetDirectoryName(solutionPath)!);
         return solution;
     }
 
-    private static Document? GetDocumentByPath(Solution solution, string filePath)
+    internal static Document? GetDocumentByPath(Solution solution, string filePath)
     {
         var normalizedPath = Path.GetFullPath(filePath);
         return solution.Projects
@@ -39,7 +39,7 @@ public static partial class RefactoringTools
             .FirstOrDefault(d => Path.GetFullPath(d.FilePath ?? "") == normalizedPath);
     }
 
-    private static bool TryParseRange(string range, out int startLine, out int startColumn, out int endLine, out int endColumn)
+    internal static bool TryParseRange(string range, out int startLine, out int startColumn, out int endLine, out int endColumn)
     {
         startLine = startColumn = endLine = endColumn = 0;
         var parts = range.Split('-');
@@ -53,7 +53,7 @@ public static partial class RefactoringTools
                int.TryParse(endParts[1], out endColumn);
     }
 
-    private static string ThrowMcpException(string message)
+    internal static string ThrowMcpException(string message)
     {
         throw new McpException(message);
     }

--- a/RefactorMCP.ConsoleApp/Tools/UnloadSolution.cs
+++ b/RefactorMCP.ConsoleApp/Tools/UnloadSolution.cs
@@ -3,15 +3,16 @@ using Microsoft.Extensions.Caching.Memory;
 using System.ComponentModel;
 using System.IO;
 
-public static partial class RefactoringTools
+[McpServerToolType]
+public static class UnloadSolutionTool
 {
     [McpServerTool, Description("Unload a solution and remove it from the cache")]
     public static string UnloadSolution(
         [Description("Path to the solution file (.sln)")] string solutionPath)
     {
-        if (_solutionCache.TryGetValue(solutionPath, out _))
+        if (RefactoringHelpers.SolutionCache.TryGetValue(solutionPath, out _))
         {
-            _solutionCache.Remove(solutionPath);
+            RefactoringHelpers.SolutionCache.Remove(solutionPath);
             return $"Unloaded solution '{Path.GetFileName(solutionPath)}' from cache";
         }
 
@@ -21,8 +22,8 @@ public static partial class RefactoringTools
     [McpServerTool, Description("Clear all cached solutions")]
     public static string ClearSolutionCache()
     {
-        _solutionCache.Dispose();
-        _solutionCache = new MemoryCache(new MemoryCacheOptions());
+        RefactoringHelpers.SolutionCache.Dispose();
+        RefactoringHelpers.SolutionCache = new MemoryCache(new MemoryCacheOptions());
         return "Cleared all cached solutions";
     }
 }

--- a/RefactorMCP.ConsoleApp/Tools/Version.cs
+++ b/RefactorMCP.ConsoleApp/Tools/Version.cs
@@ -3,7 +3,8 @@ using System.ComponentModel;
 using System.IO;
 using System.Reflection;
 
-public static partial class RefactoringTools
+[McpServerToolType]
+public static class VersionTool
 {
     [McpServerTool, Description("Show the current version and build timestamp")]
     public static string Version()

--- a/RefactorMCP.Tests/AnalyzeRefactoringOpportunitiesTests.cs
+++ b/RefactorMCP.Tests/AnalyzeRefactoringOpportunitiesTests.cs
@@ -32,8 +32,8 @@ public class AnalyzeRefactoringOpportunitiesTests : IDisposable
     [Fact]
     public async Task AnalyzeExampleCode_ReturnsSuggestions()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
-        var result = await RefactoringTools.AnalyzeRefactoringOpportunities(SolutionPath, ExampleFilePath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var result = await AnalyzeRefactoringOpportunitiesTool.AnalyzeRefactoringOpportunities(SolutionPath, ExampleFilePath);
         Assert.Contains("safe-delete-field", result, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("safe-delete-method", result, StringComparison.OrdinalIgnoreCase);
     }

--- a/RefactorMCP.Tests/ExampleValidationTests.cs
+++ b/RefactorMCP.Tests/ExampleValidationTests.cs
@@ -58,10 +58,10 @@ public class ExampleValidationTests : IDisposable
         // Arrange - Create the exact code from our documentation
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "ExtractMethodExample.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForExtractMethod());
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
         // Act - Use the exact command from EXAMPLES.md
-        var result = await RefactoringTools.ExtractMethod(
+        var result = await ExtractMethodTool.ExtractMethod(
             SolutionPath,
             testFile,
             "22:9-25:10", // From documentation: validation block
@@ -80,10 +80,10 @@ public class ExampleValidationTests : IDisposable
         // Arrange - Create the exact code from our documentation
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "IntroduceFieldExample.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForIntroduceField());
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
         // Act - Use the exact command from EXAMPLES.md
-        var result = await RefactoringTools.IntroduceField(
+        var result = await IntroduceFieldTool.IntroduceField(
             SolutionPath,
             testFile,
             "36:20-36:56", // From documentation: Sum() / Count expression
@@ -103,10 +103,10 @@ public class ExampleValidationTests : IDisposable
         // Arrange - Create the exact code from our documentation
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "IntroduceVariableExample.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForIntroduceVariable());
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
         // Act - Use the exact command from EXAMPLES.md
-        var result = await RefactoringTools.IntroduceVariable(
+        var result = await IntroduceVariableTool.IntroduceVariable(
             SolutionPath,
             testFile,
             "42:50-42:63", // From documentation: value * 2 + 10 expression
@@ -125,10 +125,10 @@ public class ExampleValidationTests : IDisposable
         // Arrange - Create the exact code from our documentation
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MakeFieldReadonlyExample.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForMakeFieldReadonly());
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
         // Act - Use the exact command from EXAMPLES.md
-        var result = await RefactoringTools.MakeFieldReadonly(
+        var result = await MakeFieldReadonlyTool.MakeFieldReadonly(
             SolutionPath,
             testFile,
             "format" // From documentation: line with format field
@@ -145,9 +145,9 @@ public class ExampleValidationTests : IDisposable
     {
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "SafeDeleteParameter.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForSafeDelete());
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
-        var result = await RefactoringTools.SafeDeleteParameter(
+        var result = await SafeDeleteTool.SafeDeleteParameter(
             SolutionPath,
             testFile,
             "Multiply",
@@ -165,10 +165,10 @@ public class ExampleValidationTests : IDisposable
         // Test the quick reference example
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "QuickRefExtractMethod.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForExtractMethod());
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
         // Use the exact command from QUICK_REFERENCE.md
-        var result = await RefactoringTools.ExtractMethod(
+        var result = await ExtractMethodTool.ExtractMethod(
             SolutionPath,
             testFile,
             "22:9-25:10",
@@ -185,10 +185,10 @@ public class ExampleValidationTests : IDisposable
         // Test the quick reference example
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "QuickRefIntroduceField.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForIntroduceField());
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
         // Use the exact command from QUICK_REFERENCE.md
-        var result = await RefactoringTools.IntroduceField(
+        var result = await IntroduceFieldTool.IntroduceField(
             SolutionPath,
             testFile,
             "36:20-36:56",
@@ -211,9 +211,9 @@ public class ExampleValidationTests : IDisposable
         // Test that all documented access modifiers work
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, $"AccessModifier_{accessModifier}.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForIntroduceField());
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
-        var result = await RefactoringTools.IntroduceField(
+        var result = await IntroduceFieldTool.IntroduceField(
             SolutionPath,
             testFile,
             "36:20-36:56",
@@ -241,12 +241,12 @@ public int Calculate(int a, int b)
 }
 """;
         await CreateTestFile(testFile, code);
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
         // The documentation says to select "if (a < 0 || b < 0)" on line 3
         // with range "3:5-3:25"
         await Assert.ThrowsAsync<McpException>(async () =>
-            await RefactoringTools.ExtractMethod(
+            await ExtractMethodTool.ExtractMethod(
                 SolutionPath,
                 testFile,
                 "3:5-3:25", // From documentation example
@@ -256,18 +256,18 @@ public int Calculate(int a, int b)
     [Fact]
     public async Task ErrorHandling_DocumentedErrorCases_ReturnExpectedMessages()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
         // Test documented error cases
         await Assert.ThrowsAsync<McpException>(async () =>
-            await RefactoringTools.ExtractMethod(
+            await ExtractMethodTool.ExtractMethod(
                 SolutionPath,
                 "./NonExistent.cs",
                 "1:1-2:2",
                 "TestMethod"));
 
         await Assert.ThrowsAsync<McpException>(async () =>
-            await RefactoringTools.ExtractMethod(
+            await ExtractMethodTool.ExtractMethod(
                 SolutionPath,
                 Path.Combine(Path.GetDirectoryName(SolutionPath)!, "RefactorMCP.Tests", "ExampleCode.cs"),
                 "invalid-range",

--- a/RefactorMCP.Tests/PerformanceTests.cs
+++ b/RefactorMCP.Tests/PerformanceTests.cs
@@ -53,7 +53,7 @@ public class PerformanceTests
         var stopwatch = Stopwatch.StartNew();
 
         // Act
-        var result = await RefactoringTools.LoadSolution(SolutionPath);
+        var result = await LoadSolutionTool.LoadSolution(SolutionPath);
 
         // Assert
         stopwatch.Stop();
@@ -69,12 +69,12 @@ public class PerformanceTests
         // Arrange
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "LargeFileTest.cs"));
         await CreateLargeTestFile(testFile);
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
         var stopwatch = Stopwatch.StartNew();
 
         // Act
-        var result = await RefactoringTools.ExtractMethod(
+        var result = await ExtractMethodTool.ExtractMethod(
             SolutionPath,
             testFile,
             "10:9-13:10", // Extract a validation block
@@ -95,19 +95,19 @@ public class PerformanceTests
         // Arrange
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MultipleRefactoringsTest.cs"));
         await CreateTestFileForMultipleRefactorings(testFile);
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
         var totalStopwatch = Stopwatch.StartNew();
 
         // Act - Perform multiple refactorings in sequence
-        var extractResult = await RefactoringTools.ExtractMethod(
+        var extractResult = await ExtractMethodTool.ExtractMethod(
             SolutionPath,
             testFile,
             "8:9-11:10",
             "ValidateInputs"
         );
 
-        var fieldResult = await RefactoringTools.IntroduceField(
+        var fieldResult = await IntroduceFieldTool.IntroduceField(
             SolutionPath,
             testFile,
             "15:16-15:40",
@@ -115,7 +115,7 @@ public class PerformanceTests
             "private"
         );
 
-        var variableResult = await RefactoringTools.IntroduceVariable(
+        var variableResult = await IntroduceVariableTool.IntroduceVariable(
             SolutionPath,
             testFile,
             "19:20-19:35",
@@ -137,12 +137,12 @@ public class PerformanceTests
     {
         // Arrange & Act - First load
         var firstStopwatch = Stopwatch.StartNew();
-        var firstResult = await RefactoringTools.LoadSolution(SolutionPath);
+        var firstResult = await LoadSolutionTool.LoadSolution(SolutionPath);
         firstStopwatch.Stop();
 
         // Act - Second load (should use cache)
         var secondStopwatch = Stopwatch.StartNew();
-        var secondResult = await RefactoringTools.LoadSolution(SolutionPath);
+        var secondResult = await LoadSolutionTool.LoadSolution(SolutionPath);
         secondStopwatch.Stop();
 
         // Assert
@@ -163,7 +163,7 @@ public class PerformanceTests
         // Arrange
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MemoryTest.cs"));
         await CreateTestFileForMultipleRefactorings(testFile);
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
 
         var initialMemory = GC.GetTotalMemory(true);
 
@@ -173,7 +173,7 @@ public class PerformanceTests
             var testFileCopy = testFile.Replace(".cs", $"_{i}.cs");
             await File.WriteAllTextAsync(testFileCopy, await File.ReadAllTextAsync(testFile));
 
-            await RefactoringTools.ExtractMethod(
+            await ExtractMethodTool.ExtractMethod(
                 SolutionPath,
                 testFileCopy,
                 "8:9-11:10",

--- a/RefactorMCP.Tests/RoslynTransformationTests.cs
+++ b/RefactorMCP.Tests/RoslynTransformationTests.cs
@@ -24,7 +24,7 @@ public class RoslynTransformationTests
     }
 }
 ";
-        var output = RefactoringTools.IntroduceVariableInSource(input, "5:27-5:31", "result");
+        var output = IntroduceVariableTool.IntroduceVariableInSource(input, "5:27-5:31", "result");
         Assert.Equal(expected, output);
     }
 
@@ -47,7 +47,7 @@ public class RoslynTransformationTests
     }
 }
 ";
-        var output = RefactoringTools.IntroduceParameterInSource(input, "AddNumbers", "5:16-5:42", "calculationMode");
+        var output = IntroduceParameterTool.IntroduceParameterInSource(input, "AddNumbers", "5:16-5:42", "calculationMode");
         Assert.Equal(expected, output);
     }
 
@@ -73,7 +73,7 @@ public class RoslynTransformationTests
     }
 }
 ";
-        var output = RefactoringTools.MakeFieldReadonlyInSource(input, "formatPattern");
+        var output = MakeFieldReadonlyTool.MakeFieldReadonlyInSource(input, "formatPattern");
         Assert.Equal(expected, output);
     }
 
@@ -90,7 +90,7 @@ public class RoslynTransformationTests
     public string UserName { get; init; } = ""DefaultUser"";
 }
 ";
-        var output = RefactoringTools.TransformSetterToInitInSource(input, "UserName");
+        var output = TransformSetterToInitTool.TransformSetterToInitInSource(input, "UserName");
         Assert.Equal(expected, output);
     }
 
@@ -117,7 +117,7 @@ public static class StringProcessorExtensions
     {
     }
 }";
-        var output = RefactoringTools.ConvertToExtensionMethodInSource(input, "FormatText", null);
+        var output = ConvertToExtensionMethodTool.ConvertToExtensionMethodInSource(input, "FormatText", null);
         Assert.Equal(expected, output.Trim());
     }
 
@@ -148,7 +148,7 @@ public static class StringProcessorExtensions
     {
     }
 }";
-        var output = RefactoringTools.ConvertToExtensionMethodInSource(input, "FormatText", "StringProcessorExtensions");
+        var output = ConvertToExtensionMethodTool.ConvertToExtensionMethodInSource(input, "FormatText", "StringProcessorExtensions");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -172,7 +172,7 @@ public static class StringProcessorExtensions
         return instance.dataCount;
     }
 }";
-        var output = RefactoringTools.ConvertToStaticWithInstanceInSource(input, "GetDataCount", "instance");
+        var output = ConvertToStaticWithInstanceTool.ConvertToStaticWithInstanceInSource(input, "GetDataCount", "instance");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -196,7 +196,7 @@ public static class StringProcessorExtensions
         return multiplier;
     }
 }";
-        var output = RefactoringTools.ConvertToStaticWithParametersInSource(input, "MultiplyValue");
+        var output = ConvertToStaticWithParametersTool.ConvertToStaticWithParametersInSource(input, "MultiplyValue");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -224,7 +224,7 @@ public static class StringProcessorExtensions
     }
 }
 ";
-        var output = RefactoringTools.ExtractMethodInSource(input, "5:9-5:49", "DisplayProcessingMessage");
+        var output = ExtractMethodTool.ExtractMethodInSource(input, "5:9-5:49", "DisplayProcessingMessage");
         Assert.Equal(expected, output);
     }
 
@@ -247,7 +247,7 @@ public static class StringProcessorExtensions
     }
 }
 ";
-        var output = RefactoringTools.IntroduceFieldInSource(input, "5:16-5:23", "calculationResult", "private");
+        var output = IntroduceFieldTool.IntroduceFieldInSource(input, "5:16-5:23", "calculationResult", "private");
         Assert.Equal(expected, output);
     }
 
@@ -261,7 +261,7 @@ public static class StringProcessorExtensions
         var expected = @"class ConfigurationManager
 {
 }";
-        var output = RefactoringTools.SafeDeleteFieldInSource(input, "configurationFlag");
+        var output = SafeDeleteTool.SafeDeleteFieldInSource(input, "configurationFlag");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -277,7 +277,7 @@ public static class StringProcessorExtensions
         var expected = @"class ServiceManager
 {
 }";
-        var output = RefactoringTools.SafeDeleteMethodInSource(input, "UnusedMethod");
+        var output = SafeDeleteTool.SafeDeleteMethodInSource(input, "UnusedMethod");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -296,7 +296,7 @@ public static class StringProcessorExtensions
     {
     }
 }";
-        var output = RefactoringTools.SafeDeleteParameterInSource(input, "ProcessData", "unusedValue");
+        var output = SafeDeleteTool.SafeDeleteParameterInSource(input, "ProcessData", "unusedValue");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -316,7 +316,7 @@ public static class StringProcessorExtensions
     {
     }
 }";
-        var output = RefactoringTools.SafeDeleteVariableInSource(input, "5:9-5:30");
+        var output = SafeDeleteTool.SafeDeleteVariableInSource(input, "5:9-5:30");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -347,7 +347,7 @@ class ValidationService
     {
     }
 }";
-        var output = RefactoringTools.MoveInstanceMethodInSource(input, "DocumentProcessor", "ValidateDocument", "ValidationService", "validationService", "field");
+        var output = MoveMethodsTool.MoveInstanceMethodInSource(input, "DocumentProcessor", "ValidateDocument", "ValidationService", "validationService", "field");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -378,7 +378,7 @@ class TaskRunner
     {
     }
 }";
-        var output = RefactoringTools.MoveInstanceMethodInSource(input, "TaskProcessor", "RunTask", "TaskRunner", "Runner", "property");
+        var output = MoveMethodsTool.MoveInstanceMethodInSource(input, "TaskProcessor", "RunTask", "TaskRunner", "Runner", "property");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -407,7 +407,7 @@ public class Logger
     {
     }
 }";
-        var output = RefactoringTools.MoveInstanceMethodInSource(input, "Calculator", "Compute", "Logger", "logger", "field");
+        var output = MoveMethodsTool.MoveInstanceMethodInSource(input, "Calculator", "Compute", "Logger", "logger", "field");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -434,7 +434,7 @@ public class StringUtilities
     {
     }
 }";
-        var output = RefactoringTools.MoveStaticMethodInSource(input, "FormatString", "StringUtilities");
+        var output = MoveMethodsTool.MoveStaticMethodInSource(input, "FormatString", "StringUtilities");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -465,7 +465,7 @@ class StringUtilities
     {
     }
 }";
-        var output = RefactoringTools.MoveStaticMethodInSource(input, "FormatString", "StringUtilities");
+        var output = MoveMethodsTool.MoveStaticMethodInSource(input, "FormatString", "StringUtilities");
         Assert.Equal(expected, output.Trim());
     }
 
@@ -503,7 +503,7 @@ class MathUtilities
         return calculator.numbers.Sum() / (double)calculator.numbers.Count;
     }
 }";
-        var output = RefactoringTools.MoveInstanceMethodInSource(input, "Calculator", "GetAverage", "MathUtilities", "mathUtilities", "field");
+        var output = MoveMethodsTool.MoveInstanceMethodInSource(input, "Calculator", "GetAverage", "MathUtilities", "mathUtilities", "field");
         Assert.Equal(expected, output.Trim());
     }
 }

--- a/RefactorMCP.Tests/Split/ConvertToExtensionMethodTests.cs
+++ b/RefactorMCP.Tests/Split/ConvertToExtensionMethodTests.cs
@@ -10,11 +10,11 @@ public class ConvertToExtensionMethodTests : TestBase
     [Fact]
     public async Task ConvertToExtensionMethod_ReturnsSuccess()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "ConvertToExtension.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForConvertToExtension());
 
-        var result = await RefactoringTools.ConvertToExtensionMethod(
+        var result = await ConvertToExtensionMethodTool.ConvertToExtensionMethod(
             SolutionPath,
             testFile,
             "GetFormattedNumber",

--- a/RefactorMCP.Tests/Split/ConvertToStaticWithInstanceTests.cs
+++ b/RefactorMCP.Tests/Split/ConvertToStaticWithInstanceTests.cs
@@ -10,11 +10,11 @@ public class ConvertToStaticWithInstanceTests : TestBase
     [Fact]
     public async Task ConvertToStaticWithInstance_ReturnsSuccess()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "ConvertToStaticInstance.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForConvertToStaticInstance());
 
-        var result = await RefactoringTools.ConvertToStaticWithInstance(
+        var result = await ConvertToStaticWithInstanceTool.ConvertToStaticWithInstance(
             SolutionPath,
             testFile,
             "GetFormattedNumber",

--- a/RefactorMCP.Tests/Split/ExtractMethodTests.cs
+++ b/RefactorMCP.Tests/Split/ExtractMethodTests.cs
@@ -10,11 +10,11 @@ public class ExtractMethodTests : TestBase
     [Fact]
     public async Task ExtractMethod_ValidSelection_ReturnsSuccess()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "ExtractMethodTest.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForExtractMethod());
 
-        var result = await RefactoringTools.ExtractMethod(
+        var result = await ExtractMethodTool.ExtractMethod(
             SolutionPath,
             testFile,
             "7:9-10:10",
@@ -28,9 +28,9 @@ public class ExtractMethodTests : TestBase
     [Fact]
     public async Task ExtractMethod_InvalidRange_ReturnsError()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         await Assert.ThrowsAsync<McpException>(async () =>
-            await RefactoringTools.ExtractMethod(
+            await ExtractMethodTool.ExtractMethod(
                 SolutionPath,
                 ExampleFilePath,
                 "invalid-range",
@@ -40,9 +40,9 @@ public class ExtractMethodTests : TestBase
     [Fact]
     public async Task RefactoringTools_FileNotInSolution_ReturnsError()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         await Assert.ThrowsAsync<McpException>(async () =>
-            await RefactoringTools.ExtractMethod(
+            await ExtractMethodTool.ExtractMethod(
                 SolutionPath,
                 "./NonExistent.cs",
                 "1:1-2:2",
@@ -56,9 +56,9 @@ public class ExtractMethodTests : TestBase
     [InlineData("1:1-2", "TestMethod")]
     public async Task ExtractMethod_InvalidRangeFormats_ReturnsError(string range, string methodName)
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         await Assert.ThrowsAsync<McpException>(async () =>
-            await RefactoringTools.ExtractMethod(
+            await ExtractMethodTool.ExtractMethod(
                 SolutionPath,
                 ExampleFilePath,
                 range,

--- a/RefactorMCP.Tests/Split/IntroduceFieldTests.cs
+++ b/RefactorMCP.Tests/Split/IntroduceFieldTests.cs
@@ -10,11 +10,11 @@ public class IntroduceFieldTests : TestBase
     [Fact]
     public async Task IntroduceField_ValidExpression_ReturnsSuccess()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "IntroduceFieldTest.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForIntroduceField());
 
-        var result = await RefactoringTools.IntroduceField(
+        var result = await IntroduceFieldTool.IntroduceField(
             SolutionPath,
             testFile,
             "4:16-4:58",
@@ -29,11 +29,11 @@ public class IntroduceFieldTests : TestBase
     [Fact]
     public async Task IntroduceField_WithPublicModifier_ReturnsSuccess()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "IntroduceFieldPublicTest.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForIntroduceField());
 
-        var result = await RefactoringTools.IntroduceField(
+        var result = await IntroduceFieldTool.IntroduceField(
             SolutionPath,
             testFile,
             "4:16-4:58",
@@ -48,7 +48,7 @@ public class IntroduceFieldTests : TestBase
     [Fact]
     public async Task IntroduceField_DifferentAccessModifiers_ReturnsCorrectModifier()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "AccessModifierTest.cs");
 
         var accessModifiers = new[] { "private", "public", "protected", "internal" };
@@ -57,7 +57,7 @@ public class IntroduceFieldTests : TestBase
             var modifierTestFile = testFile.Replace(".cs", $"_{modifier}.cs");
             await TestUtilities.CreateTestFile(modifierTestFile, TestUtilities.GetSampleCodeForIntroduceField());
 
-            var result = await RefactoringTools.IntroduceField(
+            var result = await IntroduceFieldTool.IntroduceField(
                 SolutionPath,
                 modifierTestFile,
                 "4:16-4:58",

--- a/RefactorMCP.Tests/Split/IntroduceVariableTests.cs
+++ b/RefactorMCP.Tests/Split/IntroduceVariableTests.cs
@@ -10,11 +10,11 @@ public class IntroduceVariableTests : TestBase
     [Fact]
     public async Task IntroduceVariable_ValidExpression_ReturnsSuccess()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "IntroduceVariableTest.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForIntroduceVariable());
 
-        var result = await RefactoringTools.IntroduceVariable(
+        var result = await IntroduceVariableTool.IntroduceVariable(
             SolutionPath,
             testFile,
             "42:50-42:63",

--- a/RefactorMCP.Tests/Split/LoadSolutionTests.cs
+++ b/RefactorMCP.Tests/Split/LoadSolutionTests.cs
@@ -9,7 +9,7 @@ public class LoadSolutionTests : TestBase
     [Fact]
     public async Task LoadSolution_ValidPath_ReturnsSuccess()
     {
-        var result = await RefactoringTools.LoadSolution(SolutionPath);
+        var result = await LoadSolutionTool.LoadSolution(SolutionPath);
         Assert.Contains("Successfully loaded solution", result);
         Assert.Contains("RefactorMCP.ConsoleApp", result);
         Assert.Contains("RefactorMCP.Tests", result);
@@ -18,8 +18,8 @@ public class LoadSolutionTests : TestBase
     [Fact]
     public async Task UnloadSolution_RemovesCachedSolution()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
-        var result = RefactoringTools.UnloadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var result = UnloadSolutionTool.UnloadSolution(SolutionPath);
         Assert.Contains("Unloaded solution", result);
     }
 
@@ -27,13 +27,13 @@ public class LoadSolutionTests : TestBase
     public async Task LoadSolution_InvalidPath_ReturnsError()
     {
         await Assert.ThrowsAsync<McpException>(async () =>
-            await RefactoringTools.LoadSolution("./NonExistent.sln"));
+            await LoadSolutionTool.LoadSolution("./NonExistent.sln"));
     }
 
     [Fact]
     public void Version_ReturnsInfo()
     {
-        var result = RefactoringTools.Version();
+        var result = VersionTool.Version();
         Assert.Contains("Version:", result);
         Assert.Contains("Build", result);
     }

--- a/RefactorMCP.Tests/Split/MakeFieldReadonlyTests.cs
+++ b/RefactorMCP.Tests/Split/MakeFieldReadonlyTests.cs
@@ -10,11 +10,11 @@ public class MakeFieldReadonlyTests : TestBase
     [Fact]
     public async Task MakeFieldReadonly_FieldWithInitializer_ReturnsSuccess()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "MakeFieldReadonlyTest.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForMakeFieldReadonly());
 
-        var result = await RefactoringTools.MakeFieldReadonly(
+        var result = await MakeFieldReadonlyTool.MakeFieldReadonly(
             SolutionPath,
             testFile,
             "format");
@@ -27,11 +27,11 @@ public class MakeFieldReadonlyTests : TestBase
     [Fact]
     public async Task MakeFieldReadonly_FieldWithoutInitializer_ReturnsSuccess()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "MakeFieldReadonlyNoInitTest.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForMakeFieldReadonlyNoInit());
 
-        var result = await RefactoringTools.MakeFieldReadonly(
+        var result = await MakeFieldReadonlyTool.MakeFieldReadonly(
             SolutionPath,
             testFile,
             "description");
@@ -44,9 +44,9 @@ public class MakeFieldReadonlyTests : TestBase
     [Fact]
     public async Task MakeFieldReadonly_InvalidLine_ReturnsError()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         await Assert.ThrowsAsync<McpException>(async () =>
-            await RefactoringTools.MakeFieldReadonly(
+            await MakeFieldReadonlyTool.MakeFieldReadonly(
                 SolutionPath,
                 ExampleFilePath,
                 "nonexistent"));

--- a/RefactorMCP.Tests/Split/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Split/MoveInstanceMethodTests.cs
@@ -13,11 +13,11 @@ public class MoveInstanceMethodTests : TestBase
     [Fact]
     public async Task MoveInstanceMethod_ReturnsSuccess()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "MoveInstanceMethod.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForMoveInstanceMethod());
 
-        var result = await RefactoringTools.MoveInstanceMethod(
+        var result = await MoveMethodsTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "Calculator",

--- a/RefactorMCP.Tests/Split/MoveStaticMethodTests.cs
+++ b/RefactorMCP.Tests/Split/MoveStaticMethodTests.cs
@@ -13,11 +13,11 @@ public class MoveStaticMethodTests : TestBase
     [Fact]
     public async Task MoveStaticMethod_ReturnsSuccess()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "MoveStaticMethod.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForMoveStaticMethod());
 
-        var result = await RefactoringTools.MoveStaticMethod(
+        var result = await MoveMethodsTool.MoveStaticMethod(
             SolutionPath,
             testFile,
             "FormatCurrency",
@@ -32,11 +32,11 @@ public class MoveStaticMethodTests : TestBase
     [Fact]
     public async Task MoveStaticMethod_AddsUsingsAndCompiles()
     {
-        await RefactoringTools.LoadSolution(SolutionPath);
+        await LoadSolutionTool.LoadSolution(SolutionPath);
         var testFile = Path.Combine(TestOutputPath, "MoveStaticWithUsings.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForMoveStaticMethodWithUsings());
 
-        var result = await RefactoringTools.MoveStaticMethod(
+        var result = await MoveMethodsTool.MoveStaticMethod(
             SolutionPath,
             testFile,
             "PrintList",


### PR DESCRIPTION
## Summary
- convert refactoring tools from a single partial class into individual classes
- update usage docs to explain new class-based tools
- revise agent guidelines for new structure
- adjust CLI and tests to reflect new tool classes

## Testing
- `dotnet format`
- `dotnet test RefactorMCP.sln`

------
https://chatgpt.com/codex/tasks/task_e_684a01fe83848327bfa9c63c4d54f0b9