### PR TITLE
Add TestHelpers for shared logic

### DIFF
--- a/RefactorMCP.Tests/AnalyzeRefactoringOpportunitiesTests.cs
+++ b/RefactorMCP.Tests/AnalyzeRefactoringOpportunitiesTests.cs
@@ -7,7 +7,7 @@ namespace RefactorMCP.Tests;
 
 public class AnalyzeRefactoringOpportunitiesTests : IDisposable
 {
-    private static readonly string SolutionPath = GetSolutionPath();
+    private static readonly string SolutionPath = TestHelpers.GetSolutionPath();
     private static readonly string ExampleFilePath = Path.Combine(Path.GetDirectoryName(SolutionPath)!, "RefactorMCP.Tests", "ExampleCode.cs");
     private readonly string _originalDir = Directory.GetCurrentDirectory();
 
@@ -16,18 +16,6 @@ public class AnalyzeRefactoringOpportunitiesTests : IDisposable
         Directory.SetCurrentDirectory(_originalDir);
     }
 
-    private static string GetSolutionPath()
-    {
-        var currentDir = Directory.GetCurrentDirectory();
-        var dir = new DirectoryInfo(currentDir);
-        while (dir != null)
-        {
-            var sln = Path.Combine(dir.FullName, "RefactorMCP.sln");
-            if (File.Exists(sln)) return sln;
-            dir = dir.Parent;
-        }
-        return "./RefactorMCP.sln";
-    }
 
     [Fact]
     public async Task AnalyzeExampleCode_ReturnsSuggestions()

--- a/RefactorMCP.Tests/ClassLengthMetricsTests.cs
+++ b/RefactorMCP.Tests/ClassLengthMetricsTests.cs
@@ -7,7 +7,7 @@ namespace RefactorMCP.Tests;
 
 public class ClassLengthMetricsTests : IDisposable
 {
-    private static readonly string SolutionPath = GetSolutionPath();
+    private static readonly string SolutionPath = TestHelpers.GetSolutionPath();
     private readonly string _originalDir = Directory.GetCurrentDirectory();
 
     public void Dispose()
@@ -15,18 +15,6 @@ public class ClassLengthMetricsTests : IDisposable
         Directory.SetCurrentDirectory(_originalDir);
     }
 
-    private static string GetSolutionPath()
-    {
-        var currentDir = Directory.GetCurrentDirectory();
-        var dir = new DirectoryInfo(currentDir);
-        while (dir != null)
-        {
-            var sln = Path.Combine(dir.FullName, "RefactorMCP.sln");
-            if (File.Exists(sln)) return sln;
-            dir = dir.Parent;
-        }
-        return "./RefactorMCP.sln";
-    }
 
     [Fact]
     public async Task ListClassLengths_ReturnsMetrics()

