### PR TITLE
Add missing syntax rewriter tests

### DIFF
--- a/RefactorMCP.Tests/Roslyn/Rewriters/ExtensionMethodRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ExtensionMethodRewriterTests.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void ExtensionMethodRewriter_AddsThisParameterAndQualifiesMembers()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Print(){ Console.WriteLine(Value); }") as MethodDeclarationSyntax;
+        var rewriter = new ExtensionMethodRewriter("inst", "C", new HashSet<string> { "Value" });
+        var result = rewriter.Rewrite(method!).NormalizeWhitespace().ToFullString();
+        Assert.Contains("static", result);
+        Assert.Contains("this C inst", result);
+        Assert.Contains("inst.Value", result);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/ExtractMethodRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ExtractMethodRewriterTests.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void ExtractMethodRewriter_ExtractsStatementsToNewMethod()
+    {
+        var code = @"class C{ void M(){ Console.WriteLine(1); Console.WriteLine(2); } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+        var firstStmt = method.Body!.Statements.First();
+        var rewriter = new ExtractMethodRewriter(method, root.DescendantNodes().OfType<ClassDeclarationSyntax>().First(), new List<StatementSyntax> { firstStmt }, "NewMethod");
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var text = newRoot.ToFullString();
+        Assert.Contains("private void NewMethod()", text);
+        Assert.Contains("NewMethod();", text);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/FieldIntroductionRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/FieldIntroductionRewriterTests.cs
@@ -1,0 +1,31 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void FieldIntroductionRewriter_AddsFieldAndReplacesExpression()
+    {
+        var tree = CSharpSyntaxTree.ParseText("class C{int Get(){return 1;}} ");
+        var root = tree.GetRoot();
+        var expr = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1));
+        var fieldRef = SyntaxFactory.IdentifierName("value");
+        var fieldDecl = SyntaxFactory.FieldDeclaration(
+                SyntaxFactory.VariableDeclaration(SyntaxFactory.ParseTypeName("int"))
+                    .AddVariables(SyntaxFactory.VariableDeclarator("value")
+                        .WithInitializer(SyntaxFactory.EqualsValueClause(expr))))
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
+        var classNode = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
+        var rewriter = new FieldIntroductionRewriter(expr, fieldRef, fieldDecl, classNode);
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var text = newRoot.ToFullString();
+        Assert.Contains("private int value", text);
+        Assert.Contains("return value", text);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/FieldRemovalRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/FieldRemovalRewriterTests.cs
@@ -1,0 +1,19 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void FieldRemovalRewriter_RemovesField()
+    {
+        var tree = CSharpSyntaxTree.ParseText("class A{int x;}");
+        var root = tree.GetRoot();
+        var rewriter = new FieldRemovalRewriter("x");
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        Assert.Equal("class A { }", newRoot.ToFullString().Trim());
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/InlineInvocationRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/InlineInvocationRewriterTests.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void InlineInvocationRewriter_InlinesVoidMethodCall()
+    {
+        var code = @"class C{ void Helper(){ Console.WriteLine(""Hi""); } void Call(){ Helper(); } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+        var helper = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First(m => m.Identifier.ValueText == "Helper");
+        var rewriter = new InlineInvocationRewriter(helper);
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var callMethod = newRoot.DescendantNodes().OfType<MethodDeclarationSyntax>().First(m => m.Identifier.ValueText == "Call");
+        var text = callMethod.Body!.Statements.ToFullString();
+        Assert.Contains("Console.WriteLine(\"Hi\");", text);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberRewriterTests.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void InstanceMemberRewriter_QualifiesMembers()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test(){ Value = 1; }") as MethodDeclarationSyntax;
+        var rewriter = new InstanceMemberRewriter("inst", new HashSet<string> { "Value" });
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("inst.Value", result);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/MethodCallRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/MethodCallRewriterTests.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void MethodCallRewriter_QualifiesMethodCalls()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test(){ Do(); }") as MethodDeclarationSyntax;
+        var rewriter = new MethodCallRewriter(new HashSet<string> { "Do" }, "inst");
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("inst.Do()", result);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/MethodRemovalRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/MethodRemovalRewriterTests.cs
@@ -1,0 +1,19 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void MethodRemovalRewriter_RemovesMethod()
+    {
+        var tree = CSharpSyntaxTree.ParseText("class A{void M(){}}");
+        var root = tree.GetRoot();
+        var rewriter = new MethodRemovalRewriter("M");
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        Assert.Equal("class A { }", newRoot.ToFullString().Trim());
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/ParameterIntroductionRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ParameterIntroductionRewriterTests.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void ParameterIntroductionRewriter_AddsParameterAndArgument()
+    {
+        var code = @"class C{ void M(){Console.WriteLine(1);} void Call(){ M(); } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+        var expr = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1));
+        var parameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier("p")).WithType(SyntaxFactory.ParseTypeName("int"));
+        var paramRef = SyntaxFactory.IdentifierName("p");
+        var rewriter = new ParameterIntroductionRewriter(expr, "M", parameter, paramRef);
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var text = newRoot.ToFullString();
+        Assert.Contains("void M(int p)", text);
+        Assert.Contains("Console.WriteLine(p)", text);
+        Assert.Contains("M(1);", text);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/ParameterRemovalRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ParameterRemovalRewriterTests.cs
@@ -1,0 +1,19 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void ParameterRemovalRewriter_RemovesParameter()
+    {
+        var tree = CSharpSyntaxTree.ParseText("class A{void M(int a,int b){}} ");
+        var root = tree.GetRoot();
+        var rewriter = new ParameterRemovalRewriter("M", 1);
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        Assert.Contains("void M(int a)", newRoot.ToFullString());
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/ParameterRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ParameterRewriterTests.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void ParameterRewriter_ReplacesIdentifiers()
+    {
+        var expr = SyntaxFactory.ParseExpression("a + b");
+        var map = new Dictionary<string, ExpressionSyntax>
+        {
+            ["a"] = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1)),
+            ["b"] = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(2))
+        };
+        var rewriter = new ParameterRewriter(map);
+        var result = rewriter.Visit(expr)!.NormalizeWhitespace().ToFullString();
+        Assert.Equal("1 + 2", result);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/ReadonlyFieldRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ReadonlyFieldRewriterTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void ReadonlyFieldRewriter_MakesFieldReadonlyAndMovesInit()
+    {
+        var code = @"class C{ int x=1; C(){ } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+        var init = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1));
+        var rewriter = new ReadonlyFieldRewriter("x", init);
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var text = newRoot.ToFullString();
+        Assert.Contains("readonly int x", text);
+        Assert.Contains("x = 1;", text);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/SetterToInitRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/SetterToInitRewriterTests.cs
@@ -1,0 +1,18 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void SetterToInitRewriter_ReplacesSetterWithInit()
+    {
+        var prop = SyntaxFactory.ParseMemberDeclaration("public int P { get; set; }") as PropertyDeclarationSyntax;
+        var rewriter = new SetterToInitRewriter("P");
+        var result = rewriter.Visit(prop!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("init", result);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/StaticConversionRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/StaticConversionRewriterTests.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void StaticConversionRewriter_ConvertsInstanceMethod()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("int GetX(){ return x; }") as MethodDeclarationSyntax;
+        var rewriter = new StaticConversionRewriter(System.Array.Empty<(string Name, string Type)>(), "inst", new HashSet<string> { "x" });
+        var result = rewriter.Rewrite(method!).NormalizeWhitespace().ToFullString();
+        Assert.Contains("static", result);
+        Assert.Contains("inst.x", result);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/StaticFieldRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/StaticFieldRewriterTests.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void StaticFieldRewriter_QualifiesStaticField()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test(){ x = 1; }") as MethodDeclarationSyntax;
+        var rewriter = new StaticFieldRewriter(new HashSet<string> { "x" }, "C");
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("C.x", result);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/VariableIntroductionRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/VariableIntroductionRewriterTests.cs
@@ -1,0 +1,32 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void VariableIntroductionRewriter_AddsVariable()
+    {
+        var code = @"class C{ void M(){ Console.WriteLine(1+2); } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+        var expr = SyntaxFactory.ParseExpression("1+2");
+        var varRef = SyntaxFactory.IdentifierName("sum");
+        var varDecl = SyntaxFactory.LocalDeclarationStatement(
+                SyntaxFactory.VariableDeclaration(SyntaxFactory.IdentifierName("var"))
+                    .AddVariables(SyntaxFactory.VariableDeclarator("sum")
+                        .WithInitializer(SyntaxFactory.EqualsValueClause(expr))));
+        var callStmt = root.DescendantNodes().OfType<ExpressionStatementSyntax>().First();
+        var block = callStmt.Ancestors().OfType<BlockSyntax>().First();
+        var rewriter = new VariableIntroductionRewriter(expr, varRef, varDecl, callStmt, block);
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var text = newRoot.ToFullString();
+        Assert.Contains("var sum = 1 + 2;", text);
+        Assert.Contains("Console.WriteLine(sum);", text);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/VariableRemovalRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/VariableRemovalRewriterTests.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void VariableRemovalRewriter_RemovesVariable()
+    {
+        var tree = CSharpSyntaxTree.ParseText("void M(){int x=0;}");
+        var root = tree.GetRoot();
+        var varNode = root.DescendantNodes().OfType<VariableDeclaratorSyntax>().First();
+        var rewriter = new VariableRemovalRewriter("x", varNode.Span);
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        Assert.Equal("void M() { }", newRoot.ToFullString().Trim());
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/SafeDeleteTests.cs
+++ b/RefactorMCP.Tests/Roslyn/SafeDeleteTests.cs
@@ -82,44 +82,4 @@ public partial class RoslynTransformationTests
         Assert.Equal(expected, output.Trim());
     }
 
-    [Fact]
-    public void FieldRemovalRewriter_RemovesField()
-    {
-        var tree = CSharpSyntaxTree.ParseText("class A{int x;}");
-        var root = tree.GetRoot();
-        var rewriter = new FieldRemovalRewriter("x");
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
-        Assert.Equal("class A { }", newRoot.ToFullString().Trim());
-    }
-
-    [Fact]
-    public void MethodRemovalRewriter_RemovesMethod()
-    {
-        var tree = CSharpSyntaxTree.ParseText("class A{void M(){}}");
-        var root = tree.GetRoot();
-        var rewriter = new MethodRemovalRewriter("M");
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
-        Assert.Equal("class A { }", newRoot.ToFullString().Trim());
-    }
-
-    [Fact]
-    public void ParameterRemovalRewriter_RemovesParameter()
-    {
-        var tree = CSharpSyntaxTree.ParseText("class A{void M(int a,int b){}}");
-        var root = tree.GetRoot();
-        var rewriter = new ParameterRemovalRewriter("M", 1);
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
-        Assert.Contains("void M(int a)", newRoot.ToFullString());
-    }
-
-    [Fact]
-    public void VariableRemovalRewriter_RemovesVariable()
-    {
-        var tree = CSharpSyntaxTree.ParseText("void M(){int x=0;}");
-        var root = tree.GetRoot();
-        var varNode = root.DescendantNodes().OfType<VariableDeclaratorSyntax>().First();
-        var rewriter = new VariableRemovalRewriter("x", varNode.Span);
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
-        Assert.Equal("void M() { }", newRoot.ToFullString().Trim());
-    }
 }


### PR DESCRIPTION
## Summary
- add one test file per syntax rewriter under Roslyn/Rewriters
- remove aggregated SyntaxRewritersTests
- prune duplicate tests from SafeDelete

## Testing
- `dotnet format --no-restore`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_684e74bb29f08327a50687827f238017