### PR TITLE
Add cleanup usings tool

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -396,6 +396,38 @@ public int Multiply(int x, int y)
 }
 ```
 
+## 12. Cleanup Usings
+
+**Purpose**: Remove unused using directives from a file.
+
+### Example
+**Before** (in `CleanupSample.cs`):
+```csharp
+using System;
+using System.Text;
+
+public class CleanupSample
+{
+    public void Say() => Console.WriteLine("Hi");
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli cleanup-usings \
+  "./CleanupSample.cs" "./RefactorMCP.sln"
+```
+
+**After**:
+```csharp
+using System;
+
+public class CleanupSample
+{
+    public void Say() => Console.WriteLine("Hi");
+}
+```
+
 ## 6. Load Solution (Utility Command)
 
 **Purpose**: Load and validate a solution file before performing refactorings.

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -129,6 +129,13 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli inline-method \
   methodName
 ```
 
+### Cleanup Usings
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli cleanup-usings \
+  "./path/to/file.cs" \
+  "./RefactorMCP.sln"
+```
+
 ### Move Instance Method
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli <command> [arguments]
 - `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
 - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFile]` - Move a static method to another class
 - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [targetFile]` - Move an instance method to another class
+- `cleanup-usings <filePath> [solutionPath]` - Remove unused using directives
 - `version` - Show build version and timestamp
 - `analyze-refactoring-opportunities <solutionPath> <filePath>` - Prompt for refactoring suggestions (long methods, long parameter lists, unused code)
 