--- a/RefactorMCP.Tests/ExampleValidationTests.cs
+++ b/RefactorMCP.Tests/ExampleValidationTests.cs
@@ -12,51 +12,27 @@ namespace RefactorMCP.Tests;
 /// </summary>
 public class ExampleValidationTests : IDisposable
 {
-    private static readonly string SolutionPath = GetSolutionPath();
-    private static readonly string TestOutputPath =
-        Path.Combine(Path.GetDirectoryName(SolutionPath)!,
-            "RefactorMCP.Tests",
-            "TestOutput",
-            "Examples");
+    private static readonly string SolutionPath = TestHelpers.GetSolutionPath();
+    private readonly string _testOutputPath;
 
     public ExampleValidationTests()
     {
-        Directory.CreateDirectory(TestOutputPath);
+        _testOutputPath = TestHelpers.CreateTestOutputDir("Examples");
     }
 
     public void Dispose()
     {
-        if (Directory.Exists(TestOutputPath))
+        if (Directory.Exists(_testOutputPath))
         {
-            Directory.Delete(TestOutputPath, true);
+            Directory.Delete(_testOutputPath, true);
         }
-    }
-
-    private static string GetSolutionPath()
-    {
-        // Start from the current directory and walk up to find the solution file
-        var currentDir = Directory.GetCurrentDirectory();
-        var dir = new DirectoryInfo(currentDir);
-
-        while (dir != null)
-        {
-            var solutionFile = Path.Combine(dir.FullName, "RefactorMCP.sln");
-            if (File.Exists(solutionFile))
-            {
-                return solutionFile;
-            }
-            dir = dir.Parent;
-        }
-
-        // Fallback to relative path
-        return "./RefactorMCP.sln";
     }
 
     [Fact]
     public async Task Example_ExtractMethod_ValidationLogic_WorksAsDocumented()
     {
         // Arrange - Create the exact code from our documentation
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "ExtractMethodExample.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "ExtractMethodExample.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForExtractMethod());
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -78,7 +54,7 @@ public class ExampleValidationTests : IDisposable
     public async Task Example_IntroduceField_AverageCalculation_WorksAsDocumented()
     {
         // Arrange - Create the exact code from our documentation
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "IntroduceFieldExample.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "IntroduceFieldExample.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForIntroduceField());
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -101,7 +77,7 @@ public class ExampleValidationTests : IDisposable
     public async Task Example_IntroduceVariable_ComplexExpression_WorksAsDocumented()
     {
         // Arrange - Create the exact code from our documentation
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "IntroduceVariableExample.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "IntroduceVariableExample.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForIntroduceVariable());
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -123,7 +99,7 @@ public class ExampleValidationTests : IDisposable
     public async Task Example_IntroduceParameter_ComplexExpression_WorksAsDocumented()
     {
         // Arrange - Create the exact code from our documentation
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "IntroduceParameterExample.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "IntroduceParameterExample.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForIntroduceParameter());
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -145,7 +121,7 @@ public class ExampleValidationTests : IDisposable
     public async Task Example_MakeFieldReadonly_FormatField_WorksAsDocumented()
     {
         // Arrange - Create the exact code from our documentation
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MakeFieldReadonlyExample.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "MakeFieldReadonlyExample.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForMakeFieldReadonly());
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -165,7 +141,7 @@ public class ExampleValidationTests : IDisposable
     [Fact]
     public async Task Example_SafeDeleteParameter_UnusedParam_WorksAsDocumented()
     {
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "SafeDeleteParameter.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "SafeDeleteParameter.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForSafeDelete());
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -184,7 +160,7 @@ public class ExampleValidationTests : IDisposable
     [Fact]
     public async Task Example_CleanupUsings_WorksAsDocumented()
     {
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "CleanupSample.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "CleanupSample.cs"));
         await CreateTestFile(testFile, TestUtilities.GetSampleCodeForCleanupUsings());
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -199,7 +175,7 @@ public class ExampleValidationTests : IDisposable
     public async Task QuickReference_ExtractMethod_WorksAsDocumented()
     {
         // Test the quick reference example
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "QuickRefExtractMethod.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "QuickRefExtractMethod.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForExtractMethod());
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -219,7 +195,7 @@ public class ExampleValidationTests : IDisposable
     public async Task QuickReference_IntroduceField_WorksAsDocumented()
     {
         // Test the quick reference example
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "QuickRefIntroduceField.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "QuickRefIntroduceField.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForIntroduceField());
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -245,7 +221,7 @@ public class ExampleValidationTests : IDisposable
     public async Task Example_IntroduceField_AllAccessModifiers_WorkCorrectly(string accessModifier)
     {
         // Test that all documented access modifiers work
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, $"AccessModifier_{accessModifier}.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, $"AccessModifier_{accessModifier}.cs"));
         await CreateTestFile(testFile, GetCalculatorCodeForIntroduceField());
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -266,7 +242,7 @@ public class ExampleValidationTests : IDisposable
     public async Task Documentation_RangeFormat_ExamplesAreAccurate()
     {
         // Test the range calculation example from EXAMPLES.md
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "RangeFormatTest.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "RangeFormatTest.cs"));
         var code = """
 public int Calculate(int a, int b)
 {

--- a/RefactorMCP.Tests/PerformanceTests.cs
+++ b/RefactorMCP.Tests/PerformanceTests.cs
@@ -13,38 +13,15 @@ namespace RefactorMCP.Tests;
 public class PerformanceTests
 {
     private readonly ITestOutputHelper _output;
-    private static readonly string SolutionPath = GetSolutionPath();
-    private static readonly string TestOutputPath =
-        Path.Combine(Path.GetDirectoryName(SolutionPath)!,
-            "RefactorMCP.Tests",
-            "TestOutput",
-            "Performance");
+    private static readonly string SolutionPath = TestHelpers.GetSolutionPath();
+    private readonly string _testOutputPath;
 
     public PerformanceTests(ITestOutputHelper output)
     {
         _output = output;
-        Directory.CreateDirectory(TestOutputPath);
+        _testOutputPath = TestHelpers.CreateTestOutputDir("Performance");
     }
 
-    private static string GetSolutionPath()
-    {
-        // Start from the current directory and walk up to find the solution file
-        var currentDir = Directory.GetCurrentDirectory();
-        var dir = new DirectoryInfo(currentDir);
-
-        while (dir != null)
-        {
-            var solutionFile = Path.Combine(dir.FullName, "RefactorMCP.sln");
-            if (File.Exists(solutionFile))
-            {
-                return solutionFile;
-            }
-            dir = dir.Parent;
-        }
-
-        // Fallback to relative path
-        return "./RefactorMCP.sln";
-    }
 
     [Fact]
     public async Task LoadSolution_LargeProject_CompletesInReasonableTime()
@@ -67,7 +44,7 @@ public class PerformanceTests
     public async Task ExtractMethod_LargeFile_CompletesInReasonableTime()
     {
         // Arrange
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "LargeFileTest.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "LargeFileTest.cs"));
         await CreateLargeTestFile(testFile);
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -93,7 +70,7 @@ public class PerformanceTests
     public async Task MultipleRefactorings_Sequential_AllComplete()
     {
         // Arrange
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MultipleRefactoringsTest.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "MultipleRefactoringsTest.cs"));
         await CreateTestFileForMultipleRefactorings(testFile);
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
@@ -161,7 +138,7 @@ public class PerformanceTests
     public async Task MemoryUsage_MultipleOperations_DoesNotLeak()
     {
         // Arrange
-        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MemoryTest.cs"));
+        var testFile = Path.GetFullPath(Path.Combine(_testOutputPath, "MemoryTest.cs"));
         await CreateTestFileForMultipleRefactorings(testFile);
         await LoadSolutionTool.LoadSolution(SolutionPath);
 

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -23,7 +23,7 @@ namespace RefactorMCP.Tests.Roslyn
 
             var orderedIndices = MoveMultipleMethodsTool.OrderOperations(root, sourceClasses, methodNames);
 
-            foreach(var i in orderedIndices)
+            foreach (var i in orderedIndices)
             {
                 if (isStatic[i])
                 {
@@ -36,7 +36,7 @@ namespace RefactorMCP.Tests.Roslyn
                     root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod);
                 }
             }
-            
+
             var workspace = new AdhocWorkspace();
             var formattedRoot = Formatter.Format(root, workspace);
             return formattedRoot.ToFullString();

--- a/RefactorMCP.Tests/TestHelpers.cs
+++ b/RefactorMCP.Tests/TestHelpers.cs
@@ -1,0 +1,27 @@
+using System.IO;
+
+namespace RefactorMCP.Tests;
+
+public static class TestHelpers
+{
+    public static string GetSolutionPath()
+    {
+        var currentDir = Directory.GetCurrentDirectory();
+        var dir = new DirectoryInfo(currentDir);
+        while (dir != null)
+        {
+            var sln = Path.Combine(dir.FullName, "RefactorMCP.sln");
+            if (File.Exists(sln)) return sln;
+            dir = dir.Parent;
+        }
+        return "./RefactorMCP.sln";
+    }
+
+    public static string CreateTestOutputDir(string subfolder)
+    {
+        var path = Path.Combine(Path.GetDirectoryName(GetSolutionPath())!,
+            "RefactorMCP.Tests", "TestOutput", subfolder);
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/RefactorMCP.Tests/Tools/CliIntegrationTests.cs
+++ b/RefactorMCP.Tests/Tools/CliIntegrationTests.cs
@@ -10,7 +10,7 @@ namespace RefactorMCP.Tests;
 
 public class CliIntegrationTests
 {
-    private static string GetSolutionPath() => TestUtilities.GetSolutionPath();
+    private static string GetSolutionPath() => TestHelpers.GetSolutionPath();
 
     [Fact]
     public async Task CliTestMode_LoadSolution_WorksCorrectly()

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
@@ -21,7 +21,7 @@ public class MoveMultipleMethodsTests
 
         var orderedIndices = MoveMultipleMethodsTool.OrderOperations(root, sourceClasses, methodNames);
 
-        foreach(var i in orderedIndices)
+        foreach (var i in orderedIndices)
         {
             if (isStatic[i])
             {
@@ -34,7 +34,7 @@ public class MoveMultipleMethodsTests
                 root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod);
             }
         }
-        
+
         var workspace = new AdhocWorkspace();
         var formattedRoot = Formatter.Format(root, workspace);
         return formattedRoot.ToFullString();
@@ -154,4 +154,4 @@ public class TargetClass
         Assert.Contains("return TargetClass.Method1()", sourceClassCode);
         Assert.Contains("return this.field1.Method2(this)", sourceClassCode);
     }
-} 
+}


### PR DESCRIPTION
## Summary
- introduce `TestHelpers` to centralize test utilities
- refactor example and performance tests to use helpers
- remove duplicate solution path logic in other tests
- minor formatting updates from `dotnet format`

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684d5736014c8327be6e0a50625c209d