### PR TITLE
Fix namespace preservation for moved classes

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
@@ -43,7 +43,7 @@ public static partial class MoveMethodsTool
             targetRoot = PropagateUsings(sourceRoot, targetRoot);
         }
 
-        targetRoot = AddMethodToTargetClass(targetRoot, targetClass, moveResult.MovedMethod);
+        targetRoot = AddMethodToTargetClass(targetRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
 
         var formattedTarget = Formatter.Format(targetRoot, RefactoringHelpers.SharedWorkspace);
         Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
@@ -105,7 +105,7 @@ public static partial class MoveMethodsTool
 
         if (sameFile)
         {
-            var targetRoot = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod);
+            var targetRoot = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
             var formatted = Formatter.Format(targetRoot, RefactoringHelpers.SharedWorkspace);
             var targetEncoding = File.Exists(targetPath)
                 ? await RefactoringHelpers.GetFileEncodingAsync(targetPath)
@@ -119,7 +119,7 @@ public static partial class MoveMethodsTool
 
             var targetRoot = await LoadOrCreateTargetRoot(targetPath);
             targetRoot = PropagateUsings(sourceRoot, targetRoot);
-            targetRoot = AddMethodToTargetClass(targetRoot, targetClass, moveResult.MovedMethod);
+            targetRoot = AddMethodToTargetClass(targetRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
 
             var formattedTarget = Formatter.Format(targetRoot, RefactoringHelpers.SharedWorkspace);
             Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
@@ -44,7 +44,7 @@ public static partial class MoveMethodsTool
         var root = tree.GetRoot();
 
         var moveResult = MoveStaticMethodAst(root, methodName, targetClass);
-        var finalRoot = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod);
+        var finalRoot = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
 
         var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace);
         return formatted.ToFullString();
@@ -56,7 +56,7 @@ public static partial class MoveMethodsTool
         var root = tree.GetRoot();
 
         var moveResult = MoveInstanceMethodAst(root, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
-        var finalRoot = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod);
+        var finalRoot = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
 
         var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace);
         return formatted.ToFullString();
@@ -70,7 +70,7 @@ public static partial class MoveMethodsTool
         foreach (var methodName in methodNames)
         {
             var moveResult = MoveInstanceMethodAst(root, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
-            root = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod);
+            root = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
         }
 
         var formatted = Formatter.Format(root, RefactoringHelpers.SharedWorkspace);

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -28,12 +28,12 @@ namespace RefactorMCP.Tests.Roslyn
                 if (isStatic[i])
                 {
                     var moveResult = MoveMethodsTool.MoveStaticMethodAst(root, methodNames[i], targetClasses[i]);
-                    root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod);
+                    root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
                 }
                 else
                 {
                     var moveResult = MoveMethodsTool.MoveInstanceMethodAst(root, sourceClasses[i], methodNames[i], targetClasses[i], accessMembers[i], accessMemberTypes[i]);
-                    root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod);
+                    root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
                 }
             }
 

--- a/RefactorMCP.Tests/Tools/MoveMethodNamespaceTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMethodNamespaceTests.cs
@@ -1,0 +1,33 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class MoveMethodNamespaceTests : TestBase
+{
+    [Fact]
+    public async Task MoveInstanceMethod_PreservesNamespaceInNewFile()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.Combine(TestOutputPath, "NamespaceSample.cs");
+        await TestUtilities.CreateTestFile(testFile, "namespace Sample.Namespace { public class A { public void Foo() {} } }");
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+
+        var targetFile = Path.Combine(Path.GetDirectoryName(testFile)!, "B.cs");
+        var result = await MoveMethodsTool.MoveInstanceMethod(
+            SolutionPath,
+            testFile,
+            "A",
+            "Foo",
+            "B",
+            "_b",
+            "field",
+            targetFile);
+
+        Assert.Contains("Successfully moved", result);
+        var newContent = await File.ReadAllTextAsync(targetFile);
+        Assert.Contains("namespace Sample.Namespace", newContent);
+    }
+}

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
@@ -26,12 +26,12 @@ public class MoveMultipleMethodsTests
             if (isStatic[i])
             {
                 var moveResult = MoveMethodsTool.MoveStaticMethodAst(root, methodNames[i], targetClasses[i]);
-                root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod);
+                root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
             }
             else
             {
                 var moveResult = MoveMethodsTool.MoveInstanceMethodAst(root, sourceClasses[i], methodNames[i], targetClasses[i], accessMembers[i], accessMemberTypes[i]);
-                root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod);
+                root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
             }
         }
 


### PR DESCRIPTION
## Summary
- ensure AddMethodToTargetClass keeps classes in the original namespace
- plumb namespace info through MoveMethods helpers
- update MoveMethods tests for new AddMethodToTargetClass API
- add regression test to verify namespace is preserved

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_684fe135cc908327a83b0e39a3711c42