### PR TITLE
Allow moving multiple methods in solution

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.cs
@@ -280,7 +280,7 @@ public static class MoveMultipleMethodsTool
                 {
                     var (msg, updatedDoc) = await MoveMethodsTool.MoveStaticMethodWithSolution(
                         currentDocument,
-                        op.Method,
+                        new[] { op.Method },
                         op.TargetClass,
                         op.TargetFile);
                     results.Add(msg);
@@ -292,7 +292,7 @@ public static class MoveMultipleMethodsTool
                     var (msg, updatedDoc) = await MoveMethodsTool.MoveInstanceMethodWithSolution(
                         currentDocument,
                         op.SourceClass,
-                        op.Method,
+                        new[] { op.Method },
                         op.TargetClass,
                         op.AccessMember,
                         op.AccessMemberType);


### PR DESCRIPTION
## Summary
- support passing multiple method names to `MoveInstanceMethodWithSolution` and `MoveStaticMethodWithSolution`
- update `MoveMethods` helper and `MoveMultipleMethodsTool` to use the new API

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet test --no-build -v n`

------
https://chatgpt.com/codex/tasks/task_e_684c3f9f6cd8832797b4f5a0a13e995d