### PR TITLE
Add move class to separate file tool

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -392,7 +392,43 @@ class Target
 }
 ```
 
-## 11. Inline Method
+## 11. Move Class to Separate File
+
+**Purpose**: Move a class into its own file named after the class.
+
+### Example
+**Before**:
+```csharp
+public class Logger
+{
+    public void Log(string message)
+    {
+        Console.WriteLine($"[LOG] {message}");
+    }
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-to-separate-file \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  Logger
+```
+
+**After**:
+```csharp
+// Logger.cs
+public class Logger
+{
+    public void Log(string message)
+    {
+        Console.WriteLine($"[LOG] {message}");
+    }
+}
+```
+
+## 12. Inline Method
 
 **Purpose**: Replace method calls with the method body and remove the original method.
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -163,6 +163,14 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
   "[{'sourceClass':'A','method':'Foo','targetClass':'B','accessMember':'b','accessMemberType':'field','isStatic':false}]"
 ```
 
+### Move To Separate File
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-to-separate-file \
+  "./RefactorMCP.sln" \
+  "./path/to/file.cs" \
+  ClassName
+```
+
 ### Convert To Extension Method
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method \

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ All CLI tools require an absolute path to a solution file. The working directory
 
 **Use solution mode for:**
 - Move Method operations
-- Convert to Static (requires dependency analysis)  
+- Move class to separate file
+- Convert to Static (requires dependency analysis)
 - Convert to Extension Method (for instance methods)
 - Safe Delete (requires usage analysis)
 - Any refactoring requiring cross-references
@@ -469,6 +470,39 @@ using System;
 public class Sample
 {
     public void Say() => Console.WriteLine("Hi");
+}
+```
+
+### 10. Move Class to Separate File
+
+**Before**:
+```csharp
+public class Logger
+{
+    public void Log(string message)
+    {
+        Console.WriteLine($"[LOG] {message}");
+    }
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-to-separate-file \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  Logger
+```
+
+**After**:
+```csharp
+// Logger.cs
+public class Logger
+{
+    public void Log(string message)
+    {
+        Console.WriteLine($"[LOG] {message}");
+    }
 }
 ```
 

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -65,6 +65,7 @@ static async Task RunCliMode(string[] args)
         ["move-static-method"] = TestMoveStaticMethod,
         ["inline-method"] = TestInlineMethod,
         ["move-instance-method"] = TestMoveInstanceMethod,
+        ["move-to-separate-file"] = TestMoveToSeparateFile,
         ["transform-setter-to-init"] = TestTransformSetterToInit,
         ["safe-delete-field"] = TestSafeDeleteField,
         ["safe-delete-method"] = TestSafeDeleteMethod,
@@ -469,6 +470,18 @@ static async Task<string> TestMoveInstanceMethod(string[] args)
     var targetFile = args.Length > 9 ? args[9] : null;
 
     return await MoveMethodsTool.MoveInstanceMethod(solutionPath, filePath, sourceClass, methodName, targetClass, accessMember, memberType, targetFile);
+}
+
+static async Task<string> TestMoveToSeparateFile(string[] args)
+{
+    if (args.Length < 5)
+        return "Error: Missing arguments. Usage: --cli move-to-separate-file <solutionPath> <filePath> <className>";
+
+    var solutionPath = args[2];
+    var filePath = args[3];
+    var className = args[4];
+
+    return await MoveClassToFileTool.MoveToSeparateFile(solutionPath, filePath, className);
 }
 
 static async Task<string> TestTransformSetterToInit(string[] args)

