### PR TITLE
Refactor readonly/init helpers

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/SyntaxRewriters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SyntaxRewriters.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
+using System.Linq;
 
 internal class ParameterRewriter : CSharpSyntaxRewriter
 {
@@ -371,151 +372,218 @@ internal class ExtensionMethodRewriter : CSharpSyntaxRewriter
 }
 
 internal class StaticConversionRewriter : CSharpSyntaxRewriter
+{
+    private readonly List<ParameterSyntax> _parameters;
+    private readonly string? _instanceParameterName;
+    private readonly HashSet<string>? _knownInstanceMembers;
+    private readonly SemanticModel? _semanticModel;
+    private readonly INamedTypeSymbol? _typeSymbol;
+    private readonly Dictionary<ISymbol, string>? _symbolRenameMap;
+    private readonly Dictionary<string, string>? _nameRenameMap;
+
+    public StaticConversionRewriter(
+        IEnumerable<(string Name, string Type)> parameters,
+        string? instanceParameterName = null,
+        HashSet<string>? knownInstanceMembers = null,
+        SemanticModel? semanticModel = null,
+        INamedTypeSymbol? typeSymbol = null,
+        Dictionary<ISymbol, string>? symbolRenameMap = null,
+        Dictionary<string, string>? nameRenameMap = null)
     {
-        private readonly List<ParameterSyntax> _parameters;
-        private readonly string? _instanceParameterName;
-        private readonly HashSet<string>? _knownInstanceMembers;
-        private readonly SemanticModel? _semanticModel;
-        private readonly INamedTypeSymbol? _typeSymbol;
-        private readonly Dictionary<ISymbol, string>? _symbolRenameMap;
-        private readonly Dictionary<string, string>? _nameRenameMap;
+        _parameters = parameters
+            .Select(p => SyntaxFactory.Parameter(SyntaxFactory.Identifier(p.Name))
+                .WithType(SyntaxFactory.ParseTypeName(p.Type)))
+            .ToList();
+        _instanceParameterName = instanceParameterName;
+        _knownInstanceMembers = knownInstanceMembers;
+        _semanticModel = semanticModel;
+        _typeSymbol = typeSymbol;
+        _symbolRenameMap = symbolRenameMap;
+        _nameRenameMap = nameRenameMap;
+    }
 
-        public StaticConversionRewriter(
-            IEnumerable<(string Name, string Type)> parameters,
-            string? instanceParameterName = null,
-            HashSet<string>? knownInstanceMembers = null,
-            SemanticModel? semanticModel = null,
-            INamedTypeSymbol? typeSymbol = null,
-            Dictionary<ISymbol, string>? symbolRenameMap = null,
-            Dictionary<string, string>? nameRenameMap = null)
+    public MethodDeclarationSyntax Rewrite(MethodDeclarationSyntax method)
+    {
+        var visited = (MethodDeclarationSyntax)Visit(method)!;
+        if (_parameters.Count > 0)
+            visited = visited.WithParameterList(method.ParameterList.AddParameters(_parameters.ToArray()));
+        visited = AstTransformations.EnsureStaticModifier(visited);
+        return visited;
+    }
+
+    public override SyntaxNode VisitThisExpression(ThisExpressionSyntax node)
+    {
+        if (_instanceParameterName != null)
+            return SyntaxFactory.IdentifierName(_instanceParameterName).WithTriviaFrom(node);
+        return base.VisitThisExpression(node);
+    }
+
+    public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        if (_semanticModel != null && _symbolRenameMap != null &&
+            _semanticModel.GetSymbolInfo(node).Symbol is ISymbol sym &&
+            _symbolRenameMap.TryGetValue(sym, out var newName))
         {
-            _parameters = parameters
-                .Select(p => SyntaxFactory.Parameter(SyntaxFactory.Identifier(p.Name))
-                    .WithType(SyntaxFactory.ParseTypeName(p.Type)))
-                .ToList();
-            _instanceParameterName = instanceParameterName;
-            _knownInstanceMembers = knownInstanceMembers;
-            _semanticModel = semanticModel;
-            _typeSymbol = typeSymbol;
-            _symbolRenameMap = symbolRenameMap;
-            _nameRenameMap = nameRenameMap;
+            return SyntaxFactory.IdentifierName(newName).WithTriviaFrom(node);
         }
 
-        public MethodDeclarationSyntax Rewrite(MethodDeclarationSyntax method)
+        if (_nameRenameMap != null &&
+            _nameRenameMap.TryGetValue(node.Identifier.ValueText, out var n))
         {
-            var visited = (MethodDeclarationSyntax)Visit(method)!;
-            if (_parameters.Count > 0)
-                visited = visited.WithParameterList(method.ParameterList.AddParameters(_parameters.ToArray()));
-            visited = AstTransformations.EnsureStaticModifier(visited);
-            return visited;
+            return SyntaxFactory.IdentifierName(n).WithTriviaFrom(node);
         }
 
-        public override SyntaxNode VisitThisExpression(ThisExpressionSyntax node)
+        bool qualify = false;
+        if (_instanceParameterName != null)
         {
-            if (_instanceParameterName != null)
-                return SyntaxFactory.IdentifierName(_instanceParameterName).WithTriviaFrom(node);
-            return base.VisitThisExpression(node);
-        }
-
-        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
-        {
-            if (_semanticModel != null && _symbolRenameMap != null &&
-                _semanticModel.GetSymbolInfo(node).Symbol is ISymbol sym &&
-                _symbolRenameMap.TryGetValue(sym, out var newName))
+            if (_semanticModel != null && _typeSymbol != null)
             {
-                return SyntaxFactory.IdentifierName(newName).WithTriviaFrom(node);
-            }
-
-            if (_nameRenameMap != null &&
-                _nameRenameMap.TryGetValue(node.Identifier.ValueText, out var n))
-            {
-                return SyntaxFactory.IdentifierName(n).WithTriviaFrom(node);
-            }
-
-            bool qualify = false;
-            if (_instanceParameterName != null)
-            {
-                if (_semanticModel != null && _typeSymbol != null)
-                {
-                    var s = _semanticModel.GetSymbolInfo(node).Symbol;
-                    if (s is IFieldSymbol or IPropertySymbol or IMethodSymbol &&
-                        SymbolEqualityComparer.Default.Equals(s.ContainingType, _typeSymbol) &&
-                        !s.IsStatic && node.Parent is not MemberAccessExpressionSyntax)
-                    {
-                        qualify = true;
-                    }
-                }
-                else if (_knownInstanceMembers != null &&
-                         _knownInstanceMembers.Contains(node.Identifier.ValueText) &&
-                         node.Parent is not MemberAccessExpressionSyntax)
+                var s = _semanticModel.GetSymbolInfo(node).Symbol;
+                if (s is IFieldSymbol or IPropertySymbol or IMethodSymbol &&
+                    SymbolEqualityComparer.Default.Equals(s.ContainingType, _typeSymbol) &&
+                    !s.IsStatic && node.Parent is not MemberAccessExpressionSyntax)
                 {
                     qualify = true;
                 }
             }
-
-            if (qualify)
+            else if (_knownInstanceMembers != null &&
+                     _knownInstanceMembers.Contains(node.Identifier.ValueText) &&
+                     node.Parent is not MemberAccessExpressionSyntax)
             {
-                return SyntaxFactory.MemberAccessExpression(
-                        SyntaxKind.SimpleMemberAccessExpression,
-                        SyntaxFactory.IdentifierName(_instanceParameterName!),
-                        node.WithoutTrivia())
-                    .WithTriviaFrom(node);
+                qualify = true;
             }
-
-            return base.VisitIdentifierName(node);
         }
-    }
 
