### PR TITLE
Remove JSON from MoveMultipleMethods

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
 - `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
  - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]` - Move a static method to another class
  - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move one or more instance methods (comma separated names) to another class. Newly created access fields are marked `readonly` and won't duplicate existing members
- - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move multiple methods from one class to another. Accepts comma separated `methodNames`. The older JSON form is still supported for backward compatibility
+ - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move multiple methods from one class to another. Accepts comma separated `methodNames`.
  - `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
 - `version` - Show build version and timestamp
 - `analyze-refactoring-opportunities <solutionPath> <filePath>` - Prompt for refactoring suggestions (long methods, long parameter lists, unused code)

--- a/README.md
+++ b/README.md
@@ -175,8 +175,11 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
 - `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
  - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]` - Move a static method to another class
  - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move one or more instance methods (comma separated names) to another class. Newly created access fields are marked `readonly` and won't duplicate existing members
- - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move multiple methods from one class to another. Accepts comma separated `methodNames`.
- - `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
+- `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move multiple methods from one class to another. Accepts comma separated `methodNames`.
+- Each method move is described by a `MoveOperation` object with these properties:
+  `SourceClass`, `Method`, `TargetClass`, `AccessMember`, `AccessMemberType`,
+  `IsStatic`, and an optional `TargetFile`.
+- `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
 - `version` - Show build version and timestamp
 - `analyze-refactoring-opportunities <solutionPath> <filePath>` - Prompt for refactoring suggestions (long methods, long parameter lists, unused code)
 - `list-class-lengths <solutionPath>` - Prompt for class names and line counts

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -401,32 +401,35 @@ class Logger
     }
 }";
 
-        // Create JSON operations for multiple method moves
-        var operationsJson = @"[
+        var operations = new[]
+        {
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""SourceClass"": ""DataProcessor"",
-                ""Method"": ""ValidateData"",
-                ""TargetClass"": ""DataValidator"",
-                ""AccessMember"": ""dataValidator"",
-                ""AccessMemberType"": ""field"",
-                ""IsStatic"": false
+                SourceClass = "DataProcessor",
+                Method = "ValidateData",
+                TargetClass = "DataValidator",
+                AccessMember = "dataValidator",
+                AccessMemberType = "field",
+                IsStatic = false
             },
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""SourceClass"": ""DataProcessor"",
-                ""Method"": ""TransformData"",
-                ""TargetClass"": ""DataValidator"",
-                ""AccessMember"": ""dataValidator"",
-                ""AccessMemberType"": ""field"",
-                ""IsStatic"": false
+                SourceClass = "DataProcessor",
+                Method = "TransformData",
+                TargetClass = "DataValidator",
+                AccessMember = "dataValidator",
+                AccessMemberType = "field",
+                IsStatic = false
             },
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""Method"": ""LogOperation"",
-                ""TargetClass"": ""Logger"",
-                ""IsStatic"": true
+                Method = "LogOperation",
+                TargetClass = "Logger",
+                IsStatic = true
             }
-        ]";
+        };
 
-        var output = MoveMultipleMethodsTool.MoveMultipleMethodsInSource(input, operationsJson);
+        var output = MoveMultipleMethodsTool.MoveMultipleMethodsInSource(input, operations);
         Assert.Contains("private readonly DataValidator dataValidator", output);
         Assert.Contains("dataValidator.ValidateData()", output);
         Assert.Contains("dataValidator.TransformData()", output);
@@ -491,27 +494,30 @@ class MathOperations
     }
 }";
 
-        // Create JSON operations that have dependencies (PerformCalculation depends on LogOperation)
-        var operationsJson = @"[
+        // Operations that have dependencies (PerformCalculation depends on LogOperation)
+        var operations = new[]
+        {
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""SourceClass"": ""Calculator"",
-                ""Method"": ""PerformCalculation"",
-                ""TargetClass"": ""MathOperations"",
-                ""AccessMember"": ""mathOperations"",
-                ""AccessMemberType"": ""field"",
-                ""IsStatic"": false
+                SourceClass = "Calculator",
+                Method = "PerformCalculation",
+                TargetClass = "MathOperations",
+                AccessMember = "mathOperations",
+                AccessMemberType = "field",
+                IsStatic = false
             },
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""SourceClass"": ""Calculator"",
-                ""Method"": ""LogOperation"",
-                ""TargetClass"": ""MathOperations"",
-                ""AccessMember"": ""mathOperations"",
-                ""AccessMemberType"": ""field"",
-                ""IsStatic"": false
+                SourceClass = "Calculator",
+                Method = "LogOperation",
+                TargetClass = "MathOperations",
+                AccessMember = "mathOperations",
+                AccessMemberType = "field",
+                IsStatic = false
             }
