### PR TITLE
Refactor analysis tool with multiple walkers

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/ClassMetricsWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/ClassMetricsWalker.cs
@@ -1,0 +1,23 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    internal class ClassMetricsWalker : CSharpSyntaxWalker
+    {
+        public List<string> Suggestions { get; } = new();
+
+        public override void VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            base.VisitClassDeclaration(node);
+
+            var members = node.Members.Count;
+            var span = node.GetLocation().GetLineSpan();
+            var lines = span.EndLinePosition.Line - span.StartLinePosition.Line + 1;
+            if (members > 15 || lines > 300)
+                Suggestions.Add($"Class '{node.Identifier}' is large ({members} members) -> consider splitting or move-method");
+        }
+    }
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodMetricsWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodMetricsWalker.cs
@@ -1,0 +1,41 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    internal class MethodMetricsWalker : CSharpSyntaxWalker
+    {
+        private readonly SemanticModel? _model;
+        public List<string> Suggestions { get; } = new();
+
+        public MethodMetricsWalker(SemanticModel? model)
+        {
+            _model = model;
+        }
+
+        public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            base.VisitMethodDeclaration(node);
+
+            var span = node.GetLocation().GetLineSpan();
+            var lines = span.EndLinePosition.Line - span.StartLinePosition.Line + 1;
+            if (lines > 30)
+                Suggestions.Add($"Method '{node.Identifier}' is {lines} lines long -> consider extract-method");
+
+            var parameters = node.ParameterList.Parameters.Count;
+            if (parameters >= 5)
+                Suggestions.Add($"Method '{node.Identifier}' has {parameters} parameters -> consider introducing parameter object");
+
+            if (_model != null && !node.Modifiers.Any(SyntaxKind.StaticKeyword))
+            {
+                var accessesInstance = node.DescendantNodes().Any(n => n is ThisExpressionSyntax ||
+                    n is MemberAccessExpressionSyntax ma && _model.GetSymbolInfo(ma).Symbol is { IsStatic: false });
+                if (!accessesInstance)
+                    Suggestions.Add($"Method '{node.Identifier}' does not access instance state -> convert-to-static-with-parameters");
+            }
+        }
+    }
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/RefactoringOpportunityWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/RefactoringOpportunityWalker.cs
@@ -1,0 +1,37 @@
+using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    internal class RefactoringOpportunityWalker
+    {
+        private readonly MethodMetricsWalker _methodMetrics;
+        private readonly ClassMetricsWalker _classMetrics;
+        private readonly UnusedMembersWalker _unusedMembers;
+
+        public List<string> Suggestions { get; } = new();
+
+        public RefactoringOpportunityWalker(SemanticModel? model = null, Solution? solution = null)
+        {
+            _methodMetrics = new MethodMetricsWalker(model);
+            _classMetrics = new ClassMetricsWalker();
+            _unusedMembers = new UnusedMembersWalker(model, solution);
+        }
+
+        public void Visit(SyntaxNode root)
+        {
+            _methodMetrics.Visit(root);
+            _classMetrics.Visit(root);
+            _unusedMembers.Visit(root);
+        }
+
+        public async Task PostProcessAsync()
+        {
+            await _unusedMembers.PostProcessAsync();
+            Suggestions.AddRange(_methodMetrics.Suggestions);
+            Suggestions.AddRange(_classMetrics.Suggestions);
+            Suggestions.AddRange(_unusedMembers.Suggestions);
+        }
+    }
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/UnusedMembersWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/UnusedMembersWalker.cs
@@ -1,0 +1,120 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    internal class UnusedMembersWalker : CSharpSyntaxWalker
+    {
+        private readonly SemanticModel? _model;
+        private readonly Solution? _solution;
+
+        private readonly Dictionary<string, MethodDeclarationSyntax> _methods = new();
+        private readonly Dictionary<string, VariableDeclaratorSyntax> _fields = new();
+        private readonly Dictionary<string, int> _invocations = new();
+        private readonly Dictionary<string, int> _fieldRefs = new();
+
+        public List<string> Suggestions { get; } = new();
+
+        public UnusedMembersWalker(SemanticModel? model = null, Solution? solution = null)
+            : base(SyntaxWalkerDepth.Token)
+        {
+            _model = model;
+            _solution = solution;
+        }
+
+        public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            base.VisitMethodDeclaration(node);
+            _methods.TryAdd(node.Identifier.ValueText, node);
+        }
+
+        public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            base.VisitInvocationExpression(node);
+            if (node.Expression is IdentifierNameSyntax id)
+            {
+                _invocations.TryGetValue(id.Identifier.ValueText, out var count);
+                _invocations[id.Identifier.ValueText] = count + 1;
+            }
+        }
+
+        public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+        {
+            base.VisitFieldDeclaration(node);
+            foreach (var variable in node.Declaration.Variables)
+            {
+                _fields.TryAdd(variable.Identifier.ValueText, variable);
+            }
+        }
+
+        public override void VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            base.VisitIdentifierName(node);
+            var name = node.Identifier.ValueText;
+            _fieldRefs.TryGetValue(name, out var count);
+            _fieldRefs[name] = count + 1;
+        }
+
+        public async Task PostProcessAsync()
+        {
+            if (_model != null && _solution != null)
+            {
+                await AnalyzeWithModelAsync();
+            }
+            else
+            {
+                AnalyzeSingleFile();
+            }
+        }
+
+        private async Task AnalyzeWithModelAsync()
+        {
+            foreach (var method in _methods.Values)
+            {
+                if (method.Modifiers.Any(SyntaxKind.PublicKeyword))
+                    continue;
+
+                if (_model!.GetDeclaredSymbol(method) is IMethodSymbol symbol)
+                {
+                    var refs = await SymbolFinder.FindReferencesAsync(symbol, _solution!);
+                    if (refs.All(r => r.Locations.All(l => l.Location.SourceSpan == method.Identifier.Span)))
+                        Suggestions.Add($"Method '{method.Identifier}' appears unused -> safe-delete-method");
+                }
+            }
+
+            foreach (var variable in _fields.Values)
+            {
+                if (_model!.GetDeclaredSymbol(variable) is IFieldSymbol symbol)
+                {
+                    var refs = await SymbolFinder.FindReferencesAsync(symbol, _solution!);
+                    if (refs.All(r => r.Locations.All(l => l.Location.SourceSpan == variable.Identifier.Span)))
+                        Suggestions.Add($"Field '{variable.Identifier}' appears unused -> safe-delete-field");
+                }
+            }
+        }
+
+        private void AnalyzeSingleFile()
+        {
+            foreach (var (name, method) in _methods)
+            {
+                if (method.Modifiers.Any(SyntaxKind.PublicKeyword))
+                    continue;
+                _invocations.TryGetValue(name, out var count);
+                if (count == 0)
+                    Suggestions.Add($"Method '{name}' appears unused -> safe-delete-method");
+            }
+
+            foreach (var (name, _) in _fields)
+            {
+                _fieldRefs.TryGetValue(name, out var count);
+                if (count <= 1)
+                    Suggestions.Add($"Field '{name}' appears unused -> safe-delete-field");
+            }
+        }
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/AnalyzeRefactoringOpportunities.cs
+++ b/RefactorMCP.ConsoleApp/Tools/AnalyzeRefactoringOpportunities.cs
@@ -2,8 +2,7 @@ using ModelContextProtocol.Server;
 using ModelContextProtocol;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.FindSymbols;
