### PR TITLE
Fix parameter rewriting for 'this.' accesses

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberRewriter.cs
@@ -16,6 +16,19 @@ internal class InstanceMemberRewriter : CSharpSyntaxRewriter
         _knownInstanceMembers = knownInstanceMembers;
     }
 
+    public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+    {
+        if (node.Expression is ThisExpressionSyntax &&
+            node.Name is IdentifierNameSyntax id &&
+            _knownInstanceMembers.Contains(id.Identifier.ValueText))
+        {
+            var updated = node.WithExpression(SyntaxFactory.IdentifierName(_parameterName));
+            return base.VisitMemberAccessExpression(updated);
+        }
+
+        return base.VisitMemberAccessExpression(node);
+    }
+
     public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
     {
         var parent = node.Parent;

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodCallRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodCallRewriter.cs
@@ -30,6 +30,14 @@ internal class MethodCallRewriter : CSharpSyntaxRewriter
                 return node.WithExpression(memberAccess);
             }
         }
+        else if (node.Expression is MemberAccessExpressionSyntax member &&
+                 member.Expression is ThisExpressionSyntax &&
+                 member.Name is IdentifierNameSyntax id &&
+                 _classMethodNames.Contains(id.Identifier.ValueText))
+        {
+            var updatedMember = member.WithExpression(SyntaxFactory.IdentifierName(_parameterName));
+            return node.WithExpression(updatedMember);
+        }
 
         return base.VisitInvocationExpression(node);
     }

--- a/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberRewriterTests.cs
@@ -16,4 +16,14 @@ public partial class RoslynTransformationTests
         var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
         Assert.Contains("inst.Value", result);
     }
+
+    [Fact]
+    public void InstanceMemberRewriter_QualifiesThisMember()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test(){ var x = this.Value; }") as MethodDeclarationSyntax;
+        var rewriter = new InstanceMemberRewriter("inst", new HashSet<string> { "Value" });
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("inst.Value", result);
+        Assert.DoesNotContain("this.Value", result);
+    }
 }

--- a/RefactorMCP.Tests/Roslyn/Rewriters/MethodCallRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/MethodCallRewriterTests.cs
@@ -16,4 +16,14 @@ public partial class RoslynTransformationTests
         var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
         Assert.Contains("inst.Do()", result);
     }
+
+    [Fact]
+    public void MethodCallRewriter_QualifiesThisMethodCalls()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test(){ this.Do(); }") as MethodDeclarationSyntax;
+        var rewriter = new MethodCallRewriter(new HashSet<string> { "Do" }, "inst");
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("inst.Do()", result);
+        Assert.DoesNotContain("this.Do()", result);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure InstanceMemberRewriter handles `this.` member accesses
- ensure MethodCallRewriter updates calls like `this.Method()`
- add regression tests for rewriting `this` properties and methods

## Testing
- `dotnet format RefactorMCP.sln --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684fe0e2805c8327b1e6f229306e5538