### PR TITLE
Avoid this prefix in moved method stubs

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -434,27 +434,12 @@ public static partial class MoveMethodsTool
         foreach (var fieldName in fieldArguments)
         {
             originalParameters.Add(SyntaxFactory.Argument(
-                SyntaxFactory.MemberAccessExpression(
-                    SyntaxKind.SimpleMemberAccessExpression,
-                    SyntaxFactory.ThisExpression(),
-                    SyntaxFactory.IdentifierName(fieldName))));
+                SyntaxFactory.IdentifierName(fieldName)));
         }
 
         var argumentList = SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(originalParameters));
 
-        ExpressionSyntax accessExpression;
-        if (string.Equals(accessMemberType, "field", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(accessMemberType, "property", StringComparison.OrdinalIgnoreCase))
-        {
-            accessExpression = SyntaxFactory.MemberAccessExpression(
-                SyntaxKind.SimpleMemberAccessExpression,
-                SyntaxFactory.ThisExpression(),
-                SyntaxFactory.IdentifierName(accessMemberName));
-        }
-        else
-        {
-            accessExpression = SyntaxFactory.IdentifierName(accessMemberName);
-        }
+        ExpressionSyntax accessExpression = SyntaxFactory.IdentifierName(accessMemberName);
 
         var methodExpression = CreateMethodExpression(methodName, typeParameters, needsThisParameter);
 

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -174,9 +174,9 @@ public class TargetClass
             Assert.DoesNotContain("public int Method2() { return Method1() + 1; }", sourceClassCode);
             Assert.DoesNotContain("public int Method3() { return Method2() + 1; }", sourceClassCode);
 
-            Assert.Contains("return this.field1.Method1(this.field1)", sourceClassCode);
-            Assert.Contains("return this.field1.Method2(this)", sourceClassCode);
-            Assert.Contains("return this.field1.Method3(this)", sourceClassCode);
+            Assert.Contains("return field1.Method1(field1)", sourceClassCode);
+            Assert.Contains("return field1.Method2(this)", sourceClassCode);
+            Assert.Contains("return field1.Method3(this)", sourceClassCode);
         }
 
         [Fact]
@@ -208,7 +208,7 @@ public class TargetClass
 
             Assert.Contains("public int GetValue(int _value)", formatted);
             Assert.Contains("return _value + 2", formatted);
-            Assert.Contains("return this._target.GetValue(this._value)", formatted);
+            Assert.Contains("return _target.GetValue(_value)", formatted);
         }
     }
 }

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
@@ -112,8 +112,8 @@ public class TargetClass
         Assert.Contains("public int Method2(int field1)", targetClassCode);
         Assert.DoesNotContain("public int Method1() { return field1; }", sourceClassCode);
         Assert.DoesNotContain("public int Method2() { return field1 + 1; }", sourceClassCode);
-        Assert.Contains("return this.field1.Method1(this.field1)", sourceClassCode);
-        Assert.Contains("return this.field1.Method2(this.field1)", sourceClassCode);
+        Assert.Contains("return field1.Method1(field1)", sourceClassCode);
+        Assert.Contains("return field1.Method2(field1)", sourceClassCode);
     }
 
     [Fact]
@@ -152,6 +152,6 @@ public class TargetClass
         Assert.DoesNotContain("public static int Method1() { return 1; }", sourceClassCode);
         Assert.DoesNotContain("public int Method2() { return field1; }", sourceClassCode);
         Assert.Contains("return TargetClass.Method1()", sourceClassCode);
-        Assert.Contains("return this.field1.Method2(this.field1)", sourceClassCode);
+        Assert.Contains("return field1.Method2(field1)", sourceClassCode);
     }
 }


### PR DESCRIPTION
## Summary
- drop explicit `this.` for access members in MoveMethods tool
- update tests expecting new stub invocation style

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68500a81bb548327b7cea9919d29fa39