--- a/RefactorMCP.ConsoleApp/Tools/MoveClassToFile.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveClassToFile.cs
@@ -1,0 +1,74 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using System.ComponentModel;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+[McpServerToolType]
+public static class MoveClassToFileTool
+{
+    [McpServerTool, Description("Move a class to a separate file with the same name")]
+    public static async Task<string> MoveToSeparateFile(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        [Description("Path to the C# file containing the class")] string filePath,
+        [Description("Name of the class to move")] string className)
+    {
+        try
+        {
+            var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
+            var document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
+
+            CompilationUnitSyntax root;
+            if (document != null)
+            {
+                root = (CompilationUnitSyntax)(await document.GetSyntaxRootAsync())!;
+            }
+            else
+            {
+                if (!File.Exists(filePath))
+                    return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found");
+
+                var text = await File.ReadAllTextAsync(filePath);
+                root = (CompilationUnitSyntax)CSharpSyntaxTree.ParseText(text).GetRoot();
+            }
+            var classNode = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
+                .FirstOrDefault(c => c.Identifier.Text == className);
+            if (classNode == null)
+                return RefactoringHelpers.ThrowMcpException($"Error: Class {className} not found");
+
+            var rootWithoutClass = (CompilationUnitSyntax)root.RemoveNode(classNode, SyntaxRemoveOptions.KeepNoTrivia);
+            rootWithoutClass = (CompilationUnitSyntax)Formatter.Format(rootWithoutClass, RefactoringHelpers.SharedWorkspace);
+            await File.WriteAllTextAsync(filePath, rootWithoutClass.ToFullString());
+
+            var usingStatements = root.Usings;
+            CompilationUnitSyntax newRoot = SyntaxFactory.CompilationUnit().WithUsings(usingStatements);
+
+            if (classNode.Parent is NamespaceDeclarationSyntax ns)
+            {
+                var newNs = ns.WithMembers(SyntaxFactory.SingletonList<MemberDeclarationSyntax>(classNode));
+                newRoot = newRoot.AddMembers(newNs);
+            }
+            else if (classNode.Parent is FileScopedNamespaceDeclarationSyntax fns)
+            {
+                var newFsNs = fns.WithMembers(SyntaxFactory.SingletonList<MemberDeclarationSyntax>(classNode));
+                newRoot = newRoot.AddMembers(newFsNs);
+            }
+            else
+            {
+                newRoot = newRoot.AddMembers(classNode);
+            }
+
+            newRoot = (CompilationUnitSyntax)Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
+            var newFilePath = Path.Combine(Path.GetDirectoryName(filePath)!, $"{className}.cs");
+            await File.WriteAllTextAsync(newFilePath, newRoot.ToFullString());
+
+            return $"Successfully moved class '{className}' to {newFilePath}";
+        }
+        catch (Exception ex)
+        {
+            throw new McpException($"Error moving class: {ex.Message}", ex);
+        }
+    }
+}

--- a/RefactorMCP.Tests/Split/MoveClassToFileTests.cs
+++ b/RefactorMCP.Tests/Split/MoveClassToFileTests.cs
@@ -1,0 +1,30 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class MoveClassToFileTests : TestBase
+{
+    [Fact]
+    public async Task MoveClassToFile_MovesClassAndCreatesFile()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var testFile = Path.Combine(TestOutputPath, "MoveClassToFile.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForMoveClassToFile());
+
+        var result = await MoveClassToFileTool.MoveToSeparateFile(
+            SolutionPath,
+            testFile,
+            "Logger");
+
+        Assert.Contains("Successfully moved class", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.DoesNotContain("class Logger", fileContent);
+        var newFile = Path.Combine(Path.GetDirectoryName(testFile)!, "Logger.cs");
+        Assert.True(File.Exists(newFile));
+        var newFileContent = await File.ReadAllTextAsync(newFile);
+        Assert.Contains("class Logger", newFileContent);
+    }
+}

--- a/RefactorMCP.Tests/Split/TestUtilities.cs
+++ b/RefactorMCP.Tests/Split/TestUtilities.cs
@@ -165,5 +165,8 @@ public class CleanupSample
     public void Say() => Console.WriteLine("Hi");
 }
 """;
+
+    public static string GetSampleCodeForMoveClassToFile() =>
+        File.ReadAllText(Path.Combine(Path.GetDirectoryName(GetSolutionPath())!, "RefactorMCP.Tests", "ExampleCode.cs"));
 }
 


### PR DESCRIPTION
## Summary
- add `MoveClassToFileTool` with CLI support
- document move-to-separate-file usage in README, EXAMPLES, and QUICK_REFERENCE
- provide unit test and test utilities

## Testing
- `dotnet format RefactorMCP.sln -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684c043901d483278593398133facbff