### PR TITLE
Fix using directives when adding new classes

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -602,7 +602,10 @@ public static partial class MoveMethodsTool
         }
     }
 
-    public static SyntaxNode PropagateUsings(SyntaxNode sourceRoot, SyntaxNode targetRoot)
+    public static SyntaxNode PropagateUsings(
+        SyntaxNode sourceRoot,
+        SyntaxNode targetRoot,
+        string? namespaceName = null)
     {
         var sourceCompilationUnit = (CompilationUnitSyntax)sourceRoot;
         var sourceUsings = sourceCompilationUnit.Usings.ToList();
@@ -613,6 +616,7 @@ public static partial class MoveMethodsTool
             .ToHashSet();
         var missingUsings = sourceUsings
             .Where(u => !targetUsingNames.Contains(u.Name.ToString()))
+            .Where(u => namespaceName == null || u.Name.ToString() != namespaceName)
             .ToArray();
 
         if (missingUsings.Length > 0)

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
@@ -41,7 +41,10 @@ public static partial class MoveMethodsTool
         else
         {
             targetRoot = await LoadOrCreateTargetRoot(targetPath);
-            targetRoot = PropagateUsings(sourceRoot, targetRoot);
+            var nsName = sourceRoot.DescendantNodes()
+                .OfType<BaseNamespaceDeclarationSyntax>()
+                .FirstOrDefault()?.Name.ToString();
+            targetRoot = PropagateUsings(sourceRoot, targetRoot, nsName);
         }
 
         targetRoot = AddMethodToTargetClass(targetRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
@@ -121,7 +124,10 @@ public static partial class MoveMethodsTool
             await File.WriteAllTextAsync(filePath, formattedSource.ToFullString(), sourceEncoding);
 
             var targetRoot = await LoadOrCreateTargetRoot(targetPath);
-            targetRoot = PropagateUsings(sourceRoot, targetRoot);
+            var nsName = sourceRoot.DescendantNodes()
+                .OfType<BaseNamespaceDeclarationSyntax>()
+                .FirstOrDefault()?.Name.ToString();
+            targetRoot = PropagateUsings(sourceRoot, targetRoot, nsName);
             targetRoot = AddMethodToTargetClass(targetRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
 
             var formattedTarget = Formatter.Format(targetRoot, RefactoringHelpers.SharedWorkspace);

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -172,6 +172,7 @@ public static partial class MoveMethodsTool
 
         var missingUsings = context.SourceUsings
             .Where(u => !targetUsingNames.Contains(u.Name.ToString()))
+            .Where(u => context.Namespace == null || u.Name.ToString() != context.Namespace)
             .ToArray();
 
         if (missingUsings.Length > 0)
@@ -304,7 +305,10 @@ public static partial class MoveMethodsTool
             var sourceRoot = await sourceTree.GetRootAsync();
 
             var targetRoot = await LoadOrCreateTargetRoot(targetPath);
-            targetRoot = PropagateUsings(sourceRoot, targetRoot);
+            var nsName = sourceRoot.DescendantNodes()
+                .OfType<BaseNamespaceDeclarationSyntax>()
+                .FirstOrDefault()?.Name.ToString();
+            targetRoot = PropagateUsings(sourceRoot, targetRoot, nsName);
 
             foreach (var methodName in methodNames)
             {

--- a/RefactorMCP.Tests/Tools/MoveMethodNamespaceTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMethodNamespaceTests.cs
@@ -30,4 +30,28 @@ public class MoveMethodNamespaceTests : TestBase
         var newContent = await File.ReadAllTextAsync(targetFile);
         Assert.Contains("namespace Sample.Namespace", newContent);
     }
+
+    [Fact]
+    public async Task MoveInstanceMethod_DoesNotAddNamespaceUsing()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.Combine(TestOutputPath, "NamespaceUsingSample.cs");
+        await TestUtilities.CreateTestFile(testFile, "namespace Sample.Namespace { public class A { public void Foo() {} } }");
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+
+        var targetFile = Path.Combine(Path.GetDirectoryName(testFile)!, "C.cs");
+        var result = await MoveMethodsTool.MoveInstanceMethod(
+            SolutionPath,
+            testFile,
+            "A",
+            "Foo",
+            "C",
+            "_c",
+            "field",
+            targetFile);
+
+        Assert.Contains("Successfully moved", result);
+        var newContent = await File.ReadAllTextAsync(targetFile);
+        Assert.DoesNotContain("using Sample.Namespace;", newContent);
+    }
 }


### PR DESCRIPTION
## Summary
- avoid copying the target namespace into the generated using directives
- update MoveMethods tools to propagate usings without the class namespace
- add regression test for namespace using handling

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68506fa68aa0832786adc4b9e818206e