### PR TITLE
Simplify move dependency logic

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodDependencyWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodDependencyWalker.cs
@@ -1,0 +1,35 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    internal class MethodDependencyWalker : CSharpSyntaxWalker
+    {
+        private readonly HashSet<string> _candidateMethods;
+        public HashSet<string> Dependencies { get; } = new();
+
+        public MethodDependencyWalker(HashSet<string> candidateMethods)
+        {
+            _candidateMethods = candidateMethods;
+        }
+
+        public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            var identifier = node.Expression switch
+            {
+                IdentifierNameSyntax id => id.Identifier.ValueText,
+                MemberAccessExpressionSyntax ma => ma.Name.Identifier.ValueText,
+                _ => null
+            };
+
+            if (identifier != null && _candidateMethods.Contains(identifier))
+            {
+                Dependencies.Add(identifier);
+            }
+
+            base.VisitInvocationExpression(node);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `MethodDependencyWalker` for side-effect free dependency analysis
- simplify `BuildDependencies` with new syntax walker

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-restore -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684d2ce4c51083279f09305b2a6b12d8