### PR TITLE
Ensure encoding preservation on file edits

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/AnalyzeRefactoringOpportunities.cs
+++ b/RefactorMCP.ConsoleApp/Tools/AnalyzeRefactoringOpportunities.cs
@@ -40,12 +40,18 @@ public static class AnalyzeRefactoringOpportunitiesTool
         var document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
         if (document != null)
         {
-            var tree = await document.GetSyntaxTreeAsync() ?? CSharpSyntaxTree.ParseText(await File.ReadAllTextAsync(filePath));
+            var tree = await document.GetSyntaxTreeAsync();
+            if (tree == null)
+            {
+                var (text, _) = await RefactoringHelpers.ReadFileWithEncodingAsync(filePath);
+                tree = CSharpSyntaxTree.ParseText(text);
+            }
             var model = await document.GetSemanticModelAsync();
             return (tree, model, solution);
         }
 
-        var syntaxTree = CSharpSyntaxTree.ParseText(await File.ReadAllTextAsync(filePath));
+        var (fileText, _) = await RefactoringHelpers.ReadFileWithEncodingAsync(filePath);
+        var syntaxTree = CSharpSyntaxTree.ParseText(fileText);
         return (syntaxTree, null, null);
     }
 

--- a/RefactorMCP.ConsoleApp/Tools/CleanupUsings.cs
+++ b/RefactorMCP.ConsoleApp/Tools/CleanupUsings.cs
@@ -54,7 +54,8 @@ public static class CleanupUsingsTool
 
         var newRoot = root.RemoveNodes(unused, SyntaxRemoveOptions.KeepNoTrivia);
         var formatted = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
-        await File.WriteAllTextAsync(document.FilePath!, formatted.ToFullString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, formatted.ToFullString(), encoding);
 
         var newDocument = document.WithSyntaxRoot(formatted);
         RefactoringHelpers.UpdateSolutionCache(newDocument);

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
@@ -110,7 +110,8 @@ public static class ConvertToExtensionMethodTool
         var formatted = Formatter.Format(newRoot, document.Project.Solution.Workspace);
         var newDocument = document.WithSyntaxRoot(formatted);
         var newText = await newDocument.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDocument);
 
         return $"Successfully converted method '{methodName}' to extension method in {document.FilePath} (solution mode)";

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
@@ -93,7 +93,8 @@ public static class ConvertToStaticWithInstanceTool
         var formatted = Formatter.Format(newRoot, document.Project.Solution.Workspace);
         var newDocument = document.WithSyntaxRoot(formatted);
         var newText = await newDocument.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDocument);
 
         return $"Successfully converted method '{methodName}' to static with instance parameter in {document.FilePath} (solution mode)";

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
@@ -151,7 +151,8 @@ public static class ConvertToStaticWithParametersTool
         var formattedRoot = Formatter.Format(newRoot, document.Project.Solution.Workspace);
         var newDocument = document.WithSyntaxRoot(formattedRoot);
         var newText = await newDocument.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDocument);
 
         return $"Successfully converted method '{methodName}' to static with parameters in {document.FilePath} (solution mode)";

--- a/RefactorMCP.ConsoleApp/Tools/ExtractMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ExtractMethod.cs
@@ -70,7 +70,8 @@ public static class ExtractMethodTool
 
         // Write the changes back to the file
         var newText = await newDocument.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDocument);
 
         return $"Successfully extracted method '{methodName}' from {selectionRange} in {document.FilePath} (solution mode)";

--- a/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
@@ -33,7 +33,8 @@ public static class InlineMethodTool
                 var formatted = Formatter.Format(newRoot!, refDoc.Project.Solution.Workspace);
                 var newDoc = refDoc.WithSyntaxRoot(formatted);
                 var text = await newDoc.GetTextAsync();
-                await File.WriteAllTextAsync(refDoc.FilePath!, text.ToString());
+                var encoding = await RefactoringHelpers.GetFileEncodingAsync(refDoc.FilePath!);
+                await File.WriteAllTextAsync(refDoc.FilePath!, text.ToString(), encoding);
                 RefactoringHelpers.UpdateSolutionCache(newDoc);
             }
         }
@@ -60,7 +61,8 @@ public static class InlineMethodTool
         var formattedRoot = Formatter.Format(newRoot, document.Project.Solution.Workspace);
         var newDocument = document.WithSyntaxRoot(formattedRoot);
         var newText = await newDocument.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDocument);
 
         return $"Successfully inlined method '{methodName}' in {document.FilePath} (solution mode)";

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
@@ -91,7 +91,8 @@ public static class IntroduceFieldTool
         editor.ReplaceNode(syntaxRoot, formattedRoot);
         var newDocument = editor.GetChangedDocument();
         var newText = await newDocument.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDocument);
 
         return $"Successfully introduced {accessModifier} field '{fieldName}' from {selectionRange} in {document.FilePath} (solution mode)";

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
@@ -48,7 +48,8 @@ public static class IntroduceParameterTool
         var formattedRoot = Formatter.Format(newRoot, document.Project.Solution.Workspace);
         var newDocument = document.WithSyntaxRoot(formattedRoot);
         var newText = await newDocument.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDocument);
 
         return $"Successfully introduced parameter '{parameterName}' from {selectionRange} in method '{methodName}' in {document.FilePath} (solution mode)";

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceVariable.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceVariable.cs
@@ -86,7 +86,8 @@ public static class IntroduceVariableTool
         editor.ReplaceNode(syntaxRoot, formattedRoot);
         var newDocument = editor.GetChangedDocument();
         var newText = await newDocument.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDocument);
 
         return $"Successfully introduced variable '{variableName}' from {selectionRange} in {document.FilePath} (solution mode)";

