### PR TITLE
Simplify move tools

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -362,8 +362,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   Calculator \
   LogOperation \
-  Logger \
-  _logger field
+  Logger
 ```
 
 **After**:
@@ -419,7 +418,6 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
   Helper \
   "A,B" \
   Target \
-  t \
   "./Target.cs"
 ```
 
@@ -433,7 +431,6 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
   Helper \
   A \
   Target \
-  t \
   "./Target.cs"
 ```
 
@@ -441,16 +438,16 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
 ```csharp
 class Helper
 {
-    private readonly Target t = new Target();
+    private readonly Target _target = new Target();
 
     public void A()
     {
-        t.A();
+        _target.A();
     }
 
     public void B()
     {
-        t.B();
+        _target.B();
     }
 }
 
@@ -468,7 +465,7 @@ class Target
 }
 ```
 Each moved method in `Helper` now delegates to the corresponding method on `Target`, preserving the original public interface.
-Because `t` did not exist on `Helper`, the refactoring introduced a private readonly field with that name.
+Because an access field didn't exist, the refactoring introduced a private readonly field named `_target` automatically.
 
 ## 11. Batch Move Methods
 

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -182,7 +182,7 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \
   "TargetClass" \
   "./optional/target.cs"
 ```
-An access field named after the target class is created automatically if needed.
+An access field named after the target class is created automatically if needed. If the name is taken, a numeric suffix is appended.
 Each moved method leaves a wrapper that calls the new implementation.
 Private field values referenced by the moved method are supplied as extra parameters.
 Running the tool again on the wrapper now triggers an error. Use `inline-method` if you want to remove the wrapper.

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -180,11 +180,9 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-instance-method \
   "SourceClass" \
   "MethodA,MethodB" \
   "TargetClass" \
-  "memberName" \
-  "field" \
   "./optional/target.cs"
 ```
-Newly added access fields are readonly and existing members are reused if present.
+An access field named after the target class is created automatically if needed.
 Each moved method leaves a wrapper that calls the new implementation.
 Private field values referenced by the moved method are supplied as extra parameters.
 Running the tool again on the wrapper now triggers an error. Use `inline-method` if you want to remove the wrapper.

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
 - `convert-to-static-with-parameters <solutionPath> <filePath> <methodLine>` - Convert instance method to static with parameters
 - `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
 - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]` - Move a static method to another class
- - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [targetFilePath]` - Move one or more instance methods (comma separated names) to another class. Newly created access fields are marked `readonly` and won't duplicate existing members
- - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [targetFilePath]` - Move multiple methods from one class to another. Accepts comma separated `methodNames`. If the access member doesn't exist, a private readonly field is added. The older JSON form is still supported for backward compatibility
+ - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> [targetFilePath]` - Move one or more instance methods (comma separated names) to another class. A private readonly field named after the target is created if needed
+ - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> [targetFilePath]` - Move multiple methods from one class to another. Access fields are automatically created when required
 - `batch-move-methods <solutionPath> <filePath> <operationsJson> [defaultTargetFile]` - Move many methods in a single batch using JSON operations
 - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [targetFilePath]` - Move multiple methods from one class to another. Accepts comma separated `methodNames`.
 - Each method move is described by a `MoveOperation` object with these properties:
@@ -250,8 +250,8 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
   `IsStatic`, and an optional `TargetFile`.
 - `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
  - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]` - Move a static method to another class. A placeholder wrapper is left behind to delegate to the new location. Moving the same method again in one run results in an error; use `inline-method` to remove the wrapper.
- - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [targetFilePath]` - Move one or more instance methods to another class. Wrapper methods remain in the original class so existing callers continue to work. Repeating the command on the wrapper now errors; run `inline-method` if you no longer need it. Private field values used by the method are passed as additional parameters
- - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [targetFilePath]` - Move multiple methods from one class to another. Each method leaves a delegating wrapper behind. Accepts comma separated `methodNames`. If the access member doesn't exist, a private readonly field is added. The older JSON form is still supported for backward compatibility
+ - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> [targetFilePath]` - Move one or more instance methods to another class. Wrapper methods remain in the original class so existing callers continue to work. Private field values used by the method are passed as additional parameters
+ - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> [targetFilePath]` - Move multiple methods from one class to another. Each method leaves a delegating wrapper behind. Access fields are automatically created if they don't exist
 - `cleanup-usings [solutionPath] <filePath>` - Remove unused using directives
 - `rename-symbol <solutionPath> <filePath> <oldName> <newName> [line] [column]` - Rename a symbol across the solution
 - `extract-interface <solutionPath> <filePath> <className> <memberNames> <interfacePath>` - Generate an interface from specified members

