### PR TITLE
Add extension method rewriter

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/SyntaxRewriters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SyntaxRewriters.cs
@@ -291,3 +291,81 @@ internal class VariableIntroductionRewriter : CSharpSyntaxRewriter
         return rewritten;
     }
 }
+
+internal class ExtensionMethodRewriter : CSharpSyntaxRewriter
+{
+    private readonly string _parameterName;
+    private readonly string _parameterType;
+    private readonly SemanticModel? _semanticModel;
+    private readonly INamedTypeSymbol? _typeSymbol;
+    private readonly HashSet<string>? _knownMembers;
+
+    public ExtensionMethodRewriter(string parameterName, string parameterType, SemanticModel semanticModel, INamedTypeSymbol typeSymbol)
+    {
+        _parameterName = parameterName;
+        _parameterType = parameterType;
+        _semanticModel = semanticModel;
+        _typeSymbol = typeSymbol;
+    }
+
+    public ExtensionMethodRewriter(string parameterName, string parameterType, HashSet<string> knownMembers)
+    {
+        _parameterName = parameterName;
+        _parameterType = parameterType;
+        _knownMembers = knownMembers;
+    }
+
+    public MethodDeclarationSyntax Rewrite(MethodDeclarationSyntax method)
+    {
+        return (MethodDeclarationSyntax)Visit(method)!;
+    }
+
+    public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
+    {
+        var thisParam = SyntaxFactory.Parameter(SyntaxFactory.Identifier(_parameterName))
+            .WithType(SyntaxFactory.ParseTypeName(_parameterType))
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.ThisKeyword));
+
+        var updated = node.WithParameterList(node.ParameterList.AddParameters(thisParam));
+        updated = AstTransformations.EnsureStaticModifier(updated);
+        return base.VisitMethodDeclaration(updated);
+    }
+
+    public override SyntaxNode VisitThisExpression(ThisExpressionSyntax node)
+    {
+        return SyntaxFactory.IdentifierName(_parameterName).WithTriviaFrom(node);
+    }
+
+    public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        bool qualify = false;
+
+        if (_semanticModel != null)
+        {
+            var sym = _semanticModel.GetSymbolInfo(node).Symbol;
+            if (sym is IFieldSymbol or IPropertySymbol or IMethodSymbol &&
+                SymbolEqualityComparer.Default.Equals(sym.ContainingType, _typeSymbol) &&
+                !sym.IsStatic && node.Parent is not MemberAccessExpressionSyntax)
+            {
+                qualify = true;
+            }
+        }
+        else if (_knownMembers != null &&
+                 _knownMembers.Contains(node.Identifier.ValueText) &&
+                 node.Parent is not MemberAccessExpressionSyntax)
+        {
+            qualify = true;
+        }
+
+        if (qualify)
+        {
+            return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(_parameterName),
+                    node.WithoutTrivia())
+                .WithTriviaFrom(node);
+        }
+
+        return base.VisitIdentifierName(node);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/ConvertTests.cs
+++ b/RefactorMCP.Tests/Roslyn/ConvertTests.cs
@@ -30,11 +30,13 @@ public static class StringProcessorExtensions
     }
 }";
         var output = ConvertToExtensionMethodTool.ConvertToExtensionMethodInSource(input, "FormatText", null);
-Assert.Equal(expected, output.Trim());
+        Assert.Equal(expected, output.Trim());
     }
-public void ConvertToExtensionMethodInSource_AppendsToExistingClass()
-{
-    var input = @"class StringProcessor
+
+    [Fact]
+    public void ConvertToExtensionMethodInSource_AppendsToExistingClass()
+    {
+        var input = @"class StringProcessor
 {
     void FormatText()
     {
@@ -62,11 +64,13 @@ public static class StringProcessorExtensions
     }
 }";
         var output = ConvertToExtensionMethodTool.ConvertToExtensionMethodInSource(input, "FormatText", "StringProcessorExtensions");
-Assert.Equal(expected, output.Trim());
+        Assert.Equal(expected, output.Trim());
     }
-public void ConvertToStaticWithInstanceInSource_TransformsMethod()
-{
-    var input = @"class DataProcessor
+
+    [Fact]
+    public void ConvertToStaticWithInstanceInSource_TransformsMethod()
+    {
+        var input = @"class DataProcessor
 {
     int dataCount;
     int GetDataCount()
@@ -74,7 +78,7 @@ public void ConvertToStaticWithInstanceInSource_TransformsMethod()
         return dataCount;
     }
 }";
-    var expected = @"class DataProcessor
+        var expected = @"class DataProcessor
 {
     int dataCount;
 
@@ -83,13 +87,14 @@ public void ConvertToStaticWithInstanceInSource_TransformsMethod()
         return instance.dataCount;
     }
 }";
-    var output = ConvertToStaticWithInstanceTool.ConvertToStaticWithInstanceInSource(input, "GetDataCount", "instance");
-    Assert.Equal(expected, output.Trim());
-}
+        var output = ConvertToStaticWithInstanceTool.ConvertToStaticWithInstanceInSource(input, "GetDataCount", "instance");
+        Assert.Equal(expected, output.Trim());
+    }
 
-public void ConvertToStaticWithParametersInSource_TransformsMethod()
-{
-    var input = @"class Calculator
+    [Fact]
+    public void ConvertToStaticWithParametersInSource_TransformsMethod()
+    {
+        var input = @"class Calculator
 {
     int multiplier;
     int MultiplyValue()
@@ -97,7 +102,7 @@ public void ConvertToStaticWithParametersInSource_TransformsMethod()
         return multiplier;
     }
 }";
-    var expected = @"class Calculator
+        var expected = @"class Calculator
 {
     int multiplier;
 
@@ -106,7 +111,7 @@ public void ConvertToStaticWithParametersInSource_TransformsMethod()
         return multiplier;
     }
 }";
-    var output = ConvertToStaticWithParametersTool.ConvertToStaticWithParametersInSource(input, "MultiplyValue");
-    Assert.Equal(expected, output.Trim());
-}
+        var output = ConvertToStaticWithParametersTool.ConvertToStaticWithParametersInSource(input, "MultiplyValue");
+        Assert.Equal(expected, output.Trim());
+    }
 }


### PR DESCRIPTION
## Summary
- support converting instance methods to extension methods via new `ExtensionMethodRewriter`
- simplify `ConvertToExtensionMethodTool` using the rewriter
- auto format of Roslyn tests

## Testing
- `dotnet format -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684c0d597cd08327afe46543be064734