### PR TITLE
Add MoveMultipleMethods tool

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -331,7 +331,62 @@ public class MathUtilities
 }
 ```
 
-## 10. Inline Method
+## 10. Move Multiple Methods
+
+**Purpose**: Move several methods at once, ordered by dependencies.
+
+### Example
+**Before**:
+```csharp
+class Helper
+{
+    public void A() { B(); }
+    public void B() { Console.WriteLine("B"); }
+}
+
+class Target { }
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  "[{\"sourceClass\":\"Helper\",\"method\":\"A\",\"targetClass\":\"Target\",\"accessMember\":\"t\",\"accessMemberType\":\"field\"},{\"sourceClass\":\"Helper\",\"method\":\"B\",\"targetClass\":\"Target\",\"accessMember\":\"t\",\"accessMemberType\":\"field\"}]"
+```
+
+**After**:
+```csharp
+class Helper
+{
+    private Target t = new Target();
+
+    public void A()
+    {
+        t.A();
+    }
+
+    public void B()
+    {
+        t.B();
+    }
+}
+
+class Target
+{
+    public void B()
+    {
+        Console.WriteLine("B");
+    }
+
+    public void A()
+    {
+        B();
+    }
+}
+```
+
+## 11. Inline Method
 
 **Purpose**: Replace method calls with the method body and remove the original method.
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -142,11 +142,19 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
   "SourceClass" \
-  "MethodName" \
+  "MethodA,MethodB" \
   "TargetClass" \
   "memberName" \
   "field" \
   "./optional/target.cs"
+```
+
+### Move Multiple Methods
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
+  "./RefactorMCP.sln" \
+  "./path/to/file.cs" \
+  "[{'sourceClass':'A','method':'Foo','targetClass':'B','accessMember':'b','accessMemberType':'field','isStatic':false}]"
 ```
 
 ### Convert To Extension Method

--- a/README.md
+++ b/README.md
@@ -163,8 +163,9 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli <command> [arguments]
 - `introduce-parameter <solutionPath> <filePath> <methodLine> <range> <parameterName>` - Create parameter from expression
 - `convert-to-static-with-parameters <solutionPath> <filePath> <methodLine>` - Convert instance method to static with parameters
 - `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
-- `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFile]` - Move a static method to another class
-- `move-instance-method <solutionPath> <filePath> <sourceClass> <methodName> <targetClass> <accessMember> [memberType] [targetFile]` - Move an instance method to another class
+ - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFile]` - Move a static method to another class
+ - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFile]` - Move one or more instance methods (comma separated names) to another class
+ - `move-multiple-methods <solutionPath> <filePath> <operationsJson>` - Move multiple static or instance methods described by a JSON array
 - `cleanup-usings <filePath> [solutionPath]` - Remove unused using directives
 - `version` - Show build version and timestamp
 - `analyze-refactoring-opportunities <solutionPath> <filePath>` - Prompt for refactoring suggestions (long methods, long parameter lists, unused code)

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.cs
@@ -1,0 +1,110 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using System.ComponentModel;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Text.Json;
+
+[McpServerToolType]
+public static class MoveMultipleMethodsTool
+{
+    public class MoveOperation
+    {
+        public string SourceClass { get; set; } = string.Empty;
+        public string Method { get; set; } = string.Empty;
+        public string TargetClass { get; set; } = string.Empty;
+        public string AccessMember { get; set; } = string.Empty;
+        public string AccessMemberType { get; set; } = "field";
+        public bool IsStatic { get; set; }
+        public string? TargetFile { get; set; }
+    }
+
+    private static Dictionary<string, HashSet<string>> BuildDependencies(string sourceText, IEnumerable<MoveOperation> ops)
+    {
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        var root = tree.GetRoot();
+        var map = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .Where(m => ops.Any(o => o.Method == m.Identifier.ValueText))
+            .ToDictionary(m => m.Identifier.ValueText, m => m);
+
+        var deps = new Dictionary<string, HashSet<string>>();
+        foreach (var op in ops)
+        {
+            if (!map.TryGetValue(op.Method, out var method))
+            {
+                deps[op.Method] = new HashSet<string>();
+                continue;
+            }
+            var called = method.DescendantNodes().OfType<InvocationExpressionSyntax>()
+                .Select(inv => inv.Expression switch
+                {
+                    IdentifierNameSyntax id => id.Identifier.ValueText,
+                    MemberAccessExpressionSyntax ma => ma.Name.Identifier.ValueText,
+                    _ => null
+                })
+                .Where(n => n != null && map.ContainsKey(n))
+                .ToHashSet()!;
+            deps[op.Method] = called;
+        }
+        return deps;
+    }
+
+    private static List<MoveOperation> OrderOperations(string sourceText, List<MoveOperation> ops)
+    {
+        var deps = BuildDependencies(sourceText, ops);
+        return ops.OrderBy(o => deps.TryGetValue(o.Method, out var d) ? d.Count : 0).ToList();
+    }
+
+    public static string MoveMultipleMethodsInSource(string sourceText, string operationsJson)
+    {
+        var ops = JsonSerializer.Deserialize<List<MoveOperation>>(operationsJson);
+        if (ops == null || ops.Count == 0)
+            return RefactoringHelpers.ThrowMcpException("Error: No operations provided");
+
+        var ordered = OrderOperations(sourceText, ops);
+        var working = sourceText;
+        foreach (var op in ordered)
+        {
+            if (op.IsStatic)
+            {
+                working = MoveMethodsTool.MoveStaticMethodInSource(working, op.Method, op.TargetClass);
+            }
+            else
+            {
+                working = MoveMethodsTool.MoveInstanceMethodInSource(working, op.SourceClass, op.Method, op.TargetClass, op.AccessMember, op.AccessMemberType);
+            }
+        }
+        return working;
+    }
+
+    [McpServerTool, Description("Move multiple methods to target classes, automatically ordering by dependencies")]
+    public static async Task<string> MoveMultipleMethods(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        [Description("Path to the C# file containing the methods")] string filePath,
+        [Description("JSON array describing the move operations")] string operationsJson)
+    {
+        var ops = JsonSerializer.Deserialize<List<MoveOperation>>(operationsJson);
+        if (ops == null || ops.Count == 0)
+            return RefactoringHelpers.ThrowMcpException("Error: No operations provided");
+
+        var sourceText = await File.ReadAllTextAsync(filePath);
+        var ordered = OrderOperations(sourceText, ops);
+        var results = new List<string>();
+        foreach (var op in ordered)
+        {
+            if (op.IsStatic)
+            {
+                results.Add(await MoveMethodsTool.MoveStaticMethod(solutionPath, filePath, op.Method, op.TargetClass, op.TargetFile));
+            }
+            else
+            {
+                results.Add(await MoveMethodsTool.MoveInstanceMethod(solutionPath, filePath, op.SourceClass, op.Method, op.TargetClass, op.AccessMember, op.AccessMemberType, op.TargetFile));
+            }
+            // Refresh sourceText after each move
+            sourceText = await File.ReadAllTextAsync(filePath);
+        }
+        return string.Join("\n", results);
+    }
+}


### PR DESCRIPTION
## Summary
- add `MoveMultipleMethodsTool` for moving multiple methods
- allow comma-separated method names in `MoveInstanceMethod`
- document new functionality in README, EXAMPLES, QUICK_REFERENCE

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684a78ccab748327b1c2ebdd36beba19