--- a/README.md
+++ b/README.md
@@ -241,8 +241,8 @@ dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"
 - `convert-to-static-with-parameters <solutionPath> <filePath> <methodLine>` - Convert instance method to static with parameters
 - `convert-to-static-with-instance <solutionPath> <filePath> <methodLine> [instanceName]` - Convert instance method to static with explicit instance
 - `move-static-method <solutionPath> <filePath> <methodName> <targetClass> [targetFilePath]` - Move a static method to another class
- - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> [targetFilePath]` - Move one or more instance methods (comma separated names) to another class. A private readonly field named after the target is created if needed
- - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> [targetFilePath]` - Move multiple methods from one class to another. Access fields are automatically created when required
+ - `move-instance-method <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> [targetFilePath]` - Move one or more instance methods (comma separated names) to another class. A private readonly field named after the target is created if needed. If that field name already exists, a numeric suffix is appended
+ - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> [targetFilePath]` - Move multiple methods from one class to another. Access fields are automatically created when required. If the generated name conflicts, a numeric suffix is appended
 - `batch-move-methods <solutionPath> <filePath> <operationsJson> [defaultTargetFile]` - Move many methods in a single batch using JSON operations
 - `move-multiple-methods <solutionPath> <filePath> <sourceClass> <methodNames> <targetClass> <accessMember> [targetFilePath]` - Move multiple methods from one class to another. Accepts comma separated `methodNames`.
 - Each method move is described by a `MoveOperation` object with these properties:

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
@@ -159,6 +159,20 @@ public static partial class MoveMethodsTool
                    .Any(p => p.Identifier.ValueText == memberName);
     }
 
+    internal static string GenerateAccessMemberName(IEnumerable<string> existingNames, string targetClass)
+    {
+        var baseName = "_" + char.ToLower(targetClass[0]) + targetClass.Substring(1);
+        var name = baseName;
+        var counter = 1;
+        var nameSet = new HashSet<string>(existingNames);
+        while (nameSet.Contains(name))
+        {
+            name = baseName + counter;
+            counter++;
+        }
+        return name;
+    }
+
     private static MemberDeclarationSyntax CreateAccessMember(string accessMemberType, string accessMemberName, string targetClass)
     {
         if (accessMemberType == "property")

--- a/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
@@ -23,9 +23,7 @@ public class MoveInstanceMethodTests : TestBase
             testFile,
             "A",
             "Do",
-            "B",
-            "_b",
-            "field");
+            "B");
 
         Assert.Contains("Successfully moved", result);
         Assert.Contains("A.Do", result);
@@ -46,9 +44,7 @@ public class MoveInstanceMethodTests : TestBase
                 testFile,
                 "A",
                 "Do",
-                "B",
-                "_b",
-                "field"));
+                "B"));
     }
 
     [Fact]
@@ -64,9 +60,7 @@ public class MoveInstanceMethodTests : TestBase
             testFile,
             "A",
             "Do",
-            "B",
-            "_b",
-            "field");
+            "B");
         Assert.Contains("Successfully moved", result);
 
         await Assert.ThrowsAsync<McpException>(() =>
@@ -75,8 +69,6 @@ public class MoveInstanceMethodTests : TestBase
                 testFile,
                 "A",
                 "Do",
-                "B",
-                "_b",
-                "field"));
+                "B"));
     }
 }

--- a/RefactorMCP.Tests/Tools/MoveMethodNamespaceTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMethodNamespaceTests.cs
@@ -22,8 +22,6 @@ public class MoveMethodNamespaceTests : TestBase
             "A",
             "Foo",
             "B",
-            "_b",
-            "field",
             targetFile);
 
         Assert.Contains("Successfully moved", result);
@@ -46,8 +44,6 @@ public class MoveMethodNamespaceTests : TestBase
             "A",
             "Foo",
             "C",
-            "_c",
-            "field",
             targetFile);
 
         Assert.Contains("Successfully moved", result);


### PR DESCRIPTION
## Summary
- generate access field names automatically when moving methods
- update docs and examples to match
- update tests for new signatures

## Testing
- `dotnet format RefactorMCP.sln --no-restore --verbosity diagnostic`
- `dotnet test RefactorMCP.sln --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68508bfb91b883279dab14a22c78fcbb