### PR TITLE
Add thread-safety comment for solution cache

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
@@ -15,6 +15,9 @@ using System.Text;
 
 internal static class RefactoringHelpers
 {
+    // MemoryCache is thread-safe and Solution objects from Roslyn are immutable.
+    // This allows us to store and access Solution instances across threads
+    // without additional locking or synchronization.
     internal static MemoryCache SolutionCache = new(new MemoryCacheOptions());
 
     private static readonly Lazy<AdhocWorkspace> _workspace =
@@ -60,6 +63,8 @@ internal static class RefactoringHelpers
         return solution;
     }
 
+    // Solutions are immutable, so replacing the cached instance is safe even
+    // when accessed concurrently by multiple threads.
     internal static void UpdateSolutionCache(Document updatedDocument)
     {
         var solutionPath = updatedDocument.Project.Solution.FilePath;


### PR DESCRIPTION
## Summary
- document that `MemoryCache` is thread-safe and `Solution` objects are immutable

## Testing
- `dotnet format --no-restore`
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_684d5e04835483279136b75f9a59955e