### PR TITLE
Fix extension method generation for explicit interface methods

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/ExtensionMethodRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/ExtensionMethodRewriter.cs
@@ -42,6 +42,15 @@ internal class ExtensionMethodRewriter : CSharpSyntaxRewriter
         var parameters = node.ParameterList.Parameters.Insert(0, thisParam);
         var updated = node.WithParameterList(node.ParameterList.WithParameters(parameters));
         updated = AstTransformations.EnsureStaticModifier(updated);
+
+        // Remove explicit interface specifier when generating the extension
+        // method. The wrapper method in the original class retains it so the
+        // interface implementation remains intact.
+        if (updated.ExplicitInterfaceSpecifier != null)
+        {
+            updated = updated.WithExplicitInterfaceSpecifier(null)
+                             .WithIdentifier(SyntaxFactory.Identifier(updated.Identifier.ValueText));
+        }
         return base.VisitMethodDeclaration(updated);
     }
 

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/StaticConversionRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/StaticConversionRewriter.cs
@@ -45,6 +45,16 @@ internal class StaticConversionRewriter : CSharpSyntaxRewriter
             visited = visited.WithParameterList(method.ParameterList.WithParameters(newParameters));
         }
         visited = AstTransformations.EnsureStaticModifier(visited);
+
+        // If the original method was an explicit interface implementation, drop
+        // the interface specifier so the transformed static method compiles in
+        // the new location.
+        if (visited.ExplicitInterfaceSpecifier != null)
+        {
+            visited = visited.WithExplicitInterfaceSpecifier(null)
+                             .WithIdentifier(SyntaxFactory.Identifier(visited.Identifier.ValueText));
+        }
+
         return visited;
     }
 

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -129,6 +129,14 @@ public static partial class MoveMethodsTool
     {
         var transformedMethod = method;
 
+        // Remove explicit interface specifier from the moved method. The stub
+        // method left behind retains the interface implementation.
+        if (transformedMethod.ExplicitInterfaceSpecifier != null)
+        {
+            transformedMethod = transformedMethod.WithExplicitInterfaceSpecifier(null)
+                                                 .WithIdentifier(SyntaxFactory.Identifier(transformedMethod.Identifier.ValueText));
+        }
+
         if (needsStaticFieldQualification)
         {
             var staticFieldRewriter = new StaticFieldRewriter(staticFieldNames, sourceClassName);

--- a/RefactorMCP.Tests/Tools/MoveMethodNamespaceTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMethodNamespaceTests.cs
@@ -11,7 +11,7 @@ public class MoveMethodNamespaceTests : TestBase
     public async Task MoveInstanceMethod_PreservesNamespaceInNewFile()
     {
         UnloadSolutionTool.ClearSolutionCache();
-        var testFile = Path.Combine(TestOutputPath, "NamespaceSample.cs");
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "NamespaceSample.cs"));
         await TestUtilities.CreateTestFile(testFile, "namespace Sample.Namespace { public class A { public void Foo() {} } }");
         await LoadSolutionTool.LoadSolution(SolutionPath);
 


### PR DESCRIPTION
## Summary
- strip explicit interface specifier when creating extension methods so the generated method doesn't reference the interface
- drop explicit interface spec when converting methods to static or moving them to another class
- fix test path to use absolute path

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6850482241b48327a19e5a489bedc24d