### PR TITLE
Prevent moving instance methods to static classes

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -553,6 +553,13 @@ public static partial class MoveMethodsTool
         }
         else
         {
+            if (targetClassDecl.Modifiers.Any(SyntaxKind.StaticKeyword) &&
+                !method.Modifiers.Any(SyntaxKind.StaticKeyword))
+            {
+                throw new McpException(
+                    $"Error: Cannot move instance method '{method.Identifier.ValueText}' to static class '{targetClass}'");
+            }
+
             var updatedClass = targetClassDecl.AddMembers(method.WithLeadingTrivia());
             return targetRoot.ReplaceNode(targetClassDecl, updatedClass);
         }

--- a/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
@@ -31,4 +31,23 @@ public class MoveInstanceMethodTests : TestBase
         Assert.Contains("A.Do", result);
         Assert.Contains("B", result);
     }
+
+    [Fact]
+    public async Task MoveInstanceMethod_FailsWhenTargetClassIsStatic()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MoveInstanceMethodStatic.cs"));
+        await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public static class B { }");
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+
+        await Assert.ThrowsAsync<McpException>(() =>
+            MoveMethodsTool.MoveInstanceMethod(
+                SolutionPath,
+                testFile,
+                "A",
+                "Do",
+                "B",
+                "_b",
+                "field"));
+    }
 }


### PR DESCRIPTION
## Summary
- ensure AddMethodToTargetClass rejects adding instance methods to static classes
- test moving an instance method to a static class

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68501d7387988327b5b199ad2466c7b4