### PR TITLE
Handle underscore prefixes for parameterized fields

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -221,9 +221,11 @@ public string FormatResult(int value, int processedValue)
 ### Example
 **Before** (in `ExampleCode.cs` line 46):
 ```csharp
+private string _operatorSymbol;
+
 public string GetFormattedNumber(int number)
 {
-    return $"{operatorSymbol}: {number}";
+    return $"{_operatorSymbol}: {number}";
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -409,9 +409,11 @@ public string FormatResult(int value, int processedValue)
 
 **Before**:
 ```csharp
+private string _operatorSymbol;
+
 public string GetFormattedNumber(int number)
 {
-    return $"{operatorSymbol}: {number}";
+    return $"{_operatorSymbol}: {number}";
 }
 ```
 

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
@@ -36,7 +36,7 @@ public static class ConvertToStaticWithParametersTool
                 {
                     if (!semanticMap.ContainsKey(symbol))
                     {
-                        var name = symbol.Name;
+                        var name = symbol.Name.TrimStart('_');
                         if (method.ParameterList.Parameters.Any(p => p.Identifier.ValueText == name))
                             name += "Param";
                         semanticMap[symbol] = name;
@@ -94,7 +94,7 @@ public static class ConvertToStaticWithParametersTool
 
             foreach (var name in usedMembers)
             {
-                var paramName = name;
+                var paramName = name.TrimStart('_');
                 if (method.ParameterList.Parameters.Any(p => p.Identifier.ValueText == paramName))
                     paramName += "Param";
                 renameMap[name] = paramName;

--- a/RefactorMCP.Tests/Roslyn/ConvertTests.cs
+++ b/RefactorMCP.Tests/Roslyn/ConvertTests.cs
@@ -114,4 +114,28 @@ public static class StringProcessorExtensions
         var output = ConvertToStaticWithParametersTool.ConvertToStaticWithParametersInSource(input, "MultiplyValue");
         Assert.Equal(expected, output.Trim());
     }
+
+    [Fact]
+    public void ConvertToStaticWithParametersInSource_TrimsUnderscorePrefix()
+    {
+        var input = @"class Calculator
+{
+    int _multiplier;
+    int MultiplyValue()
+    {
+        return _multiplier;
+    }
+}";
+        var expected = @"class Calculator
+{
+    int _multiplier;
+
+    static int MultiplyValue(int multiplier)
+    {
+        return multiplier;
+    }
+}";
+        var output = ConvertToStaticWithParametersTool.ConvertToStaticWithParametersInSource(input, "MultiplyValue");
+        Assert.Equal(expected, output.Trim());
+    }
 }

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -206,9 +206,9 @@ public class TargetClass
             var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
-            Assert.Contains("public int GetValue(int _value)", formatted);
-            Assert.Contains("return _value + 2", formatted);
-            Assert.Contains("return _target.GetValue(_value)", formatted);
+            Assert.Contains("public int GetValue(int value)", formatted);
+            Assert.Contains("return value + 2", formatted);
+            Assert.Contains("return _target.GetValue(value)", formatted);
         }
 
         [Fact]
@@ -238,8 +238,8 @@ public class TargetClass
             var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
-            Assert.Contains("public int GetValue(int _value, int n = 5)", formatted);
-            Assert.Contains("_target.GetValue(_value, n)", formatted);
+            Assert.Contains("public int GetValue(int value, int n = 5)", formatted);
+            Assert.Contains("_target.GetValue(value, n)", formatted);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- convert `_field` names to `field` when turning fields into parameters
- keep moved method invocation in sync with new parameter names
- document underscore handling in ConvertToStaticWithParameters examples
- test underscore trimming behavior

## Testing
- `dotnet format --no-restore`
- `dotnet test -v q`

------
https://chatgpt.com/codex/tasks/task_e_68504ca70c748327b670d0d13c73b820