### PR TITLE
Ensure this parameter added first

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
@@ -357,8 +357,8 @@ public static class MoveMethodsTool
         var sourceParameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier(context.SourceClassName.ToLower()))
             .WithType(SyntaxFactory.IdentifierName(context.SourceClassName));
 
-        var newParameters = method.ParameterList.Parameters.Concat(new[] { sourceParameter });
-        var newParameterList = SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(newParameters));
+        var parameters = method.ParameterList.Parameters.Insert(0, sourceParameter);
+        var newParameterList = method.ParameterList.WithParameters(parameters);
 
         return method.WithParameterList(newParameterList);
     }

--- a/RefactorMCP.ConsoleApp/Tools/SyntaxRewriters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SyntaxRewriters.cs
@@ -328,7 +328,8 @@ internal class ExtensionMethodRewriter : CSharpSyntaxRewriter
             .WithType(SyntaxFactory.ParseTypeName(_parameterType))
             .AddModifiers(SyntaxFactory.Token(SyntaxKind.ThisKeyword));
 
-        var updated = node.WithParameterList(node.ParameterList.AddParameters(thisParam));
+        var parameters = node.ParameterList.Parameters.Insert(0, thisParam);
+        var updated = node.WithParameterList(node.ParameterList.WithParameters(parameters));
         updated = AstTransformations.EnsureStaticModifier(updated);
         return base.VisitMethodDeclaration(updated);
     }
@@ -407,7 +408,10 @@ internal class StaticConversionRewriter : CSharpSyntaxRewriter
     {
         var visited = (MethodDeclarationSyntax)Visit(method)!;
         if (_parameters.Count > 0)
-            visited = visited.WithParameterList(method.ParameterList.AddParameters(_parameters.ToArray()));
+        {
+            var newParameters = method.ParameterList.Parameters.InsertRange(0, _parameters);
+            visited = visited.WithParameterList(method.ParameterList.WithParameters(newParameters));
+        }
         visited = AstTransformations.EnsureStaticModifier(visited);
         return visited;
     }

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -484,7 +484,7 @@ class MathOperations
     {
         Console.WriteLine($""Performing {operation}"");
     }
-    public int PerformCalculation(int a, int b, string operation, Calculator calculator)
+    public int PerformCalculation(Calculator calculator, int a, int b, string operation)
     {
         LogOperation(operation);
         return operation == ""+"" ? a + b : a - b;
@@ -817,7 +817,7 @@ class MathOperations
 
 class MathOperations
 {
-    public int Square(int number, Calculator calculator)
+    public int Square(Calculator calculator, int number)
     {
         return calculator.Multiply(number, number);
     }
@@ -1004,7 +1004,7 @@ class MathOperations
 
 class MathOperations
 {
-    public int Factorial(int n, Calculator calculator)
+    public int Factorial(Calculator calculator, int n)
     {
         if (n <= 1) return 1;
         return n * calculator.Factorial(n - 1);


### PR DESCRIPTION
## Summary
- ensure added 'this' parameters appear first when moving or converting methods
- update tests for new parameter positions

## Testing
- `dotnet format RefactorMCP.sln --verbosity minimal`
- `dotnet test RefactorMCP.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_684c2ddf9ee08327a742eef4235e5737