### PR TITLE
Ensure move tools use readonly fields when possible

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -365,7 +365,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
 ```csharp
 class Helper
 {
-    private Target t = new Target();
+    private readonly Target t = new Target();
 
     public void A()
     {

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -153,6 +153,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \
   "field" \
   "./optional/target.cs"
 ```
+Newly added access fields are readonly and existing members are reused if present.
 
 ### Move Multiple Methods
 ```bash

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
 - `convert-to-static-with-parameters <solutionPath> <filePath> <methodLine>` - Convert instance method to static with parameters
 - `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
  - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFile]` - Move a static method to another class
- - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFile]` - Move one or more instance methods (comma separated names) to another class
+ - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFile]` - Move one or more instance methods (comma separated names) to another class. Newly created access fields are marked `readonly` and won't duplicate existing members
  - `move-multiple-methods <solutionPath> <filePath> <operationsJson>` - Move multiple static or instance methods described by a JSON array
 - `cleanup-usings <filePath> [solutionPath]` - Remove unused using directives
 - `version` - Show build version and timestamp


### PR DESCRIPTION
## Summary
- add helper method for detecting existing members
- create access field with readonly modifier
- skip adding duplicate fields
- document readonly behavior in README, quick reference, and examples
- update tests and add new coverage for existing field

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684abc23e9f48327b72a1a86f4f06225