### PR TITLE
Move ComplexityWalker to dedicated file

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/ComplexityWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/ComplexityWalker.cs
@@ -1,0 +1,95 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    internal class ComplexityWalker : CSharpSyntaxWalker
+    {
+        public int Complexity { get; private set; } = 1;
+        private int _depth;
+        public int MaxDepth { get; private set; }
+
+        private void Enter()
+        {
+            _depth++;
+            if (_depth > MaxDepth)
+                MaxDepth = _depth;
+        }
+
+        private void Exit() => _depth--;
+
+        public override void VisitIfStatement(IfStatementSyntax node)
+        {
+            Complexity++;
+            Enter();
+            base.VisitIfStatement(node);
+            Exit();
+        }
+
+        public override void VisitForStatement(ForStatementSyntax node)
+        {
+            Complexity++;
+            Enter();
+            base.VisitForStatement(node);
+            Exit();
+        }
+
+        public override void VisitForEachStatement(ForEachStatementSyntax node)
+        {
+            Complexity++;
+            Enter();
+            base.VisitForEachStatement(node);
+            Exit();
+        }
+
+        public override void VisitWhileStatement(WhileStatementSyntax node)
+        {
+            Complexity++;
+            Enter();
+            base.VisitWhileStatement(node);
+            Exit();
+        }
+
+        public override void VisitDoStatement(DoStatementSyntax node)
+        {
+            Complexity++;
+            Enter();
+            base.VisitDoStatement(node);
+            Exit();
+        }
+
+        public override void VisitSwitchStatement(SwitchStatementSyntax node)
+        {
+            var count = node.Sections.Count; // each case adds complexity
+            Complexity += Math.Max(1, count);
+            Enter();
+            base.VisitSwitchStatement(node);
+            Exit();
+        }
+
+        public override void VisitCatchClause(CatchClauseSyntax node)
+        {
+            Complexity++;
+            Enter();
+            base.VisitCatchClause(node);
+            Exit();
+        }
+
+        public override void VisitBinaryExpression(BinaryExpressionSyntax node)
+        {
+            if (node.IsKind(SyntaxKind.LogicalAndExpression) || node.IsKind(SyntaxKind.LogicalOrExpression))
+                Complexity++;
+            base.VisitBinaryExpression(node);
+        }
+
+        public override void VisitConditionalExpression(ConditionalExpressionSyntax node)
+        {
+            Complexity++;
+            Enter();
+            base.VisitConditionalExpression(node);
+            Exit();
+        }
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/MetricsProvider.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MetricsProvider.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.Extensions.Caching.Memory;
+using RefactorMCP.ConsoleApp.SyntaxRewriters;
 using System.Text.Json;
 using System.IO;
 
@@ -133,83 +134,6 @@ public static class MetricsProvider
         }
     }
 
-    private class ComplexityWalker : CSharpSyntaxWalker
-    {
-        public int Complexity { get; private set; } = 1;
-        private int _depth;
-        public int MaxDepth { get; private set; }
-
-        private void Enter()
-        {
-            _depth++;
-            if (_depth > MaxDepth) MaxDepth = _depth;
-        }
-        private void Exit() => _depth--;
-
-        public override void VisitIfStatement(IfStatementSyntax node)
-        {
-            Complexity++;
-            Enter();
-            base.VisitIfStatement(node);
-            Exit();
-        }
-        public override void VisitForStatement(ForStatementSyntax node)
-        {
-            Complexity++;
-            Enter();
-            base.VisitForStatement(node);
-            Exit();
-        }
-        public override void VisitForEachStatement(ForEachStatementSyntax node)
-        {
-            Complexity++;
-            Enter();
-            base.VisitForEachStatement(node);
-            Exit();
-        }
-        public override void VisitWhileStatement(WhileStatementSyntax node)
-        {
-            Complexity++;
-            Enter();
-            base.VisitWhileStatement(node);
-            Exit();
-        }
-        public override void VisitDoStatement(DoStatementSyntax node)
-        {
-            Complexity++;
-            Enter();
-            base.VisitDoStatement(node);
-            Exit();
-        }
-        public override void VisitSwitchStatement(SwitchStatementSyntax node)
-        {
-            var count = node.Sections.Count; // each case adds complexity
-            Complexity += Math.Max(1, count);
-            Enter();
-            base.VisitSwitchStatement(node);
-            Exit();
-        }
-        public override void VisitCatchClause(CatchClauseSyntax node)
-        {
-            Complexity++;
-            Enter();
-            base.VisitCatchClause(node);
-            Exit();
-        }
-        public override void VisitBinaryExpression(BinaryExpressionSyntax node)
-        {
-            if (node.IsKind(SyntaxKind.LogicalAndExpression) || node.IsKind(SyntaxKind.LogicalOrExpression))
-                Complexity++;
-            base.VisitBinaryExpression(node);
-        }
-        public override void VisitConditionalExpression(ConditionalExpressionSyntax node)
-        {
-            Complexity++;
-            Enter();
-            base.VisitConditionalExpression(node);
-            Exit();
-        }
-    }
 
     private class FileMetrics
     {


### PR DESCRIPTION
## Summary
- extract `ComplexityWalker` from `MetricsProvider` into its own file under `SyntaxRewriters`
- reference the new class from `MetricsProvider`

## Testing
- `dotnet format RefactorMCP.sln -v diag`
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68509e66f42c832794c8ce524a33b9fe