### PR TITLE
Add BatchMoveMethods tool

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -411,7 +411,19 @@ class Target
 }
 ```
 
-## 11. Move Class to Separate File
+## 11. Batch Move Methods
+
+**Purpose**: Move several methods at once using a JSON description. This supersedes the older move commands.
+
+### Example
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli batch-move-methods \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  "[{\"SourceClass\":\"Helper\",\"Method\":\"A\",\"TargetClass\":\"Target\",\"AccessMember\":\"t\"}]"
+```
+
+## 12. Move Class to Separate File
 
 **Purpose**: Move a class into its own file named after the class.
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -175,6 +175,14 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
   "./optional/Target.cs"
 ```
 
+### Batch Move Methods
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli batch-move-methods \
+  "./RefactorMCP.sln" \
+  "./path/to/file.cs" \
+  "[{\"SourceClass\":\"Foo\",\"Method\":\"Bar\",\"TargetClass\":\"Target\"}]"
+```
+
 ### Move To Separate File
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --cli move-to-separate-file \

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
  - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]` - Move a static method to another class
  - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move one or more instance methods (comma separated names) to another class. Newly created access fields are marked `readonly` and won't duplicate existing members
  - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move multiple methods from one class to another. Accepts comma separated `methodNames`. The older JSON form is still supported for backward compatibility
+ - `batch-move-methods <solutionPath> <filePath> <operationsJson> [defaultTargetFile]` - Move many methods in a single batch using JSON operations
  - `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
 - `version` - Show build version and timestamp
 - `analyze-refactoring-opportunities <solutionPath> <filePath>` - Prompt for refactoring suggestions (long methods, long parameter lists, unused code)

--- a/RefactorMCP.ConsoleApp/Tools/BatchMoveMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/BatchMoveMethods.cs
@@ -1,0 +1,16 @@
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+[McpServerToolType]
+public static class BatchMoveMethodsTool
+{
+    [McpServerTool, Description("Move methods in batch using JSON operations")]
+    public static async Task<string> BatchMoveMethods(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        [Description("Path to the C# file containing the methods")] string filePath,
+        [Description("JSON array describing the move operations")] string operationsJson,
+        [Description("Default target file path used when operations omit targetFile (optional)")] string? defaultTargetFilePath = null)
+    {
+        return await MoveMultipleMethodsTool.MoveMultipleMethods(solutionPath, filePath, operationsJson, defaultTargetFilePath);
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.cs
@@ -1,5 +1,6 @@
 using ModelContextProtocol.Server;
 using ModelContextProtocol;
+using System;
 using System.ComponentModel;
 using System.Linq;
 using Microsoft.CodeAnalysis;
@@ -972,7 +973,8 @@ public static class MoveMethodsTool
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword), SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
     }
 
-    [McpServerTool, Description("Move a static method to another class (preferred for large C# file refactoring)")]
+    [Obsolete("Use BatchMoveMethodsTool.BatchMoveMethods instead")]
+    [McpServerTool, Description("Move a static method to another class (preferred for large C# file refactoring) [DEPRECATED]")]
     public static async Task<string> MoveStaticMethod(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file containing the method")] string filePath,
@@ -1129,7 +1131,8 @@ public static class MoveMethodsTool
         await File.WriteAllTextAsync(context.TargetPath, formattedTarget.ToFullString());
     }
 
-    [McpServerTool, Description("Move one or more instance methods to another class (preferred for large C# file refactoring)")]
+    [Obsolete("Use BatchMoveMethodsTool.BatchMoveMethods instead")]
+    [McpServerTool, Description("Move one or more instance methods to another class (preferred for large C# file refactoring) [DEPRECATED]")]
     public static async Task<string> MoveInstanceMethod(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file containing the method")] string filePath,

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.cs
@@ -1,5 +1,6 @@
 using ModelContextProtocol.Server;
 using ModelContextProtocol;
+using System;
 using System.ComponentModel;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -239,7 +240,8 @@ public static class MoveMultipleMethodsTool
     // ===== SOLUTION OPERATION LAYER =====
     // Solution/Document operations that use the AST layer
 
-    [McpServerTool, Description("Move multiple methods to target classes, automatically ordering by dependencies")]
+    [Obsolete("Use BatchMoveMethodsTool.BatchMoveMethods instead")]
+    [McpServerTool, Description("Move multiple methods to target classes, automatically ordering by dependencies [DEPRECATED]")]
     public static async Task<string> MoveMultipleMethods(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file containing the methods")] string filePath,
@@ -313,7 +315,8 @@ public static class MoveMultipleMethodsTool
         }
     }
 
