### PR TITLE
Reduce duplication with helper for SingleFile edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ The examples use the sample code in [RefactorMCP.Tests/ExampleCode.cs](./Refacto
 # Run existing tests
 dotnet test
 
+*Note: Avoid using `--no-build` on the first run unless the project has already been built, or tests may fail with an "invalid argument" error.*
+
 # Test specific refactoring tool
 dotnet run --project RefactorMCP.ConsoleApp -- --cli <tool-name> [args]
 

--- a/RefactorMCP.ConsoleApp/Tools/CleanupUsings.cs
+++ b/RefactorMCP.ConsoleApp/Tools/CleanupUsings.cs
@@ -42,16 +42,12 @@ public static class CleanupUsingsTool
         return $"Removed unused usings in {document.FilePath}";
     }
 
-    private static async Task<string> CleanupUsingsSingleFile(string filePath)
+    private static Task<string> CleanupUsingsSingleFile(string filePath)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = CleanupUsingsInSource(sourceText);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Removed unused usings in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            CleanupUsingsInSource,
+            $"Removed unused usings in {filePath} (single file mode)");
     }
 
     public static string CleanupUsingsInSource(string sourceText)

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
@@ -137,16 +137,12 @@ public static class ConvertToExtensionMethodTool
         return $"Successfully converted method '{methodName}' to extension method in {document.FilePath} (solution mode)";
     }
 
-    private static async Task<string> ConvertToExtensionMethodSingleFile(string filePath, string methodName, string? extensionClass)
+    private static Task<string> ConvertToExtensionMethodSingleFile(string filePath, string methodName, string? extensionClass)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = ConvertToExtensionMethodInSource(sourceText, methodName, extensionClass);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully converted method '{methodName}' to extension method in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => ConvertToExtensionMethodInSource(text, methodName, extensionClass),
+            $"Successfully converted method '{methodName}' to extension method in {filePath} (single file mode)");
     }
 
     public static string ConvertToExtensionMethodInSource(string sourceText, string methodName, string? extensionClass)

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
@@ -90,16 +90,12 @@ public static class ConvertToStaticWithInstanceTool
         return $"Successfully converted method '{methodName}' to static with instance parameter in {document.FilePath} (solution mode)";
     }
 
-    private static async Task<string> ConvertToStaticWithInstanceSingleFile(string filePath, string methodName, string instanceParameterName)
+    private static Task<string> ConvertToStaticWithInstanceSingleFile(string filePath, string methodName, string instanceParameterName)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = ConvertToStaticWithInstanceInSource(sourceText, methodName, instanceParameterName);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully converted method '{methodName}' to static with instance parameter in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => ConvertToStaticWithInstanceInSource(text, methodName, instanceParameterName),
+            $"Successfully converted method '{methodName}' to static with instance parameter in {filePath} (single file mode)");
     }
 
     public static string ConvertToStaticWithInstanceInSource(string sourceText, string methodName, string instanceParameterName)

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
@@ -111,16 +111,12 @@ public static class ConvertToStaticWithParametersTool
         return $"Successfully converted method '{methodName}' to static with parameters in {document.FilePath} (solution mode)";
     }
 
-    private static async Task<string> ConvertToStaticWithParametersSingleFile(string filePath, string methodName)
+    private static Task<string> ConvertToStaticWithParametersSingleFile(string filePath, string methodName)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = ConvertToStaticWithParametersInSource(sourceText, methodName);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully converted method '{methodName}' to static with parameters in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => ConvertToStaticWithParametersInSource(text, methodName),
+            $"Successfully converted method '{methodName}' to static with parameters in {filePath} (single file mode)");
     }
 
     public static string ConvertToStaticWithParametersInSource(string sourceText, string methodName)

--- a/RefactorMCP.ConsoleApp/Tools/ExtractMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ExtractMethod.cs
@@ -98,16 +98,12 @@ public static class ExtractMethodTool
         return $"Successfully extracted method '{methodName}' from {selectionRange} in {document.FilePath} (solution mode)";
     }
 
-    private static async Task<string> ExtractMethodSingleFile(string filePath, string selectionRange, string methodName)
+    private static Task<string> ExtractMethodSingleFile(string filePath, string selectionRange, string methodName)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = ExtractMethodInSource(sourceText, selectionRange, methodName);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully extracted method '{methodName}' from {selectionRange} in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => ExtractMethodInSource(text, selectionRange, methodName),
+            $"Successfully extracted method '{methodName}' from {selectionRange} in {filePath} (single file mode)");
     }
 
     public static string ExtractMethodInSource(string sourceText, string selectionRange, string methodName)

