### PR TITLE
Fix some nullability warnings

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -17,17 +17,17 @@ public static partial class MoveMethodsTool
 
     public class MoveStaticMethodResult
     {
-        public SyntaxNode NewSourceRoot { get; set; }
-        public MethodDeclarationSyntax MovedMethod { get; set; }
-        public MethodDeclarationSyntax StubMethod { get; set; }
+        public SyntaxNode NewSourceRoot { get; set; } = null!;
+        public MethodDeclarationSyntax MovedMethod { get; set; } = null!;
+        public MethodDeclarationSyntax StubMethod { get; set; } = null!;
         public string? Namespace { get; set; }
     }
 
     public class MoveInstanceMethodResult
     {
-        public SyntaxNode NewSourceRoot { get; set; }
-        public MethodDeclarationSyntax MovedMethod { get; set; }
-        public MethodDeclarationSyntax StubMethod { get; set; }
+        public SyntaxNode NewSourceRoot { get; set; } = null!;
+        public MethodDeclarationSyntax MovedMethod { get; set; } = null!;
+        public MethodDeclarationSyntax StubMethod { get; set; } = null!;
         public MemberDeclarationSyntax? AccessMember { get; set; }
         public bool NeedsThisParameter { get; set; }
         public string? Namespace { get; set; }

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -51,20 +51,20 @@ public static partial class MoveMethodsTool
 
     private class StaticMethodMoveContext
     {
-        public string SourcePath { get; set; }
-        public string TargetPath { get; set; }
+        public string SourcePath { get; set; } = string.Empty;
+        public string TargetPath { get; set; } = string.Empty;
         public bool SameFile { get; set; }
-        public SyntaxNode SourceRoot { get; set; }
-        public List<UsingDirectiveSyntax> SourceUsings { get; set; }
-        public string TargetClassName { get; set; }
-        public Encoding SourceEncoding { get; set; }
+        public SyntaxNode SourceRoot { get; set; } = null!;
+        public List<UsingDirectiveSyntax> SourceUsings { get; set; } = new();
+        public string TargetClassName { get; set; } = string.Empty;
+        public Encoding SourceEncoding { get; set; } = Encoding.UTF8;
         public string? Namespace { get; set; }
     }
 
     private class SourceAndTargetRoots
     {
-        public SyntaxNode UpdatedSourceRoot { get; set; }
-        public SyntaxNode UpdatedTargetRoot { get; set; }
+        public SyntaxNode UpdatedSourceRoot { get; set; } = null!;
+        public SyntaxNode UpdatedTargetRoot { get; set; } = null!;
     }
 
     private static async Task<StaticMethodMoveContext> PrepareStaticMethodMove(

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -21,7 +21,7 @@ public class MethodAndMemberVisitor : CSharpSyntaxWalker
 
     public class MemberInfo
     {
-        public string Type { get; set; } // "field" or "property"
+        public string Type { get; set; } = string.Empty; // "field" or "property"
     }
 
     public Dictionary<string, MethodInfo> Methods { get; } = new();
@@ -95,7 +95,7 @@ public static partial class MoveMultipleMethodsTool
         var newRoot = await CSharpSyntaxTree.ParseText(newText).GetRootAsync();
         var solution = document.Project.Solution.WithDocumentSyntaxRoot(document.Id, newRoot);
 
-        var project = solution.GetProject(document.Project.Id);
+        var project = solution.GetProject(document.Project.Id)!;
         var targetDocument = project.Documents.FirstOrDefault(d => d.FilePath == targetPath);
         if (targetDocument == null)
         {


### PR DESCRIPTION
## Summary
- initialize non-nullable properties in MoveMethods and MoveMultipleMethods tools
- assert project retrieval is non-null when moving multiple methods

## Testing
- `dotnet test RefactorMCP.sln`

------
https://chatgpt.com/codex/tasks/task_e_68506c33a2fc83279a46db2353326876