### PR TITLE
Add inline invocation rewriter

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
@@ -8,53 +8,33 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.FindSymbols;
 using System.Linq;
 using System.IO;
-using System.Collections.Generic;
 
 [McpServerToolType]
 public static class InlineMethodTool
 {
 
-    private static SyntaxNode InlineInvocation(MethodDeclarationSyntax method, InvocationExpressionSyntax invocation)
-    {
-        var argMap = method.ParameterList.Parameters
-            .Zip(invocation.ArgumentList.Arguments, (p, a) => new { p, a })
-            .ToDictionary(x => x.p.Identifier.ValueText, x => x.a.Expression);
-
-        var rewriter = new ParameterRewriter(argMap);
-        var statements = method.Body!.Statements.Select(s => (StatementSyntax)rewriter.Visit(s)!);
-        var stmt = invocation.FirstAncestorOrSelf<ExpressionStatementSyntax>();
-        if (stmt != null && method.ReturnType is PredefinedTypeSyntax pts && pts.Keyword.IsKind(SyntaxKind.VoidKeyword))
-        {
-            return SyntaxFactory.Block(statements);
-        }
-        return invocation;
-    }
-
     private static async Task InlineReferences(MethodDeclarationSyntax method, Solution solution, ISymbol methodSymbol)
     {
         var refs = await SymbolFinder.FindReferencesAsync(methodSymbol, solution);
-        foreach (var loc in refs.SelectMany(r => r.Locations))
+        var documents = refs.SelectMany(r => r.Locations)
+            .Where(l => l.Location.IsInSource)
+            .Select(l => solution.GetDocument(l.Location.SourceTree)!)
+            .Distinct();
+
+        foreach (var refDoc in documents)
         {
-            if (!loc.Location.IsInSource) continue;
-            var refDoc = solution.GetDocument(loc.Location.SourceTree)!;
             var refRoot = await refDoc.GetSyntaxRootAsync();
-            var node = refRoot!.FindNode(loc.Location.SourceSpan);
-            var invocation = node.FirstAncestorOrSelf<InvocationExpressionSyntax>();
-            if (invocation == null) continue;
-            var inlineBlock = InlineInvocation(method, invocation);
-            SyntaxNode newRefRoot;
-            if (inlineBlock is BlockSyntax block && invocation.Parent is ExpressionStatementSyntax stmt)
+            var semanticModel = await refDoc.GetSemanticModelAsync();
+            var rewriter = new InlineInvocationRewriter(method, semanticModel!, (IMethodSymbol)methodSymbol);
+            var newRoot = rewriter.Visit(refRoot!);
+
+            if (!ReferenceEquals(refRoot, newRoot))
             {
-                newRefRoot = refRoot.ReplaceNode(stmt, block.Statements);
+                var formatted = Formatter.Format(newRoot!, refDoc.Project.Solution.Workspace);
+                var newDoc = refDoc.WithSyntaxRoot(formatted);
+                var text = await newDoc.GetTextAsync();
+                await File.WriteAllTextAsync(refDoc.FilePath!, text.ToString());
             }
-            else
-            {
-                continue;
-            }
-            var formatted = Formatter.Format(newRefRoot, refDoc.Project.Solution.Workspace);
-            var newDoc = refDoc.WithSyntaxRoot(formatted);
-            var text = await newDoc.GetTextAsync();
-            await File.WriteAllTextAsync(refDoc.FilePath!, text.ToString());
         }
     }
 
@@ -71,7 +51,11 @@ public static class InlineMethodTool
         var symbol = semanticModel!.GetDeclaredSymbol(method)!;
         await InlineReferences(method, document.Project.Solution, symbol);
 
-        var newRoot = (await document.GetSyntaxRootAsync())!.RemoveNode(method, SyntaxRemoveOptions.KeepNoTrivia);
+        var newRoot = await document.GetSyntaxRootAsync();
+        var updatedMethod = newRoot!.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .First(m => m.Identifier.ValueText == methodName);
+        newRoot = newRoot.RemoveNode(updatedMethod, SyntaxRemoveOptions.KeepNoTrivia);
         var formattedRoot = Formatter.Format(newRoot, document.Project.Solution.Workspace);
         var newDocument = document.WithSyntaxRoot(formattedRoot);
         var newText = await newDocument.GetTextAsync();
@@ -97,24 +81,13 @@ public static class InlineMethodTool
         if (method == null)
             return RefactoringHelpers.ThrowMcpException($"Error: Method '{methodName}' not found or has parameters");
 
-        var bodyText = string.Join("\n", method.Body!.Statements.Select(s => s.ToFullString()));
-
-        var invocationNodes = root.DescendantNodes().OfType<InvocationExpressionSyntax>()
-            .Where(i => i.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == methodName)
-            .ToList();
-
-        foreach (var inv in invocationNodes)
-        {
-            var stmt = inv.FirstAncestorOrSelf<ExpressionStatementSyntax>();
-            if (stmt != null)
-            {
-                var newStmt = SyntaxFactory.ParseStatement(bodyText);
-                root = root.ReplaceNode(stmt, newStmt);
-            }
-        }
-
-        root = root.RemoveNode(method, SyntaxRemoveOptions.KeepNoTrivia);
-        var formatted = Formatter.Format(root, RefactoringHelpers.SharedWorkspace);
+        var rewriter = new InlineInvocationRewriter(method);
+        var newRoot = rewriter.Visit(root)!;
+        var updatedMethod = newRoot.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .First(m => m.Identifier.ValueText == methodName && m.ParameterList.Parameters.Count == 0);
+        newRoot = newRoot.RemoveNode(updatedMethod, SyntaxRemoveOptions.KeepNoTrivia);
+        var formatted = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
         return formatted.ToFullString();
     }
 

