### PR TITLE
Add persistent metrics cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
 - `version` - Show build version and timestamp
 - `analyze-refactoring-opportunities <solutionPath> <filePath>` - Prompt for refactoring suggestions (long methods, long parameter lists, unused code)
 - `list-class-lengths <solutionPath>` - Prompt for class names and line counts
+- `code-metrics <solutionPath> <filePath>` - Output metrics for classes and methods (results cached to disk)
 
 #### Quick Start Example
 
@@ -218,6 +219,11 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method
 The original instance method remains in the class as a thin wrapper that
 invokes the generated extension method, ensuring existing call sites keep
 working.
+
+### Metrics Cache
+
+`code-metrics` stores results in `codeMetricsCache.json` under the current working directory. Repeated calls with the same
+solution and file paths return the cached JSON without recomputing. Delete this file to reset the cache.
 
 ## Range Format
 

--- a/RefactorMCP.Tests/Tools/CodeMetricsTests.cs
+++ b/RefactorMCP.Tests/Tools/CodeMetricsTests.cs
@@ -1,0 +1,28 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class CodeMetricsToolTests : TestBase
+{
+    [Fact]
+    public async Task RepeatedCalls_UseCachedValue()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var cacheFile = Path.Combine(Path.GetDirectoryName(SolutionPath)!, "codeMetricsCache.json");
+        if (File.Exists(cacheFile))
+            File.Delete(cacheFile);
+
+        var metricsFile = Path.Combine(TestOutputPath, "MetricsSample.cs");
+        await TestUtilities.CreateTestFile(metricsFile, TestUtilities.GetSampleCodeForIntroduceField());
+
+        var first = await CodeMetricsTool.GetFileMetrics(SolutionPath, metricsFile);
+        await File.AppendAllTextAsync(metricsFile, "\npublic class Added {}\n");
+        var second = await CodeMetricsTool.GetFileMetrics(SolutionPath, metricsFile);
+
+        Assert.Equal(first, second);
+        Assert.True(File.Exists(cacheFile));
+    }
+}


### PR DESCRIPTION
## Summary
- persist metrics cache to JSON file in working directory
- test caching of metrics results
- document metrics cache in README

## Testing
- `dotnet format RefactorMCP.sln --no-restore --verbosity diag`
- `dotnet test --logger "trx;LogFileName=test_results.trx"`

------
https://chatgpt.com/codex/tasks/task_e_684dbb22aacc832795515116ee64a033