### PR TITLE
Add RenameSymbol tool

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -152,6 +152,17 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli cleanup-usings \
   "./path/to/file.cs"
 ```
 
+### Rename Symbol
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli rename-symbol \
+  "./RefactorMCP.sln" \
+  "./path/to/file.cs" \
+  OldName \
+  NewName \
+  10 \
+  5
+```
+
 ### Move Instance Method
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
 - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move one or more instance methods to another class. Wrapper methods remain in the original class so existing callers continue to work
 - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [memberType] [targetFilePath]` - Move multiple methods from one class to another. Each method leaves a delegating wrapper behind. Accepts comma separated `methodNames`. The older JSON form is still supported for backward compatibility
 - `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
+- `rename-symbol <solutionPath> <filePath> <oldName> <newName> [line] [column]` - Rename a symbol across the solution
 - `version` - Show build version and timestamp
 - `analyze-refactoring-opportunities <solutionPath> <filePath>` - Prompt for refactoring suggestions (long methods, long parameter lists, unused code)
 - `list-class-lengths <solutionPath>` - Prompt for class names and line counts
@@ -522,6 +523,17 @@ public class Logger
         Console.WriteLine($"[LOG] {message}");
     }
 }
+```
+
+### 11. Rename Symbol
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli rename-symbol \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  numbers \
+  values
 ```
 
 ## Complete Examples

--- a/RefactorMCP.ConsoleApp/Tools/RenameSymbol.cs
+++ b/RefactorMCP.ConsoleApp/Tools/RenameSymbol.cs
@@ -1,0 +1,84 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Rename;
+using Microsoft.CodeAnalysis.FindSymbols;
+using System.ComponentModel;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+[McpServerToolType]
+public static class RenameSymbolTool
+{
+    [McpServerTool, Description("Rename a symbol across the solution using Roslyn")]
+    public static async Task<string> RenameSymbol(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        [Description("Path to the C# file containing the symbol")] string filePath,
+        [Description("Current name of the symbol")] string oldName,
+        [Description("New name for the symbol")] string newName,
+        [Description("Line number of the symbol (1-based, optional)")] int? line = null,
+        [Description("Column number of the symbol (1-based, optional)")] int? column = null)
+    {
+        try
+        {
+            var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
+            var document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
+            if (document == null)
+                return RefactoringHelpers.ThrowMcpException($"Error: File {filePath} not found in solution");
+
+            var symbol = await FindSymbol(document, oldName, line, column);
+            if (symbol == null)
+                return RefactoringHelpers.ThrowMcpException($"Error: Symbol '{oldName}' not found");
+
+            var renamed = await Renamer.RenameSymbolAsync(solution, symbol, newName, solution.Workspace.Options);
+            var changes = renamed.GetChanges(solution);
+            foreach (var projectChange in changes.GetProjectChanges())
+            {
+                foreach (var id in projectChange.GetChangedDocuments())
+                {
+                    var newDoc = renamed.GetDocument(id)!;
+                    var text = await newDoc.GetTextAsync();
+                    var encoding = await RefactoringHelpers.GetFileEncodingAsync(newDoc.FilePath!);
+                    await File.WriteAllTextAsync(newDoc.FilePath!, text.ToString(), encoding);
+                    RefactoringHelpers.UpdateSolutionCache(newDoc);
+                }
+            }
+
+            return $"Successfully renamed '{oldName}' to '{newName}'";
+        }
+        catch (Exception ex)
+        {
+            throw new McpException($"Error renaming symbol: {ex.Message}", ex);
+        }
+    }
+
+    private static async Task<ISymbol?> FindSymbol(Document document, string name, int? line, int? column)
+    {
+        var model = await document.GetSemanticModelAsync();
+        var root = await document.GetSyntaxRootAsync();
+        if (model == null || root == null)
+            return null;
+
+        if (line.HasValue && column.HasValue)
+        {
+            var text = await document.GetTextAsync();
+            if (line.Value > 0 && line.Value <= text.Lines.Count && column.Value > 0)
+            {
+                var pos = text.Lines[line.Value - 1].Start + column.Value - 1;
+                var token = root.FindToken(pos);
+                var node = token.Parent;
+                while (node != null)
+                {
+                    var sym = model.GetDeclaredSymbol(node) ?? model.GetSymbolInfo(node).Symbol;
+                    if (sym != null && sym.Name == name)
+                        return sym;
+                    node = node.Parent;
+                }
+            }
+        }
+
+        var decls = await SymbolFinder.FindDeclarationsAsync(document.Project, name, false);
+        return decls.FirstOrDefault();
+    }
+}

--- a/RefactorMCP.Tests/Tools/RenameSymbolTests.cs
+++ b/RefactorMCP.Tests/Tools/RenameSymbolTests.cs
@@ -1,0 +1,55 @@
+using ModelContextProtocol;
+using Microsoft.CodeAnalysis;
+using System.Linq;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class RenameSymbolTests : TestBase
+{
+    [Fact]
+    public async Task RenameSymbol_Field_RenamesAllReferences()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var testFile = Path.Combine(TestOutputPath, "RenameSymbol.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForRenameSymbol());
+        var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);
+        var project = solution.Projects.First();
+        RefactoringHelpers.AddDocumentToProject(project, testFile);
+
+        var result = await RenameSymbolTool.RenameSymbol(
+            SolutionPath,
+            testFile,
+            "numbers",
+            "values");
+
+        Assert.Contains("Successfully renamed", result);
+        var content = await File.ReadAllTextAsync(testFile);
+        Assert.DoesNotContain("List<int> numbers", content);
+        Assert.DoesNotContain("numbers.Add", content);
+        Assert.Contains("List<int> values", content);
+        Assert.Contains("values.Add", content);
+    }
+
+    [Fact]
+    public async Task RenameSymbol_InvalidName_ReturnsError()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var testFile = Path.Combine(TestOutputPath, "RenameInvalid.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForRenameSymbol());
+        var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);
+        var project = solution.Projects.First();
+        RefactoringHelpers.AddDocumentToProject(project, testFile);
+
+        await Assert.ThrowsAsync<McpException>(() =>
+            RenameSymbolTool.RenameSymbol(
+                SolutionPath,
+                testFile,
+                "missing",
+                "newName"));
+    }
+}

--- a/RefactorMCP.Tests/Tools/TestUtilities.cs
+++ b/RefactorMCP.Tests/Tools/TestUtilities.cs
@@ -171,5 +171,8 @@ public class CleanupSample
 
     public static string GetSampleCodeForMoveClassToFile() =>
         File.ReadAllText(Path.Combine(Path.GetDirectoryName(GetSolutionPath())!, "RefactorMCP.Tests", "ExampleCode.cs"));
+
+    public static string GetSampleCodeForRenameSymbol() =>
+        File.ReadAllText(Path.Combine(Path.GetDirectoryName(GetSolutionPath())!, "RefactorMCP.Tests", "ExampleCode.cs"));
 }
 


### PR DESCRIPTION
## Summary
- add RenameSymbol tool using Roslyn Renamer
- document RenameSymbol usage in README and quick reference
- provide RenameSymbol tests

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684dbb0f4ba8832795bb65b355063705