### PR TITLE
Fix unused parameter on method move

### DIFF
--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -210,6 +210,36 @@ public class TargetClass
             Assert.Contains("return _value + 2", formatted);
             Assert.Contains("return _target.GetValue(_value)", formatted);
         }
+
+        [Fact]
+        public void MoveInstanceMethod_OmitsUnusedThisParameter()
+        {
+            var source = @"public class SourceClass
+{
+    public void Say() { System.Console.WriteLine(1); }
+}
+
+public class TargetClass
+{
+}";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var root = tree.GetRoot();
+
+            var result = MoveMethodsTool.MoveInstanceMethodAst(
+                root,
+                "SourceClass",
+                "Say",
+                "TargetClass",
+                "_target",
+                "field");
+
+            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
+            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+
+            Assert.Contains("public void Say()", formatted);
+            Assert.DoesNotContain("@this", formatted);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- skip the injected `@this` parameter if it's unused after moving an instance method
- add test for omitting unused `@this` parameter

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685031c85a188327b236860e2be35cb0