-    [McpServerTool, Description("Move multiple methods using explicit parameters")]
+    [Obsolete("Use BatchMoveMethodsTool.BatchMoveMethods instead")]
+    [McpServerTool, Description("Move multiple methods using explicit parameters [DEPRECATED]")]
     public static async Task<string> MoveMultipleMethods(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file containing the methods")] string filePath,

--- a/RefactorMCP.Tests/Split/BatchMoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Split/BatchMoveMethodsTests.cs
@@ -1,0 +1,74 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class BatchMoveMethodsTests : TestBase
+{
+    [Fact]
+    public async Task BatchMoveMethods_CrossFileMovesAllMethods()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var testFile = Path.Combine(TestOutputPath, "BatchMove.cs");
+        await TestUtilities.CreateTestFile(testFile, GetSampleCode());
+
+        var target1 = Path.Combine(TestOutputPath, "Target1.cs");
+        var target2 = Path.Combine(TestOutputPath, "Target2.cs");
+
+        var ops = new[]
+        {
+            new MoveMultipleMethodsTool.MoveOperation
+            {
+                SourceClass = "SourceClass",
+                Method = "A",
+                TargetClass = "Target1",
+                AccessMember = "t1",
+                AccessMemberType = "field",
+                IsStatic = false,
+                TargetFile = target1
+            },
+            new MoveMultipleMethodsTool.MoveOperation
+            {
+                SourceClass = "SourceClass",
+                Method = "B",
+                TargetClass = "Target1",
+                AccessMember = "t1",
+                AccessMemberType = "field",
+                IsStatic = false,
+                TargetFile = target1
+            },
+            new MoveMultipleMethodsTool.MoveOperation
+            {
+                Method = "C",
+                TargetClass = "Target2",
+                IsStatic = true,
+                TargetFile = target2
+            }
+        };
+
+        var json = JsonSerializer.Serialize(ops);
+        var result = await BatchMoveMethodsTool.BatchMoveMethods(
+            SolutionPath, testFile, json);
+
+        Assert.Contains("Successfully moved 3 methods", result);
+        Assert.True(File.Exists(target1));
+        Assert.True(File.Exists(target2));
+    }
+
+    private static string GetSampleCode() => """
+using System;
+
+public class SourceClass
+{
+    public void A() { B(); }
+    public void B() { Console.WriteLine("B"); }
+    public static void C() { Console.WriteLine("C"); }
+}
+
+public class Target1 { }
+public class Target2 { }
+""";
+}

--- a/RefactorMCP.Tests/Split/ExtractMethodTests.cs
+++ b/RefactorMCP.Tests/Split/ExtractMethodTests.cs
@@ -26,6 +26,23 @@ public class ExtractMethodTests : TestBase
     }
 
     [Fact]
+    public async Task ExtractMethod_CreatesPrivateMethod()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var testFile = Path.Combine(TestOutputPath, "ExtractPrivate.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForExtractMethod());
+
+        await ExtractMethodTool.ExtractMethod(
+            SolutionPath,
+            testFile,
+            "7:9-10:10",
+            "ValidateInputs");
+
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.Contains("private void ValidateInputs()", fileContent);
+    }
+
+    [Fact]
     public async Task ExtractMethod_InvalidRange_ReturnsError()
     {
         await LoadSolutionTool.LoadSolution(SolutionPath);


### PR DESCRIPTION
## Summary
- add `BatchMoveMethodsTool` for bulk method movement
- mark older move APIs as deprecated
- document new tool in README, examples, and quick reference
- test batch move functionality
- add Roslyn test to confirm extracted method is `private`

## Testing
- `dotnet format --no-restore --verbosity minimal`
- `dotnet test --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_684c551abd448327bb5e54ccadac17ee