### PR TITLE
Move BodyOmitter into separate SyntaxRewriters file

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/BodyOmitter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/BodyOmitter.cs
@@ -1,0 +1,16 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+internal class BodyOmitter : CSharpSyntaxRewriter
+{
+    public override SyntaxNode? VisitBlock(BlockSyntax node)
+    {
+        return SyntaxFactory.Block(SyntaxFactory.ParseStatement("// ...\n"));
+    }
+
+    public override SyntaxNode? VisitArrowExpressionClause(ArrowExpressionClauseSyntax node)
+    {
+        return SyntaxFactory.Block(SyntaxFactory.ParseStatement("// ...\n"));
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/SummaryResources.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SummaryResources.cs
@@ -34,16 +34,4 @@ public static class SummaryResources
         return sb.ToString();
     }
 
-    private class BodyOmitter : CSharpSyntaxRewriter
-    {
-        public override SyntaxNode? VisitBlock(BlockSyntax node)
-        {
-            return SyntaxFactory.Block(SyntaxFactory.ParseStatement("// ...\n"));
-        }
-
-        public override SyntaxNode? VisitArrowExpressionClause(ArrowExpressionClauseSyntax node)
-        {
-            return SyntaxFactory.Block(SyntaxFactory.ParseStatement("// ...\n"));
-        }
-    }
 }


### PR DESCRIPTION
## Summary
- create `BodyOmitter` rewriter file
- remove nested class from `SummaryResources`
- keep summary generation working with new file

## Testing
- `dotnet format --no-restore -v normal`
- `dotnet test --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68509e95ae348327ac43e6c91fb5bc6a