### PR TITLE
Improve test suite coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -432,4 +432,4 @@ $RECYCLE.BIN/
 runtimes/
 BuildHost-net472/
 BuildHost-netcore/ 
-TestOutput/
+TestOutput/codeMetricsCache.json

--- a/RefactorMCP.Tests/Roslyn/AstTransformationsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/AstTransformationsTests.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void AddParameter_AddsParameterToMethod()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test() { }") as MethodDeclarationSyntax;
+        var updated = AstTransformations.AddParameter(method!, "value", "int");
+
+        Assert.Single(updated.ParameterList.Parameters);
+        Assert.Equal("value", updated.ParameterList.Parameters[0].Identifier.ValueText);
+        Assert.Equal("int", updated.ParameterList.Parameters[0].Type!.ToString());
+    }
+
+    [Fact]
+    public void ReplaceThisReferences_ReplacesWithParameter()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration(
+            "void Test() { Console.WriteLine(this.Value); }") as MethodDeclarationSyntax;
+        var updated = AstTransformations.ReplaceThisReferences(method!, "instance");
+        var output = updated.NormalizeWhitespace().ToFullString();
+
+        Assert.Contains("instance.Value", output);
+        Assert.DoesNotContain("this.Value", output);
+    }
+
+    [Fact]
+    public void QualifyInstanceMembers_AddsParameterQualification()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration(
+            "void Test() { Console.WriteLine(Value); }") as MethodDeclarationSyntax;
+        var qualified = AstTransformations.QualifyInstanceMembers(
+            method!,
+            "instance",
+            new HashSet<string> { "Value" });
+
+        var output = qualified.NormalizeWhitespace().ToFullString();
+        Assert.Contains("instance.Value", output);
+    }
+
+    [Fact]
+    public void EnsureStaticModifier_AddsStaticIfMissing()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test() { }") as MethodDeclarationSyntax;
+        var updated = AstTransformations.EnsureStaticModifier(method!);
+
+        Assert.Contains("static", updated.Modifiers.ToFullString());
+    }
+}

--- a/RefactorMCP.Tests/TEST_SUMMARY.md
+++ b/RefactorMCP.Tests/TEST_SUMMARY.md
@@ -29,6 +29,7 @@ Tests covering code metrics and refactoring suggestions:
 
 ### 5. RoslynTransformationTests (`Roslyn/`)
 Unit tests for single-file syntax transformations used by many tools.
+Includes tests for AST helper methods in `AstTransformations`.
 
 ### 6. CliIntegrationTests (`UnitTest1.cs`)
 **CLI integration tests**:


### PR DESCRIPTION
## Summary
- add AstTransformations unit tests
- document new Roslyn tests in TEST_SUMMARY
- ignore generated codeMetricsCache.json

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684decf2b4e0832796de59fbb26989f3