### PR TITLE
Add class length metrics prompt

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -691,6 +691,24 @@ Suggestions:
 - Field 'deprecatedCounter' appears unused -> safe-delete-field
 ```
 
+## 14. List Class Lengths
+
+**Purpose**: Display each class in the solution with its number of lines as a simple complexity metric.
+
+### Example
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli list-class-lengths "./RefactorMCP.sln"
+```
+
+**Expected Output**:
+```
+Class lengths:
+Calculator - 82 lines
+MathUtilities - 4 lines
+Logger - 8 lines
+```
+
 ## Range Format
 
 All refactoring commands that require selecting code use the range format:

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -81,6 +81,13 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli analyze-refactoring-opportu
 ```
 Prompt the server to analyze the file and suggest possible refactorings such as extract-method or safe-delete-method.
 
+### List Class Lengths
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli list-class-lengths \
+  "./RefactorMCP.sln"
+```
+Show each class in the solution with its line count for complexity insight.
+
 ### Safe Delete Parameter
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --cli safe-delete-parameter \

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Model Context Protocol (MCP) server providing automated refactoring tools for 
 - **Single File Helpers**: In-memory transformations used for unit tests
 - **Comprehensive Refactoring Tools**: Extract methods, introduce variables/fields, make fields readonly, convert methods to extension methods, and more
 - **Analysis Prompt**: Inspect code for long methods, large classes, long parameter lists, unused methods or fields
+- **Class Length Metrics**: List classes in a solution with their line counts
 - **MCP Compatible**: Works with any MCP-compatible client
 - **Preferred for Large Files**: Invoking these tools via MCP is recommended for large code files
 
@@ -178,6 +179,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
  - `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
 - `version` - Show build version and timestamp
 - `analyze-refactoring-opportunities <solutionPath> <filePath>` - Prompt for refactoring suggestions (long methods, long parameter lists, unused code)
+- `list-class-lengths <solutionPath>` - Prompt for class names and line counts
 
 #### Quick Start Example
 

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -73,6 +73,7 @@ static async Task RunCliMode(string[] args)
         ["safe-delete-variable"] = TestSafeDeleteVariable,
         ["cleanup-usings"] = TestCleanupUsings,
         ["analyze-refactoring-opportunities"] = TestAnalyzeRefactoringOpportunities,
+        ["list-class-lengths"] = TestListClassLengths,
         ["list-tools"] = _ => Task.FromResult(ListAvailableTools()),
         ["version"] = _ => Task.FromResult(ShowVersionInfo())
     };
@@ -109,6 +110,7 @@ static void ShowCliHelp()
         Console.WriteLine($"  {tool}");
     Console.WriteLine("  list-tools - List all available refactoring tools");
     Console.WriteLine("  analyze-refactoring-opportunities <solutionPath> <filePath> - Analyze code for potential refactorings");
+    Console.WriteLine("  list-class-lengths <solutionPath> - Show line counts for all classes in the solution");
 
     Console.WriteLine();
     Console.WriteLine("Examples:");
@@ -118,6 +120,7 @@ static void ShowCliHelp()
     Console.WriteLine("  --cli make-field-readonly ./MySolution.sln ./MyFile.cs 15");
     Console.WriteLine("  --cli cleanup-usings ./MySolution.sln ./MyFile.cs");
     Console.WriteLine("  --cli analyze-refactoring-opportunities ./MySolution.sln ./MyFile.cs");
+    Console.WriteLine("  --cli list-class-lengths ./MySolution.sln");
     Console.WriteLine("  --cli version");
     Console.WriteLine();
     Console.WriteLine("JSON mode: --json ToolName '{\"param\":\"value\"}'");
@@ -507,4 +510,14 @@ static async Task<string> TestInlineMethod(string[] args)
     var methodName = args[4];
 
     return await InlineMethodTool.InlineMethod(solutionPath, filePath, methodName);
+}
+
+static async Task<string> TestListClassLengths(string[] args)
+{
+    if (args.Length < 3)
+        return "Error: Missing arguments. Usage: --cli list-class-lengths <solutionPath>";
+
+    var solutionPath = args[2];
+
+    return await ClassLengthMetricsTool.ListClassLengths(solutionPath);
 }

--- a/RefactorMCP.ConsoleApp/Tools/ClassLengthMetrics.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ClassLengthMetrics.cs
@@ -1,0 +1,45 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.ComponentModel;
+
+[McpServerToolType, McpServerPromptType]
+public static class ClassLengthMetricsTool
+{
+    [McpServerPrompt, Description("List all classes in the solution with their line counts")]
+    public static async Task<string> ListClassLengths(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath)
+    {
+        try
+        {
+            var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
+            var classes = new List<(string name, int lines)>();
+            foreach (var doc in solution.Projects.SelectMany(p => p.Documents))
+            {
+                var tree = await doc.GetSyntaxTreeAsync();
+                if (tree == null) continue;
+                var root = await tree.GetRootAsync();
+                foreach (var cls in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
+                {
+                    var span = tree.GetLineSpan(cls.Span);
+                    var lines = span.EndLinePosition.Line - span.StartLinePosition.Line + 1;
+                    classes.Add((cls.Identifier.Text, lines));
+                }
+            }
+            if (classes.Count == 0)
+                return "No classes found";
+
+            var ordered = classes.OrderByDescending(c => c.lines)
+                .Select(c => $"{c.name} - {c.lines} lines");
+            return "Class lengths:\n" + string.Join("\n", ordered);
+        }
+        catch (Exception ex)
+        {
+            throw new McpException($"Error analyzing classes: {ex.Message}", ex);
+        }
+    }
+}

--- a/RefactorMCP.Tests/ClassLengthMetricsTests.cs
+++ b/RefactorMCP.Tests/ClassLengthMetricsTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class ClassLengthMetricsTests : IDisposable
+{
+    private static readonly string SolutionPath = GetSolutionPath();
+    private readonly string _originalDir = Directory.GetCurrentDirectory();
+
+    public void Dispose()
+    {
+        Directory.SetCurrentDirectory(_originalDir);
+    }
+
+    private static string GetSolutionPath()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        var dir = new DirectoryInfo(currentDir);
+        while (dir != null)
+        {
+            var sln = Path.Combine(dir.FullName, "RefactorMCP.sln");
+            if (File.Exists(sln)) return sln;
+            dir = dir.Parent;
+        }
+        return "./RefactorMCP.sln";
+    }
+
+    [Fact]
+    public async Task ListClassLengths_ReturnsMetrics()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var result = await ClassLengthMetricsTool.ListClassLengths(SolutionPath);
+        Assert.Contains("Calculator", result);
+        Assert.Contains("MathUtilities", result);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ClassLengthMetricsTool` prompt to list classes in a solution and their line counts
- expose new `list-class-lengths` CLI command
- document the command in README, EXAMPLES and QUICK_REFERENCE
- include unit test for the new prompt

## Testing
- `dotnet format --verify-no-changes --verbosity diagnostic`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684c493e584883278e3a776fbcfa4315