### PR TITLE
Fix batched move operations to return updated documents

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.cs
@@ -183,17 +183,30 @@ public static class MoveMultipleMethodsTool
             {
                 if (op.IsStatic)
                 {
-                    results.Add(await MoveMethodsTool.MoveStaticMethod(solutionPath, filePath, op.Method, op.TargetClass, op.TargetFile));
+                    var (msg, updatedDoc) = await MoveMethodsTool.MoveStaticMethodWithSolution(
+                        currentDocument,
+                        op.Method,
+                        op.TargetClass,
+                        op.TargetFile);
+                    results.Add(msg);
+                    currentDocument = updatedDoc;
                 }
                 else
                 {
-                    // For instance methods, pass single method to avoid reloading solution
-                    results.Add(await MoveMethodsTool.MoveInstanceMethod(solutionPath, filePath, op.SourceClass, op.Method, op.TargetClass, op.AccessMember, op.AccessMemberType, op.TargetFile));
+                    var (msg, updatedDoc) = await MoveMethodsTool.MoveInstanceMethodWithSolution(
+                        currentDocument,
+                        op.SourceClass,
+                        op.Method,
+                        op.TargetClass,
+                        op.AccessMember,
+                        op.AccessMemberType);
+                    results.Add(msg);
+                    currentDocument = updatedDoc;
                 }
-
-                // Clear solution cache to force reload of updated file state
-                RefactoringHelpers.SolutionCache.Remove(solutionPath);
             }
+
+            // Clear cache after batch completes
+            RefactoringHelpers.SolutionCache.Remove(solutionPath);
 
             return string.Join("\n", results);
         }


### PR DESCRIPTION
## Summary
- ensure MoveInstanceMethodWithSolution and MoveStaticMethodWithSolution return updated Document objects
- keep these Documents for subsequent operations in MoveMethods and MoveMultipleMethods

## Testing
- `dotnet format --verbosity diagnostic`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684bff1b7e708327b19fd0a10f763ff2