--- a/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
@@ -94,15 +94,12 @@ public static class InlineMethodTool
         return $"Successfully inlined method '{methodName}' in {document.FilePath} (solution mode)";
     }
 
-    private static async Task<string> InlineMethodSingleFile(string filePath, string methodName)
+    private static Task<string> InlineMethodSingleFile(string filePath, string methodName)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = InlineMethodInSource(sourceText, methodName);
-        await File.WriteAllTextAsync(filePath, newText);
-        return $"Successfully inlined method '{methodName}' in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => InlineMethodInSource(text, methodName),
+            $"Successfully inlined method '{methodName}' in {filePath} (single file mode)");
     }
 
     public static string InlineMethodInSource(string sourceText, string methodName)

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
@@ -100,16 +100,12 @@ public static class IntroduceFieldTool
         return $"Successfully introduced {accessModifier} field '{fieldName}' from {selectionRange} in {document.FilePath} (solution mode)";
     }
 
-    private static async Task<string> IntroduceFieldSingleFile(string filePath, string selectionRange, string fieldName, string accessModifier)
+    private static Task<string> IntroduceFieldSingleFile(string filePath, string selectionRange, string fieldName, string accessModifier)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = IntroduceFieldInSource(sourceText, selectionRange, fieldName, accessModifier);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully introduced {accessModifier} field '{fieldName}' from {selectionRange} in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => IntroduceFieldInSource(text, selectionRange, fieldName, accessModifier),
+            $"Successfully introduced {accessModifier} field '{fieldName}' from {selectionRange} in {filePath} (single file mode)");
     }
 
     public static string IntroduceFieldInSource(string sourceText, string selectionRange, string fieldName, string accessModifier)

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
@@ -74,16 +74,12 @@ public static class IntroduceParameterTool
         return $"Successfully introduced parameter '{parameterName}' from {selectionRange} in method '{methodName}' in {document.FilePath} (solution mode)";
     }
 
-    private static async Task<string> IntroduceParameterSingleFile(string filePath, string methodName, string selectionRange, string parameterName)
+    private static Task<string> IntroduceParameterSingleFile(string filePath, string methodName, string selectionRange, string parameterName)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = IntroduceParameterInSource(sourceText, methodName, selectionRange, parameterName);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully introduced parameter '{parameterName}' from {selectionRange} in method '{methodName}' in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => IntroduceParameterInSource(text, methodName, selectionRange, parameterName),
+            $"Successfully introduced parameter '{parameterName}' from {selectionRange} in method '{methodName}' in {filePath} (single file mode)");
     }
 
     public static string IntroduceParameterInSource(string sourceText, string methodName, string selectionRange, string parameterName)

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceVariable.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceVariable.cs
@@ -102,16 +102,12 @@ public static class IntroduceVariableTool
         return $"Successfully introduced variable '{variableName}' from {selectionRange} in {document.FilePath} (solution mode)";
     }
 
-    private static async Task<string> IntroduceVariableSingleFile(string filePath, string selectionRange, string variableName)
+    private static Task<string> IntroduceVariableSingleFile(string filePath, string selectionRange, string variableName)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = IntroduceVariableInSource(sourceText, selectionRange, variableName);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully introduced variable '{variableName}' from {selectionRange} in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => IntroduceVariableInSource(text, selectionRange, variableName),
+            $"Successfully introduced variable '{variableName}' from {selectionRange} in {filePath} (single file mode)");
     }
 
     public static string IntroduceVariableInSource(string sourceText, string selectionRange, string variableName)

--- a/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
@@ -118,16 +118,12 @@ public static class MakeFieldReadonlyTool
         return $"Field '{fieldName}' made readonly, but no constructors found for initialization";
     }
 
-    private static async Task<string> MakeFieldReadonlySingleFile(string filePath, string fieldName)
+    private static Task<string> MakeFieldReadonlySingleFile(string filePath, string fieldName)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = MakeFieldReadonlyInSource(sourceText, fieldName);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully made field '{fieldName}' readonly in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => MakeFieldReadonlyInSource(text, fieldName),
+            $"Successfully made field '{fieldName}' readonly in {filePath} (single file mode)");
     }
 
     public static string MakeFieldReadonlyInSource(string sourceText, string fieldName)

--- a/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.Extensions.Caching.Memory;
 using System;
+using System.IO;
 
 
 
@@ -56,5 +57,19 @@ internal static class RefactoringHelpers
     internal static string ThrowMcpException(string message)
     {
         throw new McpException(message);
+    }
+
+    internal static async Task<string> ApplySingleFileEdit(
+        string filePath,
+        Func<string, string> transform,
+        string successMessage)
+    {
+        if (!File.Exists(filePath))
+            return ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
+
+        var sourceText = await File.ReadAllTextAsync(filePath);
+        var newText = transform(sourceText);
+        await File.WriteAllTextAsync(filePath, newText);
+        return successMessage;
     }
 }