-    internal class ParameterIntroductionRewriter : CSharpSyntaxRewriter
+        if (qualify)
+        {
+            return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(_instanceParameterName!),
+                    node.WithoutTrivia())
+                .WithTriviaFrom(node);
+        }
+
+        return base.VisitIdentifierName(node);
+    }
+}
+
+internal class ParameterIntroductionRewriter : CSharpSyntaxRewriter
+{
+    private readonly ExpressionSyntax _targetExpression;
+    private readonly string _methodName;
+    private readonly ParameterSyntax _parameter;
+    private readonly IdentifierNameSyntax _parameterReference;
+
+    public ParameterIntroductionRewriter(
+        ExpressionSyntax targetExpression,
+        string methodName,
+        ParameterSyntax parameter,
+        IdentifierNameSyntax parameterReference)
     {
-        private readonly ExpressionSyntax _targetExpression;
-        private readonly string _methodName;
-        private readonly ParameterSyntax _parameter;
-        private readonly IdentifierNameSyntax _parameterReference;
-
-        public ParameterIntroductionRewriter(
-            ExpressionSyntax targetExpression,
-            string methodName,
-            ParameterSyntax parameter,
-            IdentifierNameSyntax parameterReference)
-        {
-            _targetExpression = targetExpression;
-            _methodName = methodName;
-            _parameter = parameter;
-            _parameterReference = parameterReference;
-        }
-
-        public override SyntaxNode Visit(SyntaxNode node)
-        {
-            if (node is ExpressionSyntax expr && SyntaxFactory.AreEquivalent(expr, _targetExpression))
-                return _parameterReference;
-
-            return base.Visit(node);
-        }
-
-        public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
-        {
-            var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node);
-            var isTarget =
-                (visited.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == _methodName) ||
-                (visited.Expression is MemberAccessExpressionSyntax ma && ma.Name.Identifier.ValueText == _methodName);
-
-            if (isTarget)
-            {
-                var newArgs = visited.ArgumentList.AddArguments(SyntaxFactory.Argument(_targetExpression.WithoutTrivia()));
-                visited = visited.WithArgumentList(newArgs);
-            }
-
-            return visited;
-        }
-
-        public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
-        {
-            var visited = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node);
-            if (node.Identifier.ValueText == _methodName)
-                visited = visited.AddParameterListParameters(_parameter);
-
-            return visited;
-
-        }
+        _targetExpression = targetExpression;
+        _methodName = methodName;
+        _parameter = parameter;
+        _parameterReference = parameterReference;
     }
