### PR TITLE
Clarify interface-preserving refactorings

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -337,6 +337,7 @@ public class MathUtilities
     }
 }
 ```
+The original method remains in `ExampleCode.cs` as a wrapper that forwards to `MathUtilities.FormatCurrency`.
 
 ## 10. Move Multiple Methods
 
@@ -410,6 +411,7 @@ class Target
     }
 }
 ```
+Each moved method in `Helper` now delegates to the corresponding method on `Target`, preserving the original public interface.
 
 ## 11. Move Class to Separate File
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -72,6 +72,8 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method
   "./path/to/file.cs" \
   methodName
 ```
+The original method remains and calls the extension method so the interface stays the same.
+The original method remains and calls the extension method so the interface stays the same.
 
 ### Analyze Refactoring Opportunities
 ```bash
@@ -133,6 +135,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-static-method \
   TargetClass \
   "./optional/target.cs"
 ```
+Leaves a delegating method in the original class so existing calls still work.
 
 ### Inline Method
 ```bash
@@ -162,6 +165,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \
   "./optional/target.cs"
 ```
 Newly added access fields are readonly and existing members are reused if present.
+Each moved method leaves a wrapper that calls the new implementation.
 
 ### Move Multiple Methods
 ```bash
@@ -174,6 +178,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
   memberName field \
   "./optional/Target.cs"
 ```
+Wrapper methods remain in the source class, delegating to their moved versions.
 
 ### Move To Separate File
 ```bash
@@ -260,6 +265,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-static-with-inst
 # Move static method to MathUtilities
 dotnet run --project RefactorMCP.ConsoleApp -- --cli move-static-method \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" FormatCurrency MathUtilities
+# The original method stays as a wrapper
 # Convert method to extension
 dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" GetFormattedNumber

--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ After configuring, restart your MCP client. The RefactorMCP tools should be avai
 - `introduce_field` - Create fields from expressions
 - `introduce_variable` - Create variables from expressions
 - `make_field_readonly` - Convert fields to readonly
-- `convert_to_extension_method` - Transform instance methods into extension methods
+- `convert_to_extension_method` - Transform instance methods into extension methods while leaving a wrapper call in the original class
 - `convert_to_static` - Transform methods to static
-- `move_method` - Relocate methods between classes
+- `move_method` - Relocate methods between classes. A delegating wrapper remains so existing callers continue to compile
 - `safe_delete` - Remove unused code safely
 - `transform_property` - Convert setters to init-only
 
@@ -173,9 +173,9 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
 - `introduce-parameter <solutionPath> <filePath> <methodLine> <range> <parameterName>` - Create parameter from expression
 - `convert-to-static-with-parameters <solutionPath> <filePath> <methodLine>` - Convert instance method to static with parameters
 - `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
- - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]` - Move a static method to another class
- - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move one or more instance methods (comma separated names) to another class. Newly created access fields are marked `readonly` and won't duplicate existing members
- - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move multiple methods from one class to another. Accepts comma separated `methodNames`. The older JSON form is still supported for backward compatibility
+ - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]` - Move a static method to another class. A placeholder wrapper is left behind to delegate to the new location
+ - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move one or more instance methods to another class. Wrapper methods remain in the original class so existing callers continue to work
+ - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move multiple methods from one class to another. Each method leaves a delegating wrapper behind. Accepts comma separated `methodNames`. The older JSON form is still supported for backward compatibility
  - `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
 - `version` - Show build version and timestamp
 - `analyze-refactoring-opportunities <solutionPath> <filePath>` - Prompt for refactoring suggestions (long methods, long parameter lists, unused code)
@@ -419,6 +419,7 @@ public class MathUtilities
     }
 }
 ```
+The original `FormatCurrency` method remains in the source file as a wrapper that calls `MathUtilities.FormatCurrency`.
 
 ### 8. Inline Method
 

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
@@ -11,7 +11,8 @@ using System.Collections.Generic;
 [McpServerToolType]
 public static class ConvertToExtensionMethodTool
 {
-    [McpServerTool, Description("Convert an instance method to an extension method in a static class")]
+    [McpServerTool, Description("Convert an instance method to an extension method in a static class. " +
+        "A wrapper method remains so existing call sites continue to work.")]
     public static async Task<string> ConvertToExtensionMethod(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file")] string filePath,

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
@@ -972,7 +972,8 @@ public static class MoveMethodsTool
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword), SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
     }
 
-    [McpServerTool, Description("Move a static method to another class (preferred for large C# file refactoring)")]
+    [McpServerTool, Description("Move a static method to another class (preferred for large C# file refactoring). " +
+        "Leaves a delegating method in the original class to preserve the interface.")]
     public static async Task<string> MoveStaticMethod(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file containing the method")] string filePath,
@@ -1129,7 +1130,8 @@ public static class MoveMethodsTool
         await File.WriteAllTextAsync(context.TargetPath, formattedTarget.ToFullString());
     }
 
-    [McpServerTool, Description("Move one or more instance methods to another class (preferred for large C# file refactoring)")]
+    [McpServerTool, Description("Move one or more instance methods to another class (preferred for large C# file refactoring). " +
+        "Each original method is replaced with a wrapper that calls the moved version to maintain the public API.")]
     public static async Task<string> MoveInstanceMethod(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file containing the method")] string filePath,

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.cs
@@ -239,7 +239,8 @@ public static class MoveMultipleMethodsTool
     // ===== SOLUTION OPERATION LAYER =====
     // Solution/Document operations that use the AST layer
 
-    [McpServerTool, Description("Move multiple methods to target classes, automatically ordering by dependencies")]
+    [McpServerTool, Description("Move multiple methods to target classes, automatically ordering by dependencies. " +
+        "Wrapper methods remain at the original locations to delegate to the moved implementations.")]
     public static async Task<string> MoveMultipleMethods(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file containing the methods")] string filePath,
@@ -313,7 +314,8 @@ public static class MoveMultipleMethodsTool
         }
     }
 
-    [McpServerTool, Description("Move multiple methods using explicit parameters")]
+    [McpServerTool, Description("Move multiple methods using explicit parameters. " +
+        "Each moved method leaves a delegating wrapper so existing calls continue to compile.")]
     public static async Task<string> MoveMultipleMethods(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file containing the methods")] string filePath,

--- a/functionality.md
+++ b/functionality.md
@@ -24,10 +24,10 @@ Creates a new field, parameter, or variable from selected code. Use `line:column
 **With Instance Parameter**: Transforms instance methods to static by adding an instance parameter to replace `this` references.
 
 ### Move Static Method
-Relocates a static method to another class (new or existing).
+Relocates a static method to another class (new or existing). A wrapper method is left in the source class to delegate to the moved implementation.
 
 ### Move Instance Method
-Relocates an instance method to another class and introduces a variable, field, or property on the origin class to maintain access.
+Relocates an instance method to another class and introduces a variable, field, or property on the origin class to maintain access. The original method becomes a delegating wrapper so callers see no interface change.
 
 ### Make Field Readonly
 Moves field initialization to all constructors and marks the field as readonly.


### PR DESCRIPTION
## Summary
- document that conversion and move tools leave wrapper methods behind
- mention wrapper behavior in Move* tool descriptions
- clarify interface preservation in the documentation and examples

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684c4d9c94a883279f1ba67a4645e006