### PR TITLE
Refactor visitor class

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodAndMemberVisitor.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodAndMemberVisitor.cs
@@ -1,0 +1,57 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    public class MethodAndMemberVisitor : CSharpSyntaxWalker
+    {
+        public class MethodInfo
+        {
+            public bool IsStatic { get; set; }
+        }
+
+        public class MemberInfo
+        {
+            public string Type { get; set; } = string.Empty; // "field" or "property"
+        }
+
+        public Dictionary<string, MethodInfo> Methods { get; } = new();
+        public Dictionary<string, MemberInfo> Members { get; } = new();
+
+        public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            var methodName = node.Identifier.ValueText;
+            if (!Methods.ContainsKey(methodName))
+            {
+                Methods[methodName] = new MethodInfo
+                {
+                    IsStatic = node.Modifiers.Any(SyntaxKind.StaticKeyword)
+                };
+            }
+        }
+
+        public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+        {
+            foreach (var variable in node.Declaration.Variables)
+            {
+                var fieldName = variable.Identifier.ValueText;
+                if (!Members.ContainsKey(fieldName))
+                {
+                    Members[fieldName] = new MemberInfo { Type = "field" };
+                }
+            }
+        }
+
+        public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            var propertyName = node.Identifier.ValueText;
+            if (!Members.ContainsKey(propertyName))
+            {
+                Members[propertyName] = new MemberInfo { Type = "property" };
+            }
+        }
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
 using System.IO;
 using System.Text;
+using RefactorMCP.ConsoleApp.SyntaxRewriters;
 
 [McpServerToolType]
 public static partial class MoveMethodsTool

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -11,55 +11,7 @@ using System.Linq;
 using System.IO;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
-
-public class MethodAndMemberVisitor : CSharpSyntaxWalker
-{
-    public class MethodInfo
-    {
-        public bool IsStatic { get; set; }
-    }
-
-    public class MemberInfo
-    {
-        public string Type { get; set; } = string.Empty; // "field" or "property"
-    }
-
-    public Dictionary<string, MethodInfo> Methods { get; } = new();
-    public Dictionary<string, MemberInfo> Members { get; } = new();
-
-    public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
-    {
-        var methodName = node.Identifier.ValueText;
-        if (!Methods.ContainsKey(methodName))
-        {
-            Methods[methodName] = new MethodInfo
-            {
-                IsStatic = node.Modifiers.Any(SyntaxKind.StaticKeyword)
-            };
-        }
-    }
-
-    public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
-    {
-        foreach (var variable in node.Declaration.Variables)
-        {
-            var fieldName = variable.Identifier.ValueText;
-            if (!Members.ContainsKey(fieldName))
-            {
-                Members[fieldName] = new MemberInfo { Type = "field" };
-            }
-        }
-    }
-
-    public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
-    {
-        var propertyName = node.Identifier.ValueText;
-        if (!Members.ContainsKey(propertyName))
-        {
-            Members[propertyName] = new MemberInfo { Type = "property" };
-        }
-    }
-}
+using RefactorMCP.ConsoleApp.SyntaxRewriters;
 
 [McpServerToolType]
 public static partial class MoveMultipleMethodsTool


### PR DESCRIPTION
## Summary
- move `MethodAndMemberVisitor` to SyntaxRewriters namespace
- update move tools to use the new namespace

## Testing
- `dotnet format --no-restore --verbosity diagnostic`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68509e654570832784d46150338aef1a