+
+    public override SyntaxNode Visit(SyntaxNode node)
+    {
+        if (node is ExpressionSyntax expr && SyntaxFactory.AreEquivalent(expr, _targetExpression))
+            return _parameterReference;
+
+        return base.Visit(node);
+    }
+
+    public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node);
+        var isTarget =
+            (visited.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == _methodName) ||
+            (visited.Expression is MemberAccessExpressionSyntax ma && ma.Name.Identifier.ValueText == _methodName);
+
+        if (isTarget)
+        {
+            var newArgs = visited.ArgumentList.AddArguments(SyntaxFactory.Argument(_targetExpression.WithoutTrivia()));
+            visited = visited.WithArgumentList(newArgs);
+        }
+
+        return visited;
+    }
+
+    public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
+    {
+        var visited = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node);
+        if (node.Identifier.ValueText == _methodName)
+            visited = visited.AddParameterListParameters(_parameter);
+
+        return visited;
+
+    }
+}
+
+internal class ReadonlyFieldRewriter : CSharpSyntaxRewriter
+{
+    private readonly string _fieldName;
+    private readonly ExpressionSyntax? _initializer;
+
+    public ReadonlyFieldRewriter(string fieldName, ExpressionSyntax? initializer)
+    {
+        _fieldName = fieldName;
+        _initializer = initializer;
+    }
+
+    public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
+    {
+        var variable = node.Declaration.Variables.FirstOrDefault(v => v.Identifier.ValueText == _fieldName);
+        if (variable == null)
+            return base.VisitFieldDeclaration(node);
+
+        var newVariable = variable.WithInitializer(null);
+        var newDecl = node.Declaration.ReplaceNode(variable, newVariable);
+        var modifiers = node.Modifiers;
+        if (!modifiers.Any(m => m.IsKind(SyntaxKind.ReadOnlyKeyword)))
+            modifiers = modifiers.Add(SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
+
+        return node.WithDeclaration(newDecl).WithModifiers(modifiers);
+    }
+
+    public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+    {
+        var visited = (ConstructorDeclarationSyntax)base.VisitConstructorDeclaration(node);
+        if (_initializer != null)
+        {
+            var assignment = SyntaxFactory.ExpressionStatement(
+                SyntaxFactory.AssignmentExpression(
+                    SyntaxKind.SimpleAssignmentExpression,
+                    SyntaxFactory.IdentifierName(_fieldName),
+                    _initializer));
+            var body = visited.Body ?? SyntaxFactory.Block();
+            visited = visited.WithBody(body.AddStatements(assignment));
+        }
+        return visited;
+    }
+}
+
+internal class SetterToInitRewriter : CSharpSyntaxRewriter
+{
+    private readonly string _propertyName;
+    public SetterToInitRewriter(string propertyName)
+    {
+        _propertyName = propertyName;
+    }
+
+    public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+    {
+        if (node.Identifier.ValueText != _propertyName)
+            return base.VisitPropertyDeclaration(node);
+
+        var setter = node.AccessorList?.Accessors.FirstOrDefault(a => a.IsKind(SyntaxKind.SetAccessorDeclaration));
+        if (setter == null)
+            return base.VisitPropertyDeclaration(node);
+
+        var initAccessor = SyntaxFactory.AccessorDeclaration(SyntaxKind.InitAccessorDeclaration)
+            .WithSemicolonToken(setter.SemicolonToken);
+        var newAccessorList = node.AccessorList.ReplaceNode(setter, initAccessor);
+        return node.WithAccessorList(newAccessorList);
+    }
+}

--- a/RefactorMCP.Tests/Split/TestUtilities.cs
+++ b/RefactorMCP.Tests/Split/TestUtilities.cs
@@ -60,6 +60,9 @@ public class TestClass
 }
 """;
 
+    public static string GetSampleCodeForTransformSetter() =>
+        File.ReadAllText(Path.Combine(Path.GetDirectoryName(GetSolutionPath())!, "RefactorMCP.Tests", "ExampleCode.cs"));
+
     public static string GetSampleCodeForConvertToStaticInstance() =>
         File.ReadAllText(Path.Combine(Path.GetDirectoryName(GetSolutionPath())!, "RefactorMCP.Tests", "ExampleCode.cs"));
 

--- a/RefactorMCP.Tests/Split/TransformSetterToInitTests.cs
+++ b/RefactorMCP.Tests/Split/TransformSetterToInitTests.cs
@@ -1,0 +1,37 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class TransformSetterToInitTests : TestBase
+{
+    [Fact]
+    public async Task TransformSetterToInit_PropertyWithSetter_ReturnsSuccess()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var testFile = Path.Combine(TestOutputPath, "TransformSetterToInit.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForTransformSetter());
+
+        var result = await TransformSetterToInitTool.TransformSetterToInit(
+            SolutionPath,
+            testFile,
+            "Name");
+
+        Assert.Contains("Successfully converted setter to init", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.Contains("init;", fileContent);
+    }
+
+    [Fact]
+    public async Task TransformSetterToInit_InvalidProperty_ReturnsError()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        await Assert.ThrowsAsync<McpException>(async () =>
+            await TransformSetterToInitTool.TransformSetterToInit(
+                SolutionPath,
+                ExampleFilePath,
+                "Nonexistent"));
+    }
+}


### PR DESCRIPTION
## Summary
- create `ReadonlyFieldRewriter` and `SetterToInitRewriter`
- simplify `MakeFieldReadonlyTool` and `TransformSetterToInitTool`
- add CLI tests for init-only conversion

## Testing
- `dotnet format --no-restore`
- `dotnet test RefactorMCP.Tests/RefactorMCP.Tests.csproj --no-build --verbosity normal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_684c139fd2708327811df5be03028130