### PR TITLE
Improve move method result messaging

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
@@ -58,7 +58,7 @@ public static partial class MoveMethodsTool
             await File.WriteAllTextAsync(filePath, formattedSource.ToFullString(), sourceEncoding);
         }
 
-        return $"Successfully moved static method '{methodName}' to {targetClass} in {targetPath}";
+        return $"Successfully moved static method '{methodName}' to {targetClass} in {targetPath}. A delegate method remains in the original class to preserve the interface.";
     }
 
 
@@ -130,7 +130,7 @@ public static partial class MoveMethodsTool
         }
 
         var locationInfo = targetFilePath != null ? $" in {targetPath}" : string.Empty;
-        return $"Successfully moved instance method {sourceClass}.{methodName} to {targetClass}{locationInfo}";
+        return $"Successfully moved instance method {sourceClass}.{methodName} to {targetClass}{locationInfo}. A delegate method remains in the original class to preserve the interface.";
     }
 
 

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -41,7 +41,7 @@ public static partial class MoveMethodsTool
             var updatedSources = await UpdateSourceAndTargetForStaticMove(moveContext, method);
             await WriteStaticMethodMoveResults(moveContext, updatedSources);
 
-            return $"Successfully moved static method '{methodName}' to {targetClass} in {moveContext.TargetPath}";
+            return $"Successfully moved static method '{methodName}' to {targetClass} in {moveContext.TargetPath}. A delegate method remains in the original class to preserve the interface.";
         }
         catch (Exception ex)
         {
@@ -267,7 +267,7 @@ public static partial class MoveMethodsTool
 
             var formatted = Formatter.Format(root, RefactoringHelpers.SharedWorkspace);
             await File.WriteAllTextAsync(filePath, formatted.ToFullString(), sourceEncoding);
-            return $"Successfully moved {methodNames.Length} methods from {sourceClass} to {targetClass} in {filePath}";
+            return $"Successfully moved {methodNames.Length} methods from {sourceClass} to {targetClass} in {filePath}. Delegate methods remain in the original class to preserve the interface.";
         }
         else
         {
@@ -295,7 +295,7 @@ public static partial class MoveMethodsTool
                 : sourceEncoding;
             await File.WriteAllTextAsync(targetPath, formattedTarget.ToFullString(), targetEncoding);
 
-            return $"Successfully moved {methodNames.Length} methods from {sourceClass} to {targetClass} in {targetPath}";
+            return $"Successfully moved {methodNames.Length} methods from {sourceClass} to {targetClass} in {targetPath}. Delegate methods remain in the original class to preserve the interface.";
         }
     }
 


### PR DESCRIPTION
## Summary
- update move methods to mention delegate wrapper in return text

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68501f271444832796ab56a87cc3fb4c