### PR TITLE
Check for duplicate classes before creation

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
@@ -89,6 +89,9 @@ public static class ConvertToExtensionMethodTool
         }
         else
         {
+            var duplicateDoc = await RefactoringHelpers.FindClassInSolution(document.Project.Solution, extClassName, document.FilePath);
+            if (duplicateDoc != null)
+                return RefactoringHelpers.ThrowMcpException($"Error: Class {extClassName} already exists in {duplicateDoc.FilePath}");
             var extensionClassDecl = SyntaxFactory.ClassDeclaration(extClassName)
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword), SyntaxFactory.Token(SyntaxKind.StaticKeyword))
                 .AddMembers(updatedMethod);

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
@@ -969,6 +969,14 @@ public static class MoveMethodsTool
             ValidateFileExists(filePath);
 
             var moveContext = await PrepareStaticMethodMove(filePath, targetFilePath, targetClass);
+            var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
+            var duplicateDoc = await RefactoringHelpers.FindClassInSolution(
+                solution,
+                targetClass,
+                filePath,
+                moveContext.TargetPath);
+            if (duplicateDoc != null)
+                return RefactoringHelpers.ThrowMcpException($"Error: Class {targetClass} already exists in {duplicateDoc.FilePath}");
             var method = ExtractStaticMethodFromSource(moveContext.SourceRoot, methodName);
             var updatedSources = UpdateSourceAndTargetForStaticMove(moveContext, method);
             await WriteStaticMethodMoveResults(moveContext, updatedSources);
@@ -1124,6 +1132,14 @@ public static class MoveMethodsTool
 
             var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
             var document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
+
+            var duplicateDoc = await RefactoringHelpers.FindClassInSolution(
+                solution,
+                targetClass,
+                filePath,
+                targetFilePath ?? Path.Combine(Path.GetDirectoryName(filePath)!, $"{targetClass}.cs"));
+            if (duplicateDoc != null)
+                return RefactoringHelpers.ThrowMcpException($"Error: Class {targetClass} already exists in {duplicateDoc.FilePath}");
 
             return await MoveMethods(filePath, sourceClass, targetClass, accessMemberName, accessMemberType, targetFilePath, methodList, document);
         }

--- a/RefactorMCP.Tests/Split/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Split/MoveInstanceMethodTests.cs
@@ -13,21 +13,22 @@ public class MoveInstanceMethodTests : TestBase
     [Fact]
     public async Task MoveInstanceMethod_ReturnsSuccess()
     {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MoveInstanceMethod.cs"));
+        await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public class B { }");
         await LoadSolutionTool.LoadSolution(SolutionPath);
-        var testFile = Path.Combine(TestOutputPath, "MoveInstanceMethod.cs");
-        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForMoveInstanceMethod());
 
         var result = await MoveMethodsTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
-            "Calculator",
-            "LogOperation",
-            "Logger",
-            "_logger",
+            "A",
+            "Do",
+            "B",
+            "_b",
             "field");
 
         Assert.Contains("Successfully moved", result);
-        Assert.Contains("Calculator.LogOperation", result);
-        Assert.Contains("Logger", result);
+        Assert.Contains("A.Do", result);
+        Assert.Contains("B", result);
     }
 }

--- a/RefactorMCP.Tests/Split/MoveStaticMethodTests.cs
+++ b/RefactorMCP.Tests/Split/MoveStaticMethodTests.cs
@@ -13,20 +13,20 @@ public class MoveStaticMethodTests : TestBase
     [Fact]
     public async Task MoveStaticMethod_ReturnsSuccess()
     {
-        await LoadSolutionTool.LoadSolution(SolutionPath);
+        UnloadSolutionTool.ClearSolutionCache();
         var testFile = Path.Combine(TestOutputPath, "MoveStaticMethod.cs");
-        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForMoveStaticMethod());
+        await TestUtilities.CreateTestFile(testFile, "public class SourceClass { public static void Foo(){} } public class TargetClass { } ");
 
         var result = await MoveMethodsTool.MoveStaticMethod(
             SolutionPath,
             testFile,
-            "FormatCurrency",
-            "MathUtilities");
+            "Foo",
+            "TargetClass");
 
         Assert.Contains("Successfully moved static method", result);
         var fileContent = await File.ReadAllTextAsync(testFile);
-        Assert.DoesNotContain("static string FormatCurrency", fileContent);
-        Assert.Contains("class MathUtilities", fileContent);
+        Assert.DoesNotContain("static void Foo()", fileContent);
+        Assert.Contains("class TargetClass", fileContent);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- add helper to find classes across solution
- ensure MoveClassToFile throws when target class or file already exists
- prevent duplicate extension class creation
- validate destination classes in MoveMethods
- update unit tests for the new behavior

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684c2da9303c8327a89ccc3a40167714