--- a/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
@@ -50,7 +50,8 @@ public static class MakeFieldReadonlyTool
         var formattedRoot = Formatter.Format(newRoot!, document.Project.Solution.Workspace);
         var newDocument = document.WithSyntaxRoot(formattedRoot);
         var newText = await newDocument.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDocument);
 
         if (initializer != null)

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -91,7 +91,7 @@ public static partial class MoveMultipleMethodsTool
                 targetPath);
         }
 
-        var newText = await File.ReadAllTextAsync(document.FilePath!);
+        var (newText, _) = await RefactoringHelpers.ReadFileWithEncodingAsync(document.FilePath!);
         var newRoot = await CSharpSyntaxTree.ParseText(newText).GetRootAsync();
         var solution = document.Project.Solution.WithDocumentSyntaxRoot(document.Id, newRoot);
 
@@ -99,15 +99,15 @@ public static partial class MoveMultipleMethodsTool
         var targetDocument = project.Documents.FirstOrDefault(d => d.FilePath == targetPath);
         if (targetDocument == null)
         {
-            var targetText = await File.ReadAllTextAsync(targetPath);
-            var targetSource = SourceText.From(targetText, System.Text.Encoding.UTF8);
+            var (targetText, targetEncoding) = await RefactoringHelpers.ReadFileWithEncodingAsync(targetPath);
+            var targetSource = SourceText.From(targetText, targetEncoding);
             targetDocument = project.AddDocument(Path.GetFileName(targetPath), targetSource, filePath: targetPath);
             solution = targetDocument.Project.Solution;
         }
         else
         {
-            var targetText = await File.ReadAllTextAsync(targetPath);
-            var targetSource = SourceText.From(targetText, System.Text.Encoding.UTF8);
+            var (targetText, targetEncoding) = await RefactoringHelpers.ReadFileWithEncodingAsync(targetPath);
+            var targetSource = SourceText.From(targetText, targetEncoding);
             solution = solution.WithDocumentText(targetDocument.Id, targetSource);
         }
 

--- a/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
@@ -115,7 +115,8 @@ public static class SafeDeleteTool
         var formatted = Formatter.Format(newRoot, document.Project.Solution.Workspace);
         var newDoc = document.WithSyntaxRoot(formatted);
         var text = await newDoc.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, text.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, text.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDoc);
         return $"Successfully deleted field '{fieldName}' in {document.FilePath}";
     }
@@ -174,7 +175,8 @@ public static class SafeDeleteTool
         var formatted = Formatter.Format(newRoot, document.Project.Solution.Workspace);
         var newDoc = document.WithSyntaxRoot(formatted);
         var text = await newDoc.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, text.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, text.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDoc);
         return $"Successfully deleted method '{methodName}' in {document.FilePath}";
     }
@@ -240,7 +242,8 @@ public static class SafeDeleteTool
             var formattedRoot = Formatter.Format(rewritten!, doc.Project.Solution.Workspace);
             var newDoc = doc.WithSyntaxRoot(formattedRoot);
             var newText = await newDoc.GetTextAsync();
-            await File.WriteAllTextAsync(doc.FilePath!, newText.ToString());
+            var encoding = await RefactoringHelpers.GetFileEncodingAsync(doc.FilePath!);
+            await File.WriteAllTextAsync(doc.FilePath!, newText.ToString(), encoding);
             RefactoringHelpers.UpdateSolutionCache(newDoc);
         }
 
@@ -301,7 +304,8 @@ public static class SafeDeleteTool
         var formatted = Formatter.Format(newRoot, document.Project.Solution.Workspace);
         var newDoc = document.WithSyntaxRoot(formatted);
         var newText = await newDoc.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDoc);
         return $"Successfully deleted variable '{variable.Identifier.ValueText}' in {document.FilePath}";
     }

--- a/RefactorMCP.ConsoleApp/Tools/TransformSetterToInit.cs
+++ b/RefactorMCP.ConsoleApp/Tools/TransformSetterToInit.cs
@@ -48,7 +48,8 @@ public static class TransformSetterToInitTool
         var formatted = Formatter.Format(newRoot!, document.Project.Solution.Workspace);
         var newDocument = document.WithSyntaxRoot(formatted);
         var newText = await newDocument.GetTextAsync();
-        await File.WriteAllTextAsync(document.FilePath!, newText.ToString());
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText.ToString(), encoding);
         RefactoringHelpers.UpdateSolutionCache(newDocument);
 
         return $"Successfully converted setter to init for '{propertyName}' in {document.FilePath} (solution mode)";


### PR DESCRIPTION
## Summary
- detect encoding when reading files
- persist original encoding when writing results
- apply encoding detection to all agents

## Testing
- `dotnet format`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684d5a456e84832799a0a0448e0b8308