-        ]";
+        };
 
-        var output = MoveMultipleMethodsTool.MoveMultipleMethodsInSource(input, operationsJson);
+        var output = MoveMultipleMethodsTool.MoveMultipleMethodsInSource(input, operations);
         Assert.Contains("private readonly MathOperations mathOperations", output);
         Assert.Contains("mathOperations.PerformCalculation", output);
     }
@@ -548,6 +554,28 @@ class Bar
         Console.WriteLine(""hi"");
     }
 }";
+
+        var operations = new[]
+        {
+            new MoveMultipleMethodsTool.MoveOperation
+            {
+                Method = "FormatString",
+                TargetClass = "StringHelper",
+                IsStatic = true
+            },
+            new MoveMultipleMethodsTool.MoveOperation
+            {
+                Method = "AddNumbers",
+                TargetClass = "MathHelper",
+                IsStatic = true
+            },
+            new MoveMultipleMethodsTool.MoveOperation
+            {
+                Method = "IsValidEmail",
+                TargetClass = "ValidationHelper",
+                IsStatic = true
+            }
+        };
 
         var output = MoveMethodsTool.MoveInstanceMethodInSource(input, "Foo", "Do", "Bar", "bar", "field");
         Assert.Contains("private readonly Bar bar", output);
@@ -941,26 +969,29 @@ class MathHelper
 class ValidationHelper
 {
 }";
-
-        var operationsJson = @"[
+        var operations = new[]
+        {
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""Method"": ""FormatString"",
-                ""TargetClass"": ""StringHelper"",
-                ""IsStatic"": true
+                Method = "FormatString",
+                TargetClass = "StringHelper",
+                IsStatic = true
             },
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""Method"": ""AddNumbers"",
-                ""TargetClass"": ""MathHelper"",
-                ""IsStatic"": true
+                Method = "AddNumbers",
+                TargetClass = "MathHelper",
+                IsStatic = true
             },
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""Method"": ""IsValidEmail"",
-                ""TargetClass"": ""ValidationHelper"",
-                ""IsStatic"": true
+                Method = "IsValidEmail",
+                TargetClass = "ValidationHelper",
+                IsStatic = true
             }
-        ]";
+        };
 
-        var output = MoveMultipleMethodsTool.MoveMultipleMethodsInSource(input, operationsJson);
+        var output = MoveMultipleMethodsTool.MoveMultipleMethodsInSource(input, operations);
 
         // Verify that methods are moved to correct classes
         Assert.Contains("class StringHelper", output);
@@ -1177,42 +1208,47 @@ class Operations
 {
 }";
 
-        var operationsJson = @"[
+        var operations = new[]
+        {
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""SourceClass"": ""ComplexCalculator"",
-                ""Method"": ""MethodA"",
-                ""TargetClass"": ""Operations"",
-                ""AccessMember"": ""operations"",
-                ""AccessMemberType"": ""field"",
-                ""IsStatic"": false
+                SourceClass = "ComplexCalculator",
+                Method = "MethodA",
+                TargetClass = "Operations",
+                AccessMember = "operations",
+                AccessMemberType = "field",
+                IsStatic = false
             },
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""SourceClass"": ""ComplexCalculator"",
-                ""Method"": ""MethodB"",
-                ""TargetClass"": ""Operations"",
-                ""AccessMember"": ""operations"",
-                ""AccessMemberType"": ""field"",
-                ""IsStatic"": false
+                SourceClass = "ComplexCalculator",
+                Method = "MethodB",
+                TargetClass = "Operations",
+                AccessMember = "operations",
+                AccessMemberType = "field",
+                IsStatic = false
             },
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""SourceClass"": ""ComplexCalculator"",
-                ""Method"": ""MethodC"",
-                ""TargetClass"": ""Operations"",
-                ""AccessMember"": ""operations"",
-                ""AccessMemberType"": ""field"",
-                ""IsStatic"": false
+                SourceClass = "ComplexCalculator",
+                Method = "MethodC",
+                TargetClass = "Operations",
+                AccessMember = "operations",
+                AccessMemberType = "field",
+                IsStatic = false
             },
