### PR TITLE
Fix build warnings

### DIFF
--- a/RefactorMCP.ConsoleApp/RefactorMCP.ConsoleApp.csproj
+++ b/RefactorMCP.ConsoleApp/RefactorMCP.ConsoleApp.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.5" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.6.10" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
     <PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.3" />

--- a/RefactorMCP.Tests/ExampleCode.cs
+++ b/RefactorMCP.Tests/ExampleCode.cs
@@ -81,11 +81,16 @@ namespace RefactorMCP.Tests.Examples
         // Example for Safe Delete - unused method and variable
         private void UnusedHelper()
         {
+#pragma warning disable CS0219 // Variable is intentionally unused for testing
             int tempValue = 0; // tempValue can be safely deleted
+#pragma warning restore CS0219
         }
 
         // Example field that might be safe to delete
-        private int deprecatedCounter = 0; // Not used anywhere
+        // Field intentionally unused for safe-delete tests
+#pragma warning disable CS0414 // Field is used for analyzer tests
+        private int deprecatedCounter = 0;
+#pragma warning restore CS0414
     }
 
     // Example class for Move Method target

--- a/RefactorMCP.Tests/Roslyn/ExtractAndIntroduceFieldTests.cs
+++ b/RefactorMCP.Tests/Roslyn/ExtractAndIntroduceFieldTests.cs
@@ -40,16 +40,6 @@ public partial class RoslynTransformationTests
         return 10 + 20;
     }
 }";
-        var expected = @"class Calculator
-{
-    private var calculationResult = 10 + 20;
-
-    int CalculateSum()
-    {
-        return calculationResult;
-    }
-}
-";
         var output = IntroduceFieldTool.IntroduceFieldInSource(input, "5:16-5:23", "calculationResult", "private");
         Assert.Contains("private var calculationResult", output);
         Assert.Contains("return calculationResult;", output);

--- a/RefactorMCP.Tests/Tools/CliIntegrationTests.cs
+++ b/RefactorMCP.Tests/Tools/CliIntegrationTests.cs
@@ -20,7 +20,7 @@ public class CliIntegrationTests
     }
 
     [Fact]
-    public async Task CliTestMode_AllToolsListed_ReturnsExpectedTools()
+    public void CliTestMode_AllToolsListed_ReturnsExpectedTools()
     {
         var expectedCommands = new[]
         {


### PR DESCRIPTION
## Summary
- upgrade Microsoft.Build.Locator package
- suppress unused variable and field warnings in ExampleCode
- remove unused variable expectation in ExtractAndIntroduceFieldTests
- make integration test synchronous

## Testing
- `dotnet build -v:m`
- `dotnet test --no-build -v:n`


------
https://chatgpt.com/codex/tasks/task_e_684db399c42083278ca8d28b9be4909b