### PR TITLE
Add SafeDelete tests

### DIFF
--- a/RefactorMCP.Tests/ExampleValidationTests.cs
+++ b/RefactorMCP.Tests/ExampleValidationTests.cs
@@ -189,6 +189,7 @@ public class ExampleValidationTests : IDisposable
 
         Assert.Contains("Successfully extracted method", result);
         var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.Contains("ValidateInputs();", fileContent);
     }
 
     [Fact]

--- a/RefactorMCP.Tests/Tools/SafeDeleteTests.cs
+++ b/RefactorMCP.Tests/Tools/SafeDeleteTests.cs
@@ -1,0 +1,60 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class SafeDeleteTests : TestBase
+{
+    [Fact]
+    public async Task SafeDeleteField_UnusedField_ReturnsSuccess()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var testFile = Path.Combine(TestOutputPath, "SafeDeleteField.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForSafeDelete());
+
+        var result = await SafeDeleteTool.SafeDeleteField(
+            SolutionPath,
+            testFile,
+            "deprecatedCounter");
+
+        Assert.Contains("Successfully deleted field", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.DoesNotContain("deprecatedCounter", fileContent);
+    }
+
+    [Fact]
+    public async Task SafeDeleteMethod_UnusedMethod_ReturnsSuccess()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var testFile = Path.Combine(TestOutputPath, "SafeDeleteMethod.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForSafeDelete());
+
+        var result = await SafeDeleteTool.SafeDeleteMethod(
+            SolutionPath,
+            testFile,
+            "UnusedHelper");
+
+        Assert.Contains("Successfully deleted method", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.DoesNotContain("UnusedHelper", fileContent);
+    }
+
+    [Fact]
+    public async Task SafeDeleteVariable_UnusedLocal_ReturnsSuccess()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var testFile = Path.Combine(TestOutputPath, "SafeDeleteVariable.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForSafeDelete());
+
+        var result = await SafeDeleteTool.SafeDeleteVariable(
+            SolutionPath,
+            testFile,
+            "85:13-85:30");
+
+        Assert.Contains("Successfully deleted variable", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.DoesNotContain("tempValue", fileContent);
+    }
+}


### PR DESCRIPTION
## Summary
- verify QuickReference Extract Method example properly updates file
- add SafeDelete tool tests for deleting unused fields, methods and variables

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet test RefactorMCP.Tests/RefactorMCP.Tests.csproj -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_684decf2b4e0832796de59fbb26989f3