### PR TITLE
Handle explicit interface method when converting to extension

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/ExtensionMethodRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/ExtensionMethodRewriter.cs
@@ -42,6 +42,15 @@ internal class ExtensionMethodRewriter : CSharpSyntaxRewriter
         var parameters = node.ParameterList.Parameters.Insert(0, thisParam);
         var updated = node.WithParameterList(node.ParameterList.WithParameters(parameters));
         updated = AstTransformations.EnsureStaticModifier(updated);
+
+        // Remove explicit interface specifier when converting to an extension method
+        if (updated.ExplicitInterfaceSpecifier != null)
+        {
+            updated = updated.WithExplicitInterfaceSpecifier(null)
+                .WithIdentifier(updated.Identifier.WithoutTrivia())
+                .WithTriviaFrom(updated);
+        }
+
         return base.VisitMethodDeclaration(updated);
     }
 


### PR DESCRIPTION
## Summary
- fix extension method rewriter to drop explicit interface specifier when generating the new method

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6850482241b48327a19e5a489bedc24d