### PR TITLE
Remove personal paths from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Add the following configuration to your `mcp.json` file:
       "args": [
         "run"
       ],
-      "cwd": "/Users/davidhillier/repos/RefactorMCP/RefactorMCP.ConsoleApp"
+      "cwd": "/path/to/RefactorMCP/RefactorMCP.ConsoleApp"
     }
   }
 }
@@ -93,9 +93,9 @@ Replace the paths with your actual installation directory:
       "args": [
         "run",
         "--project",
-        "/Users/username/repos/RefactorMCP/RefactorMCP.ConsoleApp"
+        "/path/to/RefactorMCP/RefactorMCP.ConsoleApp"
       ],
-      "cwd": "/Users/username/repos/RefactorMCP"
+      "cwd": "/path/to/RefactorMCP"
     }
   }
 }


### PR DESCRIPTION
## Summary
- sanitize personal paths in JSON config examples

## Testing
- `dotnet format --no-restore --verify-no-changes -v diag`
- `dotnet test --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_684c3bb88714832797a18f5ac4ee2809