### PR TITLE
Detect duplicate method moves

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -340,6 +340,7 @@ public class MathUtilities
 }
 ```
 The original method remains in `ExampleCode.cs` as a wrapper that forwards to `MathUtilities.FormatCurrency`.
+Running `move-static-method` again on this wrapper will now fail. Use `inline-method` if you want to remove it.
 
 ## 10. Move Instance Method
 
@@ -391,6 +392,7 @@ public class Logger
 }
 ```
 The original method in `Calculator` now delegates to `Logger.LogOperation`, preserving existing call sites.
+If you run `move-instance-method` again on this wrapper, an error will be reported. Use `inline-method` to remove the wrapper if desired.
 When a moved method references private fields from its original class, those values are passed as additional parameters.
 
 ## 10. Move Multiple Methods

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -187,6 +187,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \
 Newly added access fields are readonly and existing members are reused if present.
 Each moved method leaves a wrapper that calls the new implementation.
 Private field values referenced by the moved method are supplied as extra parameters.
+Running the tool again on the wrapper now triggers an error. Use `inline-method` if you want to remove the wrapper.
 
 ### Move Multiple Methods
 ```bash
@@ -296,6 +297,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-static-with-inst
 dotnet run --project RefactorMCP.ConsoleApp -- --cli move-static-method \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" FormatCurrency MathUtilities
 # The original method stays as a wrapper
+# Re-running move-static-method on this wrapper will now produce an error. Use `inline-method` to remove it.
 # Convert method to extension
 dotnet run --project RefactorMCP.ConsoleApp -- --cli convert-to-extension-method \
   "./RefactorMCP.sln" "./RefactorMCP.Tests/ExampleCode.cs" GetFormattedNumber

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Below is a quick reference of all tool classes provided by RefactorMCP. Each too
   Make a field readonly if assigned only during initialization (preferred for large C# file refactoring).
 - **MoveClassToFileTool** `[McpServerToolType]`  
   Move a class to a separate file with the same name.
-- **MoveMethodsTool** `[McpServerToolType]`  
-  Move a static method to another class (preferred for large C# file refactoring).
+- **MoveMethodsTool** `[McpServerToolType]`
+  Move a static or instance method to another class (preferred for large C# file refactoring).
+  If the same method is moved again in one run, an error is raised. Use `InlineMethodTool` to remove the wrapper.
 - **MoveMultipleMethodsTool** `[McpServerToolType]`  
   Move multiple methods from a source class to a target class, automatically ordering by dependencies.
 - **RenameSymbolTool** `[McpServerToolType]`  
@@ -248,8 +249,8 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
   `SourceClass`, `Method`, `TargetClass`, `AccessMember`, `AccessMemberType`,
   `IsStatic`, and an optional `TargetFile`.
 - `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
-- `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]` - Move a static method to another class. A placeholder wrapper is left behind to delegate to the new location
- - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [targetFilePath]` - Move one or more instance methods to another class. Wrapper methods remain in the original class so existing callers continue to work. Private field values used by the method are passed as additional parameters
+ - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]` - Move a static method to another class. A placeholder wrapper is left behind to delegate to the new location. Moving the same method again in one run results in an error; use `inline-method` to remove the wrapper.
+ - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [targetFilePath]` - Move one or more instance methods to another class. Wrapper methods remain in the original class so existing callers continue to work. Repeating the command on the wrapper now errors; run `inline-method` if you no longer need it. Private field values used by the method are passed as additional parameters
  - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [targetFilePath]` - Move multiple methods from one class to another. Each method leaves a delegating wrapper behind. Accepts comma separated `methodNames`. If the access member doesn't exist, a private readonly field is added. The older JSON form is still supported for backward compatibility
 - `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
 - `rename-symbol <solutionPath> <filePath> <oldName> <newName> [line] [column]` - Rename a symbol across the solution

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
@@ -22,6 +22,7 @@ public static partial class MoveMethodsTool
         string targetClass,
         string? targetFilePath = null)
     {
+        EnsureNotAlreadyMoved(filePath, methodName);
         ValidateFileExists(filePath);
 
         var targetPath = targetFilePath ?? Path.Combine(Path.GetDirectoryName(filePath)!, $"{targetClass}.cs");
@@ -58,6 +59,7 @@ public static partial class MoveMethodsTool
             await File.WriteAllTextAsync(filePath, formattedSource.ToFullString(), sourceEncoding);
         }
 
+        MarkMoved(filePath, methodName);
         return $"Successfully moved static method '{methodName}' to {targetClass} in {targetPath}. A delegate method remains in the original class to preserve the interface.";
     }
 
@@ -92,6 +94,7 @@ public static partial class MoveMethodsTool
         string accessMemberType,
         string? targetFilePath = null)
     {
+        EnsureNotAlreadyMoved(filePath, methodName);
         ValidateFileExists(filePath);
 
         var targetPath = targetFilePath ?? filePath;
@@ -130,6 +133,7 @@ public static partial class MoveMethodsTool
         }
 
         var locationInfo = targetFilePath != null ? $" in {targetPath}" : string.Empty;
+        MarkMoved(filePath, methodName);
         return $"Successfully moved instance method {sourceClass}.{methodName} to {targetClass}{locationInfo}. A delegate method remains in the original class to preserve the interface.";
     }
 

--- a/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
@@ -50,4 +50,33 @@ public class MoveInstanceMethodTests : TestBase
                 "_b",
                 "field"));
     }
+
+    [Fact]
+    public async Task MoveInstanceMethod_FailsOnSecondMove()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MoveInstanceMethodTwice.cs"));
+        await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public class B { }");
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+
+        var result = await MoveMethodsTool.MoveInstanceMethod(
+            SolutionPath,
+            testFile,
+            "A",
+            "Do",
+            "B",
+            "_b",
+            "field");
+        Assert.Contains("Successfully moved", result);
+
+        await Assert.ThrowsAsync<McpException>(() =>
+            MoveMethodsTool.MoveInstanceMethod(
+                SolutionPath,
+                testFile,
+                "A",
+                "Do",
+                "B",
+                "_b",
+                "field"));
+    }
 }


### PR DESCRIPTION
## Summary
- avoid moving a method twice within one session
- document new inline-method guidance when attempting double moves
- test duplicate move behavior

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build` *(fails: "dotnet" exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68506d59c9088327bcac5c22377b97c8