### PR TITLE
Add Inline Method refactoring tool

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -331,7 +331,42 @@ public class MathUtilities
 }
 ```
 
-## 10. Safe Delete Parameter
+## 10. Inline Method
+
+**Purpose**: Replace method calls with the method body and remove the original method.
+
+### Example
+**Before** (in `InlineSample.cs`):
+```csharp
+private void Helper()
+{
+    Console.WriteLine("Hi");
+}
+
+public void Call()
+{
+    Helper();
+    Console.WriteLine("Done");
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli inline-method \
+  "./RefactorMCP.sln" \
+  "./InlineSample.cs" \
+  Helper
+```
+
+**After**:
+```csharp
+public void Call()
+{
+    Console.WriteLine("Hi");
+    Console.WriteLine("Done");
+}
+```
+## 11. Safe Delete Parameter
 
 **Purpose**: Remove an unused method parameter and update call sites.
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -121,6 +121,14 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-static-method \
   "./optional/target.cs"
 ```
 
+### Inline Method
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli inline-method \
+  "./RefactorMCP.sln" \
+  "./path/to/file.cs" \
+  methodName
+```
+
 ### Move Instance Method
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \

--- a/README.md
+++ b/README.md
@@ -402,6 +402,37 @@ public class MathUtilities
 }
 ```
 
+### 8. Inline Method
+
+**Before**:
+```csharp
+private void Helper()
+{
+    Console.WriteLine("Hi");
+}
+
+public void Call()
+{
+    Helper();
+    Console.WriteLine("Done");
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli inline-method \
+  "./RefactorMCP.sln" "./MyFile.cs" Helper
+```
+
+**After**:
+```csharp
+public void Call()
+{
+    Console.WriteLine("Hi");
+    Console.WriteLine("Done");
+}
+```
+
 ## Complete Examples
 
 See [EXAMPLES.md](./EXAMPLES.md) for comprehensive examples of all refactoring tools, including:

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -57,6 +57,7 @@ static async Task RunCliMode(string[] args)
         ["convert-to-static-with-instance"] = TestConvertToStaticWithInstance,
         ["introduce-parameter"] = TestIntroduceParameter,
         ["move-static-method"] = TestMoveStaticMethod,
+        ["inline-method"] = TestInlineMethod,
         ["move-instance-method"] = TestMoveInstanceMethod,
         ["transform-setter-to-init"] = TestTransformSetterToInit,
         ["safe-delete-field"] = TestSafeDeleteField,
@@ -377,3 +378,15 @@ static async Task<string> TestTransformSetterToInit(string[] args)
     return await TransformSetterToInitTool.TransformSetterToInit(filePath, propertyName, solutionPath);
 }
 
+
+static async Task<string> TestInlineMethod(string[] args)
+{
+    if (args.Length < 5)
+        return "Error: Missing arguments. Usage: --cli inline-method <solutionPath> <filePath> <methodName>";
+
+    var solutionPath = args[2];
+    var filePath = args[3];
+    var methodName = args[4];
+
+    return await InlineMethodTool.InlineMethod(solutionPath, filePath, methodName);
+}

