### PR TITLE
Refactor rewriters into shared module

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
@@ -13,20 +13,6 @@ using System.Collections.Generic;
 [McpServerToolType]
 public static class InlineMethodTool
 {
-    private class ParameterRewriter : CSharpSyntaxRewriter
-    {
-        private readonly Dictionary<string, ExpressionSyntax> _map;
-        public ParameterRewriter(Dictionary<string, ExpressionSyntax> map)
-        {
-            _map = map;
-        }
-        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
-        {
-            if (_map.TryGetValue(node.Identifier.ValueText, out var expr))
-                return expr;
-            return base.VisitIdentifierName(node);
-        }
-    }
 
     private static SyntaxNode InlineInvocation(MethodDeclarationSyntax method, InvocationExpressionSyntax invocation)
     {

--- a/RefactorMCP.ConsoleApp/Tools/SyntaxRewriters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SyntaxRewriters.cs
@@ -1,0 +1,206 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class ParameterRewriter : CSharpSyntaxRewriter
+{
+    private readonly Dictionary<string, ExpressionSyntax> _map;
+    public ParameterRewriter(Dictionary<string, ExpressionSyntax> map)
+    {
+        _map = map;
+    }
+    public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        if (_map.TryGetValue(node.Identifier.ValueText, out var expr))
+            return expr;
+        return base.VisitIdentifierName(node);
+    }
+}
+
+internal class InstanceMemberUsageChecker : CSharpSyntaxRewriter
+{
+    private readonly HashSet<string> _knownInstanceMembers;
+    public bool HasInstanceMemberUsage { get; private set; }
+
+    public InstanceMemberUsageChecker(HashSet<string> knownInstanceMembers)
+    {
+        _knownInstanceMembers = knownInstanceMembers;
+    }
+
+    public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        var parent = node.Parent;
+        if (parent is ParameterSyntax || parent is TypeSyntax)
+            return base.VisitIdentifierName(node);
+
+        if (_knownInstanceMembers.Contains(node.Identifier.ValueText))
+        {
+            if (parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Expression == node)
+            {
+                HasInstanceMemberUsage = true;
+            }
+            else if (parent is not MemberAccessExpressionSyntax && parent is not InvocationExpressionSyntax)
+            {
+                HasInstanceMemberUsage = true;
+            }
+        }
+
+        return base.VisitIdentifierName(node);
+    }
+}
+
+internal class InstanceMemberRewriter : CSharpSyntaxRewriter
+{
+    private readonly string _parameterName;
+    private readonly HashSet<string> _knownInstanceMembers;
+
+    public InstanceMemberRewriter(string parameterName, HashSet<string> knownInstanceMembers)
+    {
+        _parameterName = parameterName;
+        _knownInstanceMembers = knownInstanceMembers;
+    }
+
+    public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        var parent = node.Parent;
+        if (parent is ParameterSyntax || parent is TypeSyntax)
+            return base.VisitIdentifierName(node);
+
+        if (_knownInstanceMembers.Contains(node.Identifier.ValueText))
+        {
+            if (parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Expression == node)
+            {
+                return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(_parameterName),
+                    node);
+            }
+            else if (parent is not MemberAccessExpressionSyntax)
+            {
+                return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(_parameterName),
+                    node);
+            }
+        }
+
+        return base.VisitIdentifierName(node);
+    }
+}
+
+internal class MethodCallChecker : CSharpSyntaxRewriter
+{
+    private readonly HashSet<string> _classMethodNames;
+    public bool HasMethodCalls { get; private set; }
+
+    public MethodCallChecker(HashSet<string> classMethodNames)
+    {
+        _classMethodNames = classMethodNames;
+    }
+
+    public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        if (node.Expression is IdentifierNameSyntax identifier)
+        {
+            if (_classMethodNames.Contains(identifier.Identifier.ValueText))
+            {
+                HasMethodCalls = true;
+            }
+        }
+
+        return base.VisitInvocationExpression(node);
+    }
+}
+
+internal class MethodCallRewriter : CSharpSyntaxRewriter
+{
+    private readonly HashSet<string> _classMethodNames;
+    private readonly string _parameterName;
+
+    public MethodCallRewriter(HashSet<string> classMethodNames, string parameterName)
+    {
+        _classMethodNames = classMethodNames;
+        _parameterName = parameterName;
+    }
+
+    public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        if (node.Expression is IdentifierNameSyntax identifier)
+        {
+            if (_classMethodNames.Contains(identifier.Identifier.ValueText))
+            {
+                var memberAccess = SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(_parameterName),
+                    identifier);
+
+                return node.WithExpression(memberAccess);
+            }
+        }
+
+        return base.VisitInvocationExpression(node);
+    }
+}
+
+internal class StaticFieldChecker : CSharpSyntaxRewriter
+{
+    private readonly HashSet<string> _staticFieldNames;
+    public bool HasStaticFieldReferences { get; private set; }
+
+    public StaticFieldChecker(HashSet<string> staticFieldNames)
+    {
+        _staticFieldNames = staticFieldNames;
+    }
+
+    public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        var parent = node.Parent;
+        if (parent is ParameterSyntax || parent is TypeSyntax)
+            return base.VisitIdentifierName(node);
+
+        if (_staticFieldNames.Contains(node.Identifier.ValueText))
+        {
+            if (parent is not MemberAccessExpressionSyntax ||
+                (parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == node))
+            {
+                HasStaticFieldReferences = true;
+            }
+        }
+
+        return base.VisitIdentifierName(node);
+    }
+}
+
+internal class StaticFieldRewriter : CSharpSyntaxRewriter
+{
+    private readonly HashSet<string> _staticFieldNames;
+    private readonly string _sourceClassName;
+
+    public StaticFieldRewriter(HashSet<string> staticFieldNames, string sourceClassName)
+    {
+        _staticFieldNames = staticFieldNames;
+        _sourceClassName = sourceClassName;
+    }
+
+    public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        var parent = node.Parent;
+        if (parent is ParameterSyntax || parent is TypeSyntax)
+            return base.VisitIdentifierName(node);
+
+        if (_staticFieldNames.Contains(node.Identifier.ValueText))
+        {
+            if (parent is not MemberAccessExpressionSyntax ||
+                (parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Name == node))
+            {
+                return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(_sourceClassName),
+                    node);
+            }
+        }
+
+        return base.VisitIdentifierName(node);
+    }
+}


### PR DESCRIPTION
## Summary
- extract nested CSharpSyntaxRewriter classes into `SyntaxRewriters.cs`
- remove inlined rewriters from `InlineMethodTool` and `MoveMethodsTool`
- update tools to reference the shared implementations

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684bfd06559c83278f274aa6eb5ed49d