### PR TITLE
Improve range validation

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/ExtractMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ExtractMethod.cs
@@ -39,6 +39,9 @@ public static class ExtractMethodTool
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var startLine, out var startColumn, out var endLine, out var endColumn))
             return RefactoringHelpers.ThrowMcpException("Error: Invalid selection range format. Use 'startLine:startColumn-endLine:endColumn'");
 
+        if (!RefactoringHelpers.ValidateRange(sourceText, startLine, startColumn, endLine, endColumn, out var error))
+            return RefactoringHelpers.ThrowMcpException(error);
+
         var startPosition = sourceText.Lines[startLine - 1].Start + startColumn - 1;
         var endPosition = sourceText.Lines[endLine - 1].Start + endColumn - 1;
         var span = TextSpan.FromBounds(startPosition, endPosition);
@@ -89,10 +92,14 @@ public static class ExtractMethodTool
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
         var syntaxRoot = syntaxTree.GetRoot();
-        var textLines = SourceText.From(sourceText).Lines;
+        var text = SourceText.From(sourceText);
+        var textLines = text.Lines;
 
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var startLine, out var startColumn, out var endLine, out var endColumn))
             return RefactoringHelpers.ThrowMcpException("Error: Invalid selection range format. Use 'startLine:startColumn-endLine:endColumn'");
+
+        if (!RefactoringHelpers.ValidateRange(text, startLine, startColumn, endLine, endColumn, out var error))
+            return RefactoringHelpers.ThrowMcpException(error);
 
         var startPosition = textLines[startLine - 1].Start + startColumn - 1;
         var endPosition = textLines[endLine - 1].Start + endColumn - 1;

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
@@ -42,6 +42,9 @@ public static class IntroduceFieldTool
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var startLine, out var startColumn, out var endLine, out var endColumn))
             return RefactoringHelpers.ThrowMcpException("Error: Invalid selection range format");
 
+        if (!RefactoringHelpers.ValidateRange(sourceText, startLine, startColumn, endLine, endColumn, out var error))
+            return RefactoringHelpers.ThrowMcpException(error);
+
         var startPosition = sourceText.Lines[startLine - 1].Start + startColumn - 1;
         var endPosition = sourceText.Lines[endLine - 1].Start + endColumn - 1;
         var span = TextSpan.FromBounds(startPosition, endPosition);
@@ -110,10 +113,14 @@ public static class IntroduceFieldTool
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
         var syntaxRoot = syntaxTree.GetRoot();
-        var textLines = SourceText.From(sourceText).Lines;
+        var text = SourceText.From(sourceText);
+        var textLines = text.Lines;
 
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var startLine, out var startColumn, out var endLine, out var endColumn))
             return RefactoringHelpers.ThrowMcpException("Error: Invalid selection range format");
+
+        if (!RefactoringHelpers.ValidateRange(text, startLine, startColumn, endLine, endColumn, out var error))
+            return RefactoringHelpers.ThrowMcpException(error);
 
         var startPosition = textLines[startLine - 1].Start + startColumn - 1;
         var endPosition = textLines[endLine - 1].Start + endColumn - 1;

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
@@ -26,6 +26,9 @@ public static class IntroduceParameterTool
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var startLine, out var startColumn, out var endLine, out var endColumn))
             return RefactoringHelpers.ThrowMcpException("Error: Invalid selection range format");
 
+        if (!RefactoringHelpers.ValidateRange(sourceText, startLine, startColumn, endLine, endColumn, out var error))
+            return RefactoringHelpers.ThrowMcpException(error);
+
         var startPosition = textLines[startLine - 1].Start + startColumn - 1;
         var endPosition = textLines[endLine - 1].Start + endColumn - 1;
         var span = TextSpan.FromBounds(startPosition, endPosition);
@@ -67,7 +70,8 @@ public static class IntroduceParameterTool
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
         var syntaxRoot = syntaxTree.GetRoot();
-        var textLines = SourceText.From(sourceText).Lines;
+        var text = SourceText.From(sourceText);
+        var textLines = text.Lines;
 
         var method = syntaxRoot.DescendantNodes()
             .OfType<MethodDeclarationSyntax>()
@@ -77,6 +81,9 @@ public static class IntroduceParameterTool
 
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var startLine, out var startColumn, out var endLine, out var endColumn))
             return RefactoringHelpers.ThrowMcpException("Error: Invalid selection range format");
+
+        if (!RefactoringHelpers.ValidateRange(text, startLine, startColumn, endLine, endColumn, out var error))
+            return RefactoringHelpers.ThrowMcpException(error);
 
         var startPosition = textLines[startLine - 1].Start + startColumn - 1;
         var endPosition = textLines[endLine - 1].Start + endColumn - 1;

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceVariable.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceVariable.cs
@@ -40,6 +40,9 @@ public static class IntroduceVariableTool
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var startLine, out var startColumn, out var endLine, out var endColumn))
             return RefactoringHelpers.ThrowMcpException("Error: Invalid selection range format");
 
