### PR TITLE
Fix rewriting of properties accessed via `this`

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberRewriter.cs
@@ -16,6 +16,19 @@ internal class InstanceMemberRewriter : CSharpSyntaxRewriter
         _knownInstanceMembers = knownInstanceMembers;
     }
 
+    public override SyntaxNode? VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+    {
+        if (node.Expression is ThisExpressionSyntax &&
+            node.Name is IdentifierNameSyntax id &&
+            _knownInstanceMembers.Contains(id.Identifier.ValueText))
+        {
+            var updated = node.WithExpression(SyntaxFactory.IdentifierName(_parameterName));
+            return base.VisitMemberAccessExpression(updated);
+        }
+
+        return base.VisitMemberAccessExpression(node);
+    }
+
     public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
     {
         var parent = node.Parent;

--- a/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberRewriterTests.cs
@@ -16,4 +16,15 @@ public partial class RoslynTransformationTests
         var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
         Assert.Contains("inst.Value", result);
     }
+
+    [Fact]
+    public void InstanceMemberRewriter_RewritesThisPropertyAccess()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test(){ var x = this.Value; }") as MethodDeclarationSyntax;
+        var rewriter = new InstanceMemberRewriter("inst", new HashSet<string> { "Value" });
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+
+        Assert.Contains("inst.Value", result);
+        Assert.DoesNotContain("this.Value", result);
+    }
 }


### PR DESCRIPTION
## Summary
- handle `this.Property` in `InstanceMemberRewriter`
- test property rewriting with explicit `this` access

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684fe0e2805c8327b1e6f229306e5538