### PR TITLE
Simplify move analysis with new walker

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodAnalysisWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodAnalysisWalker.cs
@@ -1,0 +1,52 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class MethodAnalysisWalker : CSharpSyntaxWalker
+{
+    private readonly HashSet<string> _instanceMembers;
+    private readonly HashSet<string> _methodNames;
+    private readonly string _methodName;
+
+    public bool UsesInstanceMembers { get; private set; }
+    public bool CallsOtherMethods { get; private set; }
+    public bool IsRecursive { get; private set; }
+
+    public MethodAnalysisWalker(HashSet<string> instanceMembers, HashSet<string> methodNames, string methodName)
+    {
+        _instanceMembers = instanceMembers;
+        _methodNames = methodNames;
+        _methodName = methodName;
+    }
+
+    public override void VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        if (_instanceMembers.Contains(node.Identifier.ValueText))
+        {
+            var parent = node.Parent;
+            if (parent is not MemberAccessExpressionSyntax ||
+                (parent is MemberAccessExpressionSyntax ma && ma.Expression == node))
+            {
+                UsesInstanceMembers = true;
+            }
+        }
+        base.VisitIdentifierName(node);
+    }
+
+    public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        if (node.Expression is IdentifierNameSyntax id && _methodNames.Contains(id.Identifier.ValueText))
+        {
+            if (id.Identifier.ValueText == _methodName)
+            {
+                IsRecursive = true;
+            }
+            else
+            {
+                CallsOtherMethods = true;
+            }
+        }
+        base.VisitInvocationExpression(node);
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -187,13 +187,17 @@ public static partial class MoveMethodsTool
 
         var instanceMembers = GetInstanceMemberNames(originClass);
         var methodNames = GetMethodNames(originClass);
+
+        var analysis = new MethodAnalysisWalker(instanceMembers, methodNames, methodName);
+        analysis.Visit(method);
+
+        bool usesInstanceMembers = analysis.UsesInstanceMembers;
+        bool callsOtherMethods = analysis.CallsOtherMethods;
+        bool isRecursive = analysis.IsRecursive;
+        bool needsThisParameter = usesInstanceMembers || callsOtherMethods || isRecursive;
+
         var otherMethodNames = new HashSet<string>(methodNames);
         otherMethodNames.Remove(methodName);
-
-        bool usesInstanceMembers = HasInstanceMemberUsage(method, instanceMembers);
-        bool callsOtherMethods = HasMethodCalls(method, otherMethodNames);
-        bool isRecursive = HasMethodCalls(method, new HashSet<string> { methodName });
-        bool needsThisParameter = usesInstanceMembers || callsOtherMethods || isRecursive;
 
         var accessMember = MemberExists(originClass, accessMemberName)
             ? null


### PR DESCRIPTION
## Summary
- add `MethodAnalysisWalker` for consolidated instance method analysis
- use `MethodAnalysisWalker` in `MoveMethods.Ast`

## Testing
- `dotnet format --no-restore --verbosity diagnostic`
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_684d2ce4c51083279f09305b2a6b12d8