### PR TITLE
Refactor checkers to use SyntaxWalker

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodCallChecker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodCallChecker.cs
@@ -1,11 +1,9 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using System.Collections.Generic;
-using System.Linq;
 
-internal class MethodCallChecker : CSharpSyntaxRewriter
+internal class MethodCallChecker : CSharpSyntaxWalker
 {
     private readonly HashSet<string> _classMethodNames;
     public bool HasMethodCalls { get; private set; }
@@ -15,7 +13,7 @@ internal class MethodCallChecker : CSharpSyntaxRewriter
         _classMethodNames = classMethodNames;
     }
 
-    public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+    public override void VisitInvocationExpression(InvocationExpressionSyntax node)
     {
         if (node.Expression is IdentifierNameSyntax identifier)
         {
@@ -24,8 +22,7 @@ internal class MethodCallChecker : CSharpSyntaxRewriter
                 HasMethodCalls = true;
             }
         }
-
-        return base.VisitInvocationExpression(node);
+        base.VisitInvocationExpression(node);
     }
 }
 

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/StaticFieldChecker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/StaticFieldChecker.cs
@@ -1,11 +1,9 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using System.Collections.Generic;
-using System.Linq;
 
-internal class StaticFieldChecker : CSharpSyntaxRewriter
+internal class StaticFieldChecker : CSharpSyntaxWalker
 {
     private readonly HashSet<string> _staticFieldNames;
     public bool HasStaticFieldReferences { get; private set; }
@@ -15,11 +13,14 @@ internal class StaticFieldChecker : CSharpSyntaxRewriter
         _staticFieldNames = staticFieldNames;
     }
 
-    public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+    public override void VisitIdentifierName(IdentifierNameSyntax node)
     {
         var parent = node.Parent;
         if (parent is ParameterSyntax || parent is TypeSyntax)
-            return base.VisitIdentifierName(node);
+        {
+            base.VisitIdentifierName(node);
+            return;
+        }
 
         if (_staticFieldNames.Contains(node.Identifier.ValueText))
         {
@@ -30,7 +31,7 @@ internal class StaticFieldChecker : CSharpSyntaxRewriter
             }
         }
 
-        return base.VisitIdentifierName(node);
+        base.VisitIdentifierName(node);
     }
 }
 


### PR DESCRIPTION
## Summary
- refactor InstanceMemberUsageChecker, MethodCallChecker and StaticFieldChecker to use `CSharpSyntaxWalker` instead of `CSharpSyntaxRewriter`
- simplify usings and update traversal methods

## Testing
- `dotnet format RefactorMCP.sln --verbosity normal`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_684cad381c0083278b637e315a96c5d4