--- a/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
@@ -1,0 +1,158 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using System.ComponentModel;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.FindSymbols;
+using System.Linq;
+using System.IO;
+using System.Collections.Generic;
+
+[McpServerToolType]
+public static class InlineMethodTool
+{
+    private class ParameterRewriter : CSharpSyntaxRewriter
+    {
+        private readonly Dictionary<string, ExpressionSyntax> _map;
+        public ParameterRewriter(Dictionary<string, ExpressionSyntax> map)
+        {
+            _map = map;
+        }
+        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            if (_map.TryGetValue(node.Identifier.ValueText, out var expr))
+                return expr;
+            return base.VisitIdentifierName(node);
+        }
+    }
+
+    private static SyntaxNode InlineInvocation(MethodDeclarationSyntax method, InvocationExpressionSyntax invocation)
+    {
+        var argMap = method.ParameterList.Parameters
+            .Zip(invocation.ArgumentList.Arguments, (p, a) => new { p, a })
+            .ToDictionary(x => x.p.Identifier.ValueText, x => x.a.Expression);
+
+        var rewriter = new ParameterRewriter(argMap);
+        var statements = method.Body!.Statements.Select(s => (StatementSyntax)rewriter.Visit(s)!);
+        var stmt = invocation.FirstAncestorOrSelf<ExpressionStatementSyntax>();
+        if (stmt != null && method.ReturnType is PredefinedTypeSyntax pts && pts.Keyword.IsKind(SyntaxKind.VoidKeyword))
+        {
+            return SyntaxFactory.Block(statements);
+        }
+        return invocation;
+    }
+
+    private static async Task InlineReferences(MethodDeclarationSyntax method, Solution solution, ISymbol methodSymbol)
+    {
+        var refs = await SymbolFinder.FindReferencesAsync(methodSymbol, solution);
+        foreach (var loc in refs.SelectMany(r => r.Locations))
+        {
+            if (!loc.Location.IsInSource) continue;
+            var refDoc = solution.GetDocument(loc.Location.SourceTree)!;
+            var refRoot = await refDoc.GetSyntaxRootAsync();
+            var node = refRoot!.FindNode(loc.Location.SourceSpan);
+            var invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
+            if (invocation == null) continue;
+            var inlineBlock = InlineInvocation(method, invocation);
+            SyntaxNode newRefRoot;
+            if (inlineBlock is BlockSyntax block && invocation.Parent is ExpressionStatementSyntax stmt)
+            {
+                newRefRoot = refRoot.ReplaceNode(stmt, block.Statements);
+            }
+            else
+            {
+                continue;
+            }
+            var formatted = Formatter.Format(newRefRoot, refDoc.Project.Solution.Workspace);
+            var newDoc = refDoc.WithSyntaxRoot(formatted);
+            var text = await newDoc.GetTextAsync();
+            await File.WriteAllTextAsync(refDoc.FilePath!, text.ToString());
+        }
+    }
+
+    private static async Task<string> InlineMethodWithSolution(Document document, string methodName)
+    {
+        var root = await document.GetSyntaxRootAsync();
+        var semanticModel = await document.GetSemanticModelAsync();
+
+        var method = root!.DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            return RefactoringHelpers.ThrowMcpException($"Error: Method '{methodName}' not found");
+
+        var symbol = semanticModel!.GetDeclaredSymbol(method)!;
+        await InlineReferences(method, document.Project.Solution, symbol);
+
+        var newRoot = (await document.GetSyntaxRootAsync())!.RemoveNode(method, SyntaxRemoveOptions.KeepNoTrivia);
+        var formattedRoot = Formatter.Format(newRoot, document.Project.Solution.Workspace);
+        var newDocument = document.WithSyntaxRoot(formattedRoot);
+        var newText = await newDocument.GetTextAsync();
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+
+        return $"Successfully inlined method '{methodName}' in {document.FilePath} (solution mode)";
+    }
+
+    private static async Task<string> InlineMethodSingleFile(string filePath, string methodName)
+    {
+        if (!File.Exists(filePath))
+            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
+
+        var sourceText = await File.ReadAllTextAsync(filePath);
+        var newText = InlineMethodInSource(sourceText, methodName);
+        await File.WriteAllTextAsync(filePath, newText);
+        return $"Successfully inlined method '{methodName}' in {filePath} (single file mode)";
+    }
+
+    public static string InlineMethodInSource(string sourceText, string methodName)
+    {
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => m.Identifier.ValueText == methodName && m.ParameterList.Parameters.Count == 0);
+        if (method == null)
+            return RefactoringHelpers.ThrowMcpException($"Error: Method '{methodName}' not found or has parameters");
+
+        var bodyText = string.Join("\n", method.Body!.Statements.Select(s => s.ToFullString()));
+
+        var invocationNodes = root.DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .Where(i => i.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == methodName)
+            .ToList();
+
+        foreach (var inv in invocationNodes)
+        {
+            var stmt = inv.FirstAncestorOrSelf<ExpressionStatementSyntax>();
+            if (stmt != null)
+            {
+                var newStmt = SyntaxFactory.ParseStatement(bodyText);
+                root = root.ReplaceNode(stmt, newStmt);
+            }
+        }
+
+        root = root.RemoveNode(method, SyntaxRemoveOptions.KeepNoTrivia);
+        var formatted = Formatter.Format(root, RefactoringHelpers.SharedWorkspace);
+        return formatted.ToFullString();
+    }
+
+    [McpServerTool, Description("Inline a method and remove its declaration (preferred for large C# file refactoring)")]
+    public static async Task<string> InlineMethod(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        [Description("Path to the C# file containing the method")] string filePath,
+        [Description("Name of the method to inline")] string methodName)
+    {
+        try
+        {
+            var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
+            var document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
+            if (document != null)
+                return await InlineMethodWithSolution(document, methodName);
+
+            return await InlineMethodSingleFile(filePath, methodName);
+        }
+        catch (Exception ex)
+        {
+            throw new McpException($"Error inlining method: {ex.Message}", ex);
+        }
+    }
+}

--- a/RefactorMCP.Tests/Split/TestUtilities.cs
+++ b/RefactorMCP.Tests/Split/TestUtilities.cs
@@ -138,5 +138,22 @@ namespace Test.Domain
     }
 }
 """;
+    public static string GetSampleCodeForInlineMethod() => """
+using System;
+
+public class InlineSample
+{
+    private void Helper()
+    {
+        Console.WriteLine("Hi");
+    }
+
+    public void Call()
+    {
+        Helper();
+        Console.WriteLine("Done");
+    }
+}
+""";
 }
 

--- a/RefactorMCP.Tests/TEST_SUMMARY.md
+++ b/RefactorMCP.Tests/TEST_SUMMARY.md
@@ -10,7 +10,7 @@ The RefactorMCP test suite is organized into three main test classes:
 - ✅ `LoadSolution_InvalidPath_ReturnsError` - Tests error handling for missing files
 - 🚧 `ExtractMethod_ValidSelection_ReturnsSuccess` - Tests method extraction
 - 🚧 `IntroduceField_ValidExpression_ReturnsSuccess` - Tests field introduction
-- 🚧 `IntroduceVariable_ValidExpression_ReturnsSuccess` - Tests variable introduction  
+- 🚧 `IntroduceVariable_ValidExpression_ReturnsSuccess` - Tests variable introduction
 - 🚧 `MakeFieldReadonly_FieldWithInitializer_ReturnsSuccess` - Tests readonly conversion
 
 ### 2. ExampleValidationTests (`ExampleValidationTests.cs`)


### PR DESCRIPTION
## Summary
- implement `InlineMethod` tool
- add CLI hook for the new tool
- document usage in README, EXAMPLES and QUICK_REFERENCE
- provide sample code in TestUtilities
- update test summary

## Testing
- `dotnet test`
- `dotnet format --no-restore` *(no output)*

------
https://chatgpt.com/codex/tasks/task_e_684a0d7174088327a715e357a806e49e