--- a/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
@@ -129,16 +129,12 @@ public static class SafeDeleteTool
         return $"Successfully deleted field '{fieldName}' in {document.FilePath}";
     }
 
-    private static async Task<string> SafeDeleteFieldSingleFile(string filePath, string fieldName)
+    private static Task<string> SafeDeleteFieldSingleFile(string filePath, string fieldName)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = SafeDeleteFieldInSource(sourceText, fieldName);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully deleted field '{fieldName}' in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => SafeDeleteFieldInSource(text, fieldName),
+            $"Successfully deleted field '{fieldName}' in {filePath} (single file mode)");
     }
 
     public static string SafeDeleteFieldInSource(string sourceText, string fieldName)
@@ -190,16 +186,12 @@ public static class SafeDeleteTool
         return $"Successfully deleted method '{methodName}' in {document.FilePath}";
     }
 
-    private static async Task<string> SafeDeleteMethodSingleFile(string filePath, string methodName)
+    private static Task<string> SafeDeleteMethodSingleFile(string filePath, string methodName)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = SafeDeleteMethodInSource(sourceText, methodName);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully deleted method '{methodName}' in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => SafeDeleteMethodInSource(text, methodName),
+            $"Successfully deleted method '{methodName}' in {filePath} (single file mode)");
     }
 
     public static string SafeDeleteMethodInSource(string sourceText, string methodName)
@@ -266,16 +258,12 @@ public static class SafeDeleteTool
         return $"Successfully deleted parameter '{parameterName}' from method '{methodName}' in {document.FilePath}";
     }
 
-    private static async Task<string> SafeDeleteParameterSingleFile(string filePath, string methodName, string parameterName)
+    private static Task<string> SafeDeleteParameterSingleFile(string filePath, string methodName, string parameterName)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = SafeDeleteParameterInSource(sourceText, methodName, parameterName);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully deleted parameter '{parameterName}' from method '{methodName}' in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => SafeDeleteParameterInSource(text, methodName, parameterName),
+            $"Successfully deleted parameter '{parameterName}' from method '{methodName}' in {filePath} (single file mode)");
     }
 
     public static string SafeDeleteParameterInSource(string sourceText, string methodName, string parameterName)
@@ -348,16 +336,12 @@ public static class SafeDeleteTool
         return $"Successfully deleted variable '{variable.Identifier.ValueText}' in {document.FilePath}";
     }
 
-    private static async Task<string> SafeDeleteVariableSingleFile(string filePath, string selectionRange)
+    private static Task<string> SafeDeleteVariableSingleFile(string filePath, string selectionRange)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = SafeDeleteVariableInSource(sourceText, selectionRange);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully deleted variable in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => SafeDeleteVariableInSource(text, selectionRange),
+            $"Successfully deleted variable in {filePath} (single file mode)");
     }
 
     public static string SafeDeleteVariableInSource(string sourceText, string selectionRange)

--- a/RefactorMCP.ConsoleApp/Tools/TransformSetterToInit.cs
+++ b/RefactorMCP.ConsoleApp/Tools/TransformSetterToInit.cs
@@ -59,16 +59,12 @@ public static class TransformSetterToInitTool
         return $"Successfully converted setter to init for '{propertyName}' in {document.FilePath} (solution mode)";
     }
 
-    private static async Task<string> TransformSetterToInitSingleFile(string filePath, string propertyName)
+    private static Task<string> TransformSetterToInitSingleFile(string filePath, string propertyName)
     {
-        if (!File.Exists(filePath))
-            return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found (current dir: {Directory.GetCurrentDirectory()})");
-
-        var sourceText = await File.ReadAllTextAsync(filePath);
-        var newText = TransformSetterToInitInSource(sourceText, propertyName);
-        await File.WriteAllTextAsync(filePath, newText);
-
-        return $"Successfully converted setter to init for '{propertyName}' in {filePath} (single file mode)";
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => TransformSetterToInitInSource(text, propertyName),
+            $"Successfully converted setter to init for '{propertyName}' in {filePath} (single file mode)");
     }
 
     public static string TransformSetterToInitInSource(string sourceText, string propertyName)


### PR DESCRIPTION
## Summary
- create `ApplySingleFileEdit` in `RefactoringHelpers`
- call the helper from tools instead of repeating file IO
- clarify the need to build before running `dotnet test`

## Testing
- `dotnet format --no-restore`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_684aa47757308327a41291b33991899d