### PR TITLE
Handle static class when moving instance methods

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -521,7 +521,8 @@ public static partial class MoveMethodsTool
         SyntaxNode targetRoot,
         string targetClass,
         MethodDeclarationSyntax method,
-        string? namespaceName = null)
+        string? namespaceName = null,
+        bool failIfStatic = false)
     {
         var targetClassDecl = targetRoot.DescendantNodes()
             .OfType<ClassDeclarationSyntax>()
@@ -553,6 +554,9 @@ public static partial class MoveMethodsTool
         }
         else
         {
+            if (failIfStatic && targetClassDecl.Modifiers.Any(SyntaxKind.StaticKeyword))
+                throw new McpException($"Error: Cannot move instance method to static class '{targetClass}'");
+
             var updatedClass = targetClassDecl.AddMembers(method.WithLeadingTrivia());
             return targetRoot.ReplaceNode(targetClassDecl, updatedClass);
         }

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
@@ -105,7 +105,7 @@ public static partial class MoveMethodsTool
 
         if (sameFile)
         {
-            var targetRoot = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
+            var targetRoot = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace, failIfStatic: true);
             var formatted = Formatter.Format(targetRoot, RefactoringHelpers.SharedWorkspace);
             var targetEncoding = File.Exists(targetPath)
                 ? await RefactoringHelpers.GetFileEncodingAsync(targetPath)
@@ -119,7 +119,7 @@ public static partial class MoveMethodsTool
 
             var targetRoot = await LoadOrCreateTargetRoot(targetPath);
             targetRoot = PropagateUsings(sourceRoot, targetRoot);
-            targetRoot = AddMethodToTargetClass(targetRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
+            targetRoot = AddMethodToTargetClass(targetRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace, failIfStatic: true);
 
             var formattedTarget = Formatter.Format(targetRoot, RefactoringHelpers.SharedWorkspace);
             Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
@@ -56,7 +56,7 @@ public static partial class MoveMethodsTool
         var root = tree.GetRoot();
 
         var moveResult = MoveInstanceMethodAst(root, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
-        var finalRoot = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
+        var finalRoot = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace, failIfStatic: true);
 
         var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace);
         return formatted.ToFullString();
@@ -70,7 +70,7 @@ public static partial class MoveMethodsTool
         foreach (var methodName in methodNames)
         {
             var moveResult = MoveInstanceMethodAst(root, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
-            root = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
+            root = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace, failIfStatic: true);
         }
 
         var formatted = Formatter.Format(root, RefactoringHelpers.SharedWorkspace);

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -262,7 +262,7 @@ public static partial class MoveMethodsTool
             foreach (var methodName in methodNames)
             {
                 var moveResult = MoveInstanceMethodAst(root, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
-                root = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
+                root = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace, failIfStatic: true);
             }
 
             var formatted = Formatter.Format(root, RefactoringHelpers.SharedWorkspace);
@@ -282,7 +282,7 @@ public static partial class MoveMethodsTool
             {
                 var moveResult = MoveInstanceMethodAst(sourceRoot, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
                 sourceRoot = moveResult.NewSourceRoot;
-                targetRoot = AddMethodToTargetClass(targetRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
+                targetRoot = AddMethodToTargetClass(targetRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace, failIfStatic: true);
             }
 
             var formattedSource = Formatter.Format(sourceRoot, RefactoringHelpers.SharedWorkspace);

--- a/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
@@ -31,4 +31,23 @@ public class MoveInstanceMethodTests : TestBase
         Assert.Contains("A.Do", result);
         Assert.Contains("B", result);
     }
+
+    [Fact]
+    public async Task MoveInstanceMethod_FailsForStaticTargetClass()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MoveInstanceMethod_Static.cs"));
+        await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public static class B { }");
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+
+        await Assert.ThrowsAsync<McpException>(() =>
+            MoveMethodsTool.MoveInstanceMethod(
+                SolutionPath,
+                testFile,
+                "A",
+                "Do",
+                "B",
+                "_b",
+                "field"));
+    }
 }


### PR DESCRIPTION
## Summary
- add `failIfStatic` flag when adding moved methods to a target class
- ensure `MoveInstanceMethod` checks and throws when the target class is static
- test failing move when the target class is static

## Testing
- `dotnet format RefactorMCP.sln --no-restore --verbosity diagnostic`
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68501d7387988327b5b199ad2466c7b4