### PR TITLE
Fix duplicate sentence in QUICK_REFERENCE

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -73,7 +73,6 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method
   methodName
 ```
 The original method remains and calls the extension method so the interface stays the same.
-The original method remains and calls the extension method so the interface stays the same.
 
 ### Analyze Refactoring Opportunities
 ```bash


### PR DESCRIPTION
## Summary
- remove redundant line in QUICK_REFERENCE

## Testing
- `dotnet format --no-restore --verify-no-changes --verbosity diagnostic`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684dba7b835c8327a975a1b20651cd4b