### PR TITLE
Add overload for MoveMultipleMethods

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -359,7 +359,10 @@ class Target { }
 dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
-  "[{\"sourceClass\":\"Helper\",\"method\":\"A\",\"targetClass\":\"Target\",\"accessMember\":\"t\",\"accessMemberType\":\"field\"},{\"sourceClass\":\"Helper\",\"method\":\"B\",\"targetClass\":\"Target\",\"accessMember\":\"t\",\"accessMemberType\":\"field\"}]" \
+  Helper \
+  "A,B" \
+  Target \
+  t field \
   "./Target.cs"
 ```
 
@@ -370,7 +373,11 @@ Move methods to a separate file using the `targetFile` property or by passing a 
 dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
-  "[{\"sourceClass\":\"Helper\",\"method\":\"A\",\"targetClass\":\"Target\",\"accessMember\":\"t\",\"accessMemberType\":\"field\",\"isStatic\":false,\"targetFile\":\"./Target.cs\"}]"
+  Helper \
+  A \
+  Target \
+  t field \
+  "./Target.cs"
 ```
 
 **After**:

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -161,7 +161,10 @@ Newly added access fields are readonly and existing members are reused if presen
 dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
   "./RefactorMCP.sln" \
   "./path/to/file.cs" \
-  "[{'sourceClass':'A','method':'Foo','targetClass':'B','accessMember':'b','accessMemberType':'field','isStatic':false}]" \
+  SourceClass \
+  "Foo,Bar" \
+  TargetClass \
+  memberName field \
   "./optional/Target.cs"
 ```
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
 - `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
  - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]` - Move a static method to another class
  - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move one or more instance methods (comma separated names) to another class. Newly created access fields are marked `readonly` and won't duplicate existing members
- - `move-multiple-methods <solutionPath> <filePath> <operationsJson> [defaultTargetFilePath]` - Move multiple static or instance methods described by a JSON array. Each operation can specify `targetFile` or you can provide a `defaultTargetFilePath` for all operations
+ - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move multiple methods from one class to another. Accepts comma separated `methodNames`. The older JSON form is still supported for backward compatibility
  - `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
 - `version` - Show build version and timestamp
 - `analyze-refactoring-opportunities <solutionPath> <filePath>` - Prompt for refactoring suggestions (long methods, long parameter lists, unused code)


### PR DESCRIPTION
## Summary
- support MoveMultipleMethods via explicit parameters
- document new command usage

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684c456d73008327a3091e9d5671d0e5