### PR TITLE
Fix BatchMoveMethods JSON parsing

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/BatchMoveMethods.cs
+++ b/RefactorMCP.ConsoleApp/Tools/BatchMoveMethods.cs
@@ -1,5 +1,7 @@
 using ModelContextProtocol.Server;
 using System.ComponentModel;
+using System.Text.Json;
+using System;
 
 [McpServerToolType]
 public static class BatchMoveMethodsTool
@@ -11,6 +13,11 @@ public static class BatchMoveMethodsTool
         [Description("JSON array describing the move operations")] string operationsJson,
         [Description("Default target file path used when operations omit targetFile (optional)")] string? defaultTargetFilePath = null)
     {
-        return await MoveMultipleMethodsTool.MoveMultipleMethods(solutionPath, filePath, operationsJson, defaultTargetFilePath);
+        var ops = JsonSerializer.Deserialize<MoveMultipleMethodsTool.MoveOperation[]>(operationsJson, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        }) ?? Array.Empty<MoveMultipleMethodsTool.MoveOperation>();
+
+        return await MoveMultipleMethodsTool.MoveMultipleMethods(solutionPath, filePath, ops, defaultTargetFilePath);
     }
 }


### PR DESCRIPTION
## Summary
- parse JSON in `BatchMoveMethods`
- add `System.Text.Json` and `System` usings

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684c7eb850bc83279f1b6a7fb27ec86c