+        if (!RefactoringHelpers.ValidateRange(sourceText, startLine, startColumn, endLine, endColumn, out var error))
+            return RefactoringHelpers.ThrowMcpException(error);
+
         var startPosition = sourceText.Lines[startLine - 1].Start + startColumn - 1;
         var endPosition = sourceText.Lines[endLine - 1].Start + endColumn - 1;
         var span = TextSpan.FromBounds(startPosition, endPosition);
@@ -105,10 +108,14 @@ public static class IntroduceVariableTool
     {
         var syntaxTree = CSharpSyntaxTree.ParseText(sourceText);
         var syntaxRoot = syntaxTree.GetRoot();
-        var textLines = SourceText.From(sourceText).Lines;
+        var text = SourceText.From(sourceText);
+        var textLines = text.Lines;
 
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var startLine, out var startColumn, out var endLine, out var endColumn))
             return RefactoringHelpers.ThrowMcpException("Error: Invalid selection range format");
+
+        if (!RefactoringHelpers.ValidateRange(text, startLine, startColumn, endLine, endColumn, out var error))
+            return RefactoringHelpers.ThrowMcpException(error);
 
         var startPosition = textLines[startLine - 1].Start + startColumn - 1;
         var endPosition = textLines[endLine - 1].Start + endColumn - 1;

--- a/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
@@ -96,6 +96,33 @@ internal static class RefactoringHelpers
                int.TryParse(endParts[1], out endColumn);
     }
 
+    internal static bool ValidateRange(
+        SourceText text,
+        int startLine,
+        int startColumn,
+        int endLine,
+        int endColumn,
+        out string error)
+    {
+        error = string.Empty;
+        if (startLine <= 0 || startColumn <= 0 || endLine <= 0 || endColumn <= 0)
+        {
+            error = "Error: Range values must be positive";
+            return false;
+        }
+        if (startLine > endLine || (startLine == endLine && startColumn >= endColumn))
+        {
+            error = "Error: Range start must precede end";
+            return false;
+        }
+        if (startLine > text.Lines.Count || endLine > text.Lines.Count)
+        {
+            error = "Error: Range exceeds file length";
+            return false;
+        }
+        return true;
+    }
+
     internal static string ThrowMcpException(string message)
     {
         throw new McpException(message);

--- a/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
@@ -284,6 +284,9 @@ public static class SafeDeleteTool
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var sl, out var sc, out var el, out var ec))
             return RefactoringHelpers.ThrowMcpException("Error: Invalid selection range format");
 
+        if (!RefactoringHelpers.ValidateRange(text, sl, sc, el, ec, out var error))
+            return RefactoringHelpers.ThrowMcpException(error);
+
         var start = text.Lines[sl - 1].Start + sc - 1;
         var end = text.Lines[el - 1].Start + ec - 1;
         var span = TextSpan.FromBounds(start, end);
@@ -322,9 +325,13 @@ public static class SafeDeleteTool
     {
         var tree = CSharpSyntaxTree.ParseText(sourceText);
         var root = tree.GetRoot();
-        var lines = SourceText.From(sourceText).Lines;
+        var text = SourceText.From(sourceText);
+        var lines = text.Lines;
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var sl, out var sc, out var el, out var ec))
             return RefactoringHelpers.ThrowMcpException("Error: Invalid selection range format");
+
+        if (!RefactoringHelpers.ValidateRange(text, sl, sc, el, ec, out var error))
+            return RefactoringHelpers.ThrowMcpException(error);
 
         var start = lines[sl - 1].Start + sc - 1;
         var end = lines[el - 1].Start + ec - 1;

--- a/RefactorMCP.Tests/Tools/ExtractMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/ExtractMethodTests.cs
@@ -81,4 +81,18 @@ public class ExtractMethodTests : TestBase
                 range,
                 methodName));
     }
+
+    [Theory]
+    [InlineData("0:1-1:1", "TestMethod")]
+    [InlineData("5:5-3:1", "TestMethod")]
+    public async Task ExtractMethod_InvalidRangeValues_ReturnsError(string range, string methodName)
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        await Assert.ThrowsAsync<McpException>(async () =>
+            await ExtractMethodTool.ExtractMethod(
+                SolutionPath,
+                ExampleFilePath,
+                range,
+                methodName));
+    }
 }


### PR DESCRIPTION
## Summary
- verify ranges after parsing
- validate ranges against document line count
- provide better error messages for range errors
- test invalid range values

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684db76ae1688327b4109f1d21a700aa