@@ -430,6 +431,35 @@ public void Call()
 {
     Console.WriteLine("Hi");
     Console.WriteLine("Done");
+}
+```
+
+### 9. Cleanup Usings
+
+**Before**:
+```csharp
+using System;
+using System.Text;
+
+public class Sample
+{
+    public void Say() => Console.WriteLine("Hi");
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli cleanup-usings \
+  "./RefactorMCP.Tests/ExampleCode.cs" "./RefactorMCP.sln"
+```
+
+**After**:
+```csharp
+using System;
+
+public class Sample
+{
+    public void Say() => Console.WriteLine("Hi");
 }
 ```
 

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -64,6 +64,7 @@ static async Task RunCliMode(string[] args)
         ["safe-delete-method"] = TestSafeDeleteMethod,
         ["safe-delete-parameter"] = TestSafeDeleteParameter,
         ["safe-delete-variable"] = TestSafeDeleteVariable,
+        ["cleanup-usings"] = TestCleanupUsings,
         ["analyze-refactoring-opportunities"] = TestAnalyzeRefactoringOpportunities,
         ["list-tools"] = _ => Task.FromResult(ListAvailableTools()),
         ["version"] = _ => Task.FromResult(ShowVersionInfo())
@@ -109,6 +110,7 @@ static void ShowCliHelp()
     Console.WriteLine("  --cli extract-method ./MyFile.cs \"10:5-15:20\" \"ExtractedMethod\" ./MySolution.sln");
     Console.WriteLine("  --cli introduce-field ./MyFile.cs \"12:10-12:25\" \"_myField\" \"private\"");
     Console.WriteLine("  --cli make-field-readonly ./MyFile.cs 15");
+    Console.WriteLine("  --cli cleanup-usings ./MyFile.cs ./MySolution.sln");
     Console.WriteLine("  --cli analyze-refactoring-opportunities ./MyFile.cs ./MySolution.sln");
     Console.WriteLine("  --cli version");
     Console.WriteLine();
@@ -283,6 +285,17 @@ static async Task<string> TestSafeDeleteVariable(string[] args)
     var solutionPath = args.Length > 4 ? args[4] : null;
 
     return await SafeDeleteTool.SafeDeleteVariable(filePath, range, solutionPath);
+}
+
+static async Task<string> TestCleanupUsings(string[] args)
+{
+    if (args.Length < 3)
+        return "Error: Missing arguments. Usage: --cli cleanup-usings <filePath> [solutionPath]";
+
+    var filePath = args[2];
+    var solutionPath = args.Length > 3 ? args[3] : null;
+
+    return await CleanupUsingsTool.CleanupUsings(solutionPath ?? string.Empty, filePath);
 }
 
 static async Task<string> TestAnalyzeRefactoringOpportunities(string[] args)

--- a/RefactorMCP.ConsoleApp/Tools/CleanupUsings.cs
+++ b/RefactorMCP.ConsoleApp/Tools/CleanupUsings.cs
@@ -1,0 +1,75 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using System.ComponentModel;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using System.IO;
+using System;
+
+[McpServerToolType]
+public static class CleanupUsingsTool
+{
+    [McpServerTool, Description("Remove unused using directives from a C# file (preferred for large C# file refactoring)")]
+    public static async Task<string> CleanupUsings(
+        [Description("Absolute path to the solution file (.sln)")] string? solutionPath,
+        [Description("Path to the C# file")] string filePath)
+    {
+        try
+        {
+            if (!string.IsNullOrWhiteSpace(solutionPath))
+            {
+                var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
+                var document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
+                if (document != null)
+                    return await CleanupUsingsWithSolution(document);
+            }
+
+            return await CleanupUsingsSingleFile(filePath);
+        }
+        catch (Exception ex)
+        {
+            throw new McpException($"Error cleaning up usings: {ex.Message}", ex);
+        }
+    }
+
+    private static async Task<string> CleanupUsingsWithSolution(Document document)
+    {
+        var sourceText = await document.GetTextAsync();
+        var newText = CleanupUsingsInSource(sourceText.ToString());
+        await File.WriteAllTextAsync(document.FilePath!, newText);
+        return $"Removed unused usings in {document.FilePath}";
+    }
+
+    private static async Task<string> CleanupUsingsSingleFile(string filePath)
+    {
+        if (!File.Exists(filePath))
+            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
+
+        var sourceText = await File.ReadAllTextAsync(filePath);
+        var newText = CleanupUsingsInSource(sourceText);
+        await File.WriteAllTextAsync(filePath, newText);
+
+        return $"Removed unused usings in {filePath} (single file mode)";
+    }
+
+    public static string CleanupUsingsInSource(string sourceText)
+    {
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        var compilation = CSharpCompilation.Create("Cleanup")
+            .AddReferences(MetadataReference.CreateFromFile(typeof(object).Assembly.Location))
+            .AddSyntaxTrees(tree);
+        var diagnostics = compilation.GetDiagnostics();
+        var root = tree.GetRoot();
+        var unused = diagnostics
+            .Where(d => d.Id == "CS8019")
+            .Select(d => root.FindNode(d.Location.SourceSpan))
+            .OfType<UsingDirectiveSyntax>()
+            .ToList();
+
+        var newRoot = root.RemoveNodes(unused, SyntaxRemoveOptions.KeepNoTrivia);
+        var formatted = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
+        return formatted.ToFullString();
+    }
+}

--- a/RefactorMCP.Tests/ExampleValidationTests.cs
+++ b/RefactorMCP.Tests/ExampleValidationTests.cs
@@ -160,6 +160,20 @@ public class ExampleValidationTests : IDisposable
     }
 
     [Fact]
+    public async Task Example_CleanupUsings_WorksAsDocumented()
+    {
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "CleanupSample.cs"));
+        await CreateTestFile(testFile, TestUtilities.GetSampleCodeForCleanupUsings());
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+
+        var result = await CleanupUsingsTool.CleanupUsings(SolutionPath, testFile);
+
+        Assert.Contains("Removed unused usings", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.DoesNotContain("System.Text", fileContent);
+    }
+
+    [Fact]
     public async Task QuickReference_ExtractMethod_WorksAsDocumented()
     {
         // Test the quick reference example

--- a/RefactorMCP.Tests/Split/CleanupUsingsTests.cs
+++ b/RefactorMCP.Tests/Split/CleanupUsingsTests.cs
@@ -1,0 +1,23 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class CleanupUsingsTests : TestBase
+{
+    [Fact]
+    public async Task CleanupUsings_RemovesUnusedUsings()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var testFile = Path.Combine(TestOutputPath, "CleanupSample.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForCleanupUsings());
+
+        var result = await CleanupUsingsTool.CleanupUsings(SolutionPath, testFile);
+
+        Assert.Contains("Removed unused usings", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.DoesNotContain("System.Text", fileContent);
+    }
+}

--- a/RefactorMCP.Tests/Split/TestUtilities.cs
+++ b/RefactorMCP.Tests/Split/TestUtilities.cs
@@ -155,5 +155,15 @@ public class InlineSample
     }
 }
 """;
+
+    public static string GetSampleCodeForCleanupUsings() => """
+using System;
+using System.Text;
+
+public class CleanupSample
+{
+    public void Say() => Console.WriteLine("Hi");
+}
+""";
 }
 


### PR DESCRIPTION
## Summary
- implement CleanupUsingsTool to remove unused using directives
- add CLI command `cleanup-usings`
- document the new tool in README, QUICK_REFERENCE and EXAMPLES
- support new example validation and unit tests

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684a738209508327adc58e19cc661e14