+using RefactorMCP.ConsoleApp.SyntaxRewriters;
 using System.ComponentModel;
 
 [McpServerToolType, McpServerPromptType]
@@ -19,11 +18,10 @@ public static class AnalyzeRefactoringOpportunitiesTool
             var (syntaxTree, model, solution) = await LoadSyntaxTreeAndModel(solutionPath, filePath);
             var root = await syntaxTree.GetRootAsync();
 
-            var suggestions = new List<string>();
-
-            AnalyzeMethodMetrics(root, syntaxTree, model, suggestions);
-            AnalyzeClassMetrics(root, syntaxTree, suggestions);
-            await AnalyzeUnusedMembersAsync(root, model, solution, suggestions);
+            var walker = new RefactoringOpportunityWalker(model, solution);
+            walker.Visit(root);
+            await walker.PostProcessAsync();
+            var suggestions = walker.Suggestions;
 
             if (suggestions.Count == 0)
                 return "No obvious refactoring opportunities detected";
@@ -51,114 +49,4 @@ public static class AnalyzeRefactoringOpportunitiesTool
         return (syntaxTree, null, null);
     }
 
-    private static void AnalyzeMethodMetrics(SyntaxNode root, SyntaxTree syntaxTree, SemanticModel? model, List<string> suggestions)
-    {
-        foreach (var method in root.DescendantNodes().OfType<MethodDeclarationSyntax>())
-        {
-            var span = syntaxTree.GetLineSpan(method.Span);
-            var lines = span.EndLinePosition.Line - span.StartLinePosition.Line + 1;
-            if (lines > 30)
-                suggestions.Add($"Method '{method.Identifier}' is {lines} lines long -> consider extract-method");
-
-            var parameters = method.ParameterList.Parameters.Count;
-            if (parameters >= 5)
-                suggestions.Add($"Method '{method.Identifier}' has {parameters} parameters -> consider introducing parameter object");
-
-            if (!method.Modifiers.Any(SyntaxKind.StaticKeyword) && model != null)
-            {
-                var accessesInstance = method.DescendantNodes()
-                    .Any(n => n is ThisExpressionSyntax ||
-                              n is MemberAccessExpressionSyntax ma &&
-                                  model.GetSymbolInfo(ma).Symbol is { IsStatic: false });
-                if (!accessesInstance)
-                    suggestions.Add($"Method '{method.Identifier}' does not access instance state -> convert-to-static-with-parameters");
-            }
-        }
-    }
-
-    private static void AnalyzeClassMetrics(SyntaxNode root, SyntaxTree syntaxTree, List<string> suggestions)
-    {
-        foreach (var cls in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
-        {
-            var members = cls.Members.Count;
-            var span = syntaxTree.GetLineSpan(cls.Span);
-            var lines = span.EndLinePosition.Line - span.StartLinePosition.Line + 1;
-            if (members > 15 || lines > 300)
-                suggestions.Add($"Class '{cls.Identifier}' is large ({members} members) -> consider splitting or move-method");
-        }
-    }
-
-    private static async Task AnalyzeUnusedMembersAsync(SyntaxNode root, SemanticModel? model, Solution? solution, List<string> suggestions)
-    {
-        if (model != null)
-        {
-            await AnalyzeUnusedWithModelAsync(root, model, solution!, suggestions);
-        }
-        else
-        {
-            AnalyzeUnusedSingleFile(root, suggestions);
-        }
-    }
-
-    private static async Task AnalyzeUnusedWithModelAsync(SyntaxNode root, SemanticModel model, Solution solution, List<string> suggestions)
-    {
-        var methods = root.DescendantNodes().OfType<MethodDeclarationSyntax>();
-        foreach (var method in methods)
-        {
-            if (method.Modifiers.Any(SyntaxKind.PublicKeyword))
-                continue;
-
-            if (model.GetDeclaredSymbol(method) is IMethodSymbol symbol)
-            {
-                var refs = await SymbolFinder.FindReferencesAsync(symbol, solution);
-                if (refs.All(r => r.Locations.All(l => l.Location.SourceSpan == method.Identifier.Span)))
-                    suggestions.Add($"Method '{method.Identifier}' appears unused -> safe-delete-method");
-            }
-        }
-
-        var fields = root.DescendantNodes().OfType<FieldDeclarationSyntax>();
-        foreach (var field in fields)
-        {
-            foreach (var variable in field.Declaration.Variables)
-            {
-                if (model.GetDeclaredSymbol(variable) is IFieldSymbol symbol)
-                {
-                    var refs = await SymbolFinder.FindReferencesAsync(symbol, solution);
-                    if (refs.All(r => r.Locations.All(l => l.Location.SourceSpan == variable.Identifier.Span)))
-                        suggestions.Add($"Field '{variable.Identifier}' appears unused -> safe-delete-field");
-                }
-            }
-        }
-    }
-
-    private static void AnalyzeUnusedSingleFile(SyntaxNode root, List<string> suggestions)
-    {
-        var methods = root.DescendantNodes().OfType<MethodDeclarationSyntax>();
-        foreach (var method in methods)
-        {
-            if (method.Modifiers.Any(SyntaxKind.PublicKeyword))
-                continue;
-
-            var identifier = method.Identifier.ValueText;
-            var invocations = root.DescendantNodes().OfType<InvocationExpressionSyntax>()
-                .Select(inv => inv.Expression)
-                .OfType<IdentifierNameSyntax>()
-                .Count(id => id.Identifier.ValueText == identifier);
-            if (invocations == 0)
-                suggestions.Add($"Method '{identifier}' appears unused -> safe-delete-method");
-        }
-
-        var fields = root.DescendantNodes().OfType<FieldDeclarationSyntax>();
-        foreach (var field in fields)
-        {
-            foreach (var variable in field.Declaration.Variables)
-            {
-                var identifier = variable.Identifier.ValueText;
-                var references = root.DescendantNodes().OfType<IdentifierNameSyntax>()
-                    .Count(id => id.Identifier.ValueText == identifier);
-                if (references <= 1)
-                    suggestions.Add($"Field '{identifier}' appears unused -> safe-delete-field");
-            }
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- split `RefactoringOpportunityWalker` into `MethodMetricsWalker`, `ClassMetricsWalker`, and `UnusedMembersWalker`
- orchestrate multiple walkers from `RefactoringOpportunityWalker`
- simplify `AnalyzeRefactoringOpportunitiesTool` to use the new composition

## Testing
- `dotnet format --no-restore`
- `dotnet test --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_684cb059a9dc83278ddd7b61e1959081