+            new MoveMultipleMethodsTool.MoveOperation
             {
-                ""SourceClass"": ""ComplexCalculator"",
-                ""Method"": ""MethodD"",
-                ""TargetClass"": ""Operations"",
-                ""AccessMember"": ""operations"",
-                ""AccessMemberType"": ""field"",
-                ""IsStatic"": false
+                SourceClass = "ComplexCalculator",
+                Method = "MethodD",
+                TargetClass = "Operations",
+                AccessMember = "operations",
+                AccessMemberType = "field",
+                IsStatic = false
             }
-        ]";
+        };
 
-        var output = MoveMultipleMethodsTool.MoveMultipleMethodsInSource(input, operationsJson);
+        var output = MoveMultipleMethodsTool.MoveMultipleMethodsInSource(input, operations);
 
         // Verify that all methods are moved
         Assert.Contains("class Operations", output);
@@ -1413,34 +1449,38 @@ class LoggingService
 }";
 
         // Create JSON operations for multiple method moves to different targets
-        var operationsJson = @"[
-            {
-                ""SourceClass"": ""DocumentProcessor"",
-                ""Method"": ""ValidateDocument"",
-                ""TargetClass"": ""ValidationService"",
-                ""AccessMember"": ""validationService"",
-                ""AccessMemberType"": ""field"",
-                ""IsStatic"": false
-            },
-            {
-                ""SourceClass"": ""DocumentProcessor"",
-                ""Method"": ""ProcessDocument"",
-                ""TargetClass"": ""ProcessingService"",
-                ""AccessMember"": ""processingService"",
-                ""AccessMemberType"": ""field"",
-                ""IsStatic"": false
-            },
-            {
-                ""SourceClass"": ""DocumentProcessor"",
-                ""Method"": ""LogActivity"",
-                ""TargetClass"": ""LoggingService"",
-                ""AccessMember"": ""loggingService"",
-                ""AccessMemberType"": ""field"",
-                ""IsStatic"": false
-            }
-        ]";
 
-        var output = MoveMultipleMethodsTool.MoveMultipleMethodsInSource(input, operationsJson);
+        var operations = new[]
+        {
+            new MoveMultipleMethodsTool.MoveOperation
+            {
+                SourceClass = "DocumentProcessor",
+                Method = "ValidateDocument",
+                TargetClass = "ValidationService",
+                AccessMember = "validationService",
+                AccessMemberType = "field",
+                IsStatic = false
+            },
+            new MoveMultipleMethodsTool.MoveOperation
+            {
+                SourceClass = "DocumentProcessor",
+                Method = "ProcessDocument",
+                TargetClass = "ProcessingService",
+                AccessMember = "processingService",
+                AccessMemberType = "field",
+                IsStatic = false
+            },
+            new MoveMultipleMethodsTool.MoveOperation
+            {
+                SourceClass = "DocumentProcessor",
+                Method = "LogActivity",
+                TargetClass = "LoggingService",
+                AccessMember = "loggingService",
+                AccessMemberType = "field",
+                IsStatic = false
+            }
+        };
+        var output = MoveMultipleMethodsTool.MoveMultipleMethodsInSource(input, operations);
 
         Assert.Equal(expected, output.Trim());
 

--- a/RefactorMCP.Tests/Split/MoveMultipleMethodsTests.cs
+++ b/RefactorMCP.Tests/Split/MoveMultipleMethodsTests.cs
@@ -1,6 +1,5 @@
 using ModelContextProtocol;
 using System.IO;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -49,9 +48,8 @@ public class MoveMultipleMethodsTests : TestBase
             }
         };
 
-        var json = JsonSerializer.Serialize(ops);
         var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
-            SolutionPath, testFile, json);
+            SolutionPath, testFile, ops);
 
         Assert.Contains("Successfully moved 3 methods", result);
 
@@ -97,10 +95,9 @@ public class MoveMultipleMethodsTests : TestBase
             }
         };
 
-        var json = JsonSerializer.Serialize(ops);
         var targetFile = Path.Combine(TestOutputPath, "Target.cs");
         var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
-            SolutionPath, testFile, json, targetFile);
+            SolutionPath, testFile, ops, targetFile);
 
         Assert.Contains("Successfully moved 2 methods", result);
         Assert.True(File.Exists(targetFile));


### PR DESCRIPTION
## Summary
- refactor MoveMultipleMethods tool to accept `MoveOperation` lists instead of JSON strings
- update tests for new API
- document new method signature in README

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684c4cf1de70832796dce3cba9edca2b