--- a/RefactorMCP.ConsoleApp/Tools/SyntaxRewriters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SyntaxRewriters.cs
@@ -587,3 +587,65 @@ internal class SetterToInitRewriter : CSharpSyntaxRewriter
         return node.WithAccessorList(newAccessorList);
     }
 }
+
+internal class InlineInvocationRewriter : CSharpSyntaxRewriter
+{
+    private readonly MethodDeclarationSyntax _method;
+    private readonly IMethodSymbol? _methodSymbol;
+    private readonly SemanticModel? _semanticModel;
+
+    public InlineInvocationRewriter(MethodDeclarationSyntax method)
+    {
+        _method = method;
+    }
+
+    public InlineInvocationRewriter(MethodDeclarationSyntax method, SemanticModel semanticModel, IMethodSymbol methodSymbol)
+    {
+        _method = method;
+        _semanticModel = semanticModel;
+        _methodSymbol = methodSymbol;
+    }
+
+    private bool IsTargetInvocation(InvocationExpressionSyntax node)
+    {
+        if (_semanticModel != null && _methodSymbol != null)
+        {
+            var symbol = _semanticModel.GetSymbolInfo(node).Symbol as IMethodSymbol;
+            if (symbol != null && SymbolEqualityComparer.Default.Equals(symbol, _methodSymbol))
+                return true;
+        }
+
+        if (node.Expression is IdentifierNameSyntax id)
+            return id.Identifier.ValueText == _method.Identifier.ValueText;
+
+        return false;
+    }
+
+    public override SyntaxNode VisitBlock(BlockSyntax node)
+    {
+        var newStatements = new List<StatementSyntax>();
+        foreach (var stmt in node.Statements)
+        {
+            if (stmt is ExpressionStatementSyntax expr &&
+                expr.Expression is InvocationExpressionSyntax invocation &&
+                IsTargetInvocation(invocation) &&
+                _method.ReturnType is PredefinedTypeSyntax pts &&
+                pts.Keyword.IsKind(SyntaxKind.VoidKeyword))
+            {
+                var argMap = _method.ParameterList.Parameters
+                    .Zip(invocation.ArgumentList.Arguments, (p, a) => new { p, a })
+                    .ToDictionary(x => x.p.Identifier.ValueText, x => x.a.Expression);
+
+                var rewriter = new ParameterRewriter(argMap);
+                var stmts = _method.Body!.Statements.Select(s => (StatementSyntax)rewriter.Visit(s)!);
+                newStatements.AddRange(stmts);
+            }
+            else
+            {
+                newStatements.Add((StatementSyntax)Visit(stmt)!);
+            }
+        }
+
+        return node.WithStatements(SyntaxFactory.List(newStatements));
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/InlineMethodTests.cs
+++ b/RefactorMCP.Tests/Roslyn/InlineMethodTests.cs
@@ -1,0 +1,28 @@
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void InlineMethodInSource_ReplacesInvocationWithBody()
+    {
+        var input = @"class InlineSample
+{
+    private void Helper()
+    {
+        Console.WriteLine(""Hi"");
+    }
+
+    public void Call()
+    {
+        Helper();
+        Console.WriteLine(""Done"");
+    }
+}";
+        var expected = "class InlineSample\n{\n\n    public void Call()\n    {\n        Console.WriteLine(\"Hi\");\n        Console.WriteLine(\"Done\");\n    }\n}";
+        var output = InlineMethodTool.InlineMethodInSource(input, "Helper");
+        Assert.Equal(expected, output.Trim());
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement `InlineInvocationRewriter` for expanding method calls
- integrate rewriter into `InlineMethodTool`
- add Roslyn test covering `InlineMethodInSource`

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build -v n`

------
https://chatgpt.com/codex/tasks/task_e_684c178dea188327a9f8e2e970e74d8f