### PR TITLE
Improve not-found messages

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveClassToFile.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveClassToFile.cs
@@ -31,7 +31,7 @@ public static class MoveClassToFileTool
             else
             {
                 if (!File.Exists(filePath))
-                    throw new McpException($"Error: File {filePath} not found");
+                    throw new McpException($"Error: File {filePath} not found. Verify the file path and ensure the file is part of the loaded solution.");
 
                 var (text, _) = await RefactoringHelpers.ReadFileWithEncodingAsync(filePath);
                 root = (CompilationUnitSyntax)CSharpSyntaxTree.ParseText(text).GetRoot();
@@ -39,7 +39,7 @@ public static class MoveClassToFileTool
             var classNode = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
                 .FirstOrDefault(c => c.Identifier.Text == className);
             if (classNode == null)
-                throw new McpException($"Error: Class {className} not found");
+                throw new McpException($"Error: Class {className} not found. Verify the class name and ensure the file is part of the loaded solution.");
 
             var duplicateDoc = await RefactoringHelpers.FindClassInSolution(solution, className, filePath, newFilePath);
             if (duplicateDoc != null)

--- a/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
@@ -99,7 +99,7 @@ public static class SafeDeleteTool
             .OfType<FieldDeclarationSyntax>()
             .FirstOrDefault(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == fieldName));
         if (field == null)
-            throw new McpException($"Error: Field '{fieldName}' not found");
+            throw new McpException($"Error: Field '{fieldName}' not found. Verify the field name and ensure the file is part of the loaded solution.");
 
         var variable = field.Declaration.Variables.First(v => v.Identifier.ValueText == fieldName);
         var semanticModel = await document.GetSemanticModelAsync();
@@ -137,7 +137,7 @@ public static class SafeDeleteTool
             .OfType<FieldDeclarationSyntax>()
             .FirstOrDefault(f => f.Declaration.Variables.Any(v => v.Identifier.ValueText == fieldName));
         if (field == null)
-            throw new McpException($"Error: Field '{fieldName}' not found");
+            throw new McpException($"Error: Field '{fieldName}' not found. Verify the field name and ensure the file is part of the loaded solution.");
 
         var references = root.DescendantNodes().OfType<IdentifierNameSyntax>().Count(id => id.Identifier.ValueText == fieldName);
         if (references > 1)
@@ -161,7 +161,7 @@ public static class SafeDeleteTool
         var root = await document.GetSyntaxRootAsync();
         var method = root!.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: Method '{methodName}' not found");
+            throw new McpException($"Error: Method '{methodName}' not found. Verify the method name and ensure the file is part of the loaded solution.");
 
         var semanticModel = await document.GetSemanticModelAsync();
         var symbol = semanticModel!.GetDeclaredSymbol(method)!;
@@ -195,7 +195,7 @@ public static class SafeDeleteTool
         var root = tree.GetRoot();
         var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: Method '{methodName}' not found");
+            throw new McpException($"Error: Method '{methodName}' not found. Verify the method name and ensure the file is part of the loaded solution.");
 
         var references = root.DescendantNodes().OfType<InvocationExpressionSyntax>()
             .Count(inv => inv.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == methodName);
@@ -213,11 +213,11 @@ public static class SafeDeleteTool
         var root = await document.GetSyntaxRootAsync();
         var method = root!.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: Method '{methodName}' not found");
+            throw new McpException($"Error: Method '{methodName}' not found. Verify the method name and ensure the file is part of the loaded solution.");
 
         var parameter = method.ParameterList.Parameters.FirstOrDefault(p => p.Identifier.ValueText == parameterName);
         if (parameter == null)
-            throw new McpException($"Error: Parameter '{parameterName}' not found");
+            throw new McpException($"Error: Parameter '{parameterName}' not found. Verify the parameter name and ensure the file is part of the loaded solution.");
 
         var semanticModel = await document.GetSemanticModelAsync();
         var methodSymbol = semanticModel!.GetDeclaredSymbol(method)!;
@@ -264,11 +264,11 @@ public static class SafeDeleteTool
         var root = tree.GetRoot();
         var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: Method '{methodName}' not found");
+            throw new McpException($"Error: Method '{methodName}' not found. Verify the method name and ensure the file is part of the loaded solution.");
 
         var parameter = method.ParameterList.Parameters.FirstOrDefault(p => p.Identifier.ValueText == parameterName);
         if (parameter == null)
-            throw new McpException($"Error: Parameter '{parameterName}' not found");
+            throw new McpException($"Error: Parameter '{parameterName}' not found. Verify the parameter name and ensure the file is part of the loaded solution.");
 
         var paramIndex = method.ParameterList.Parameters.IndexOf(parameter);
         var rewriter = new ParameterRemovalRewriter(methodName, paramIndex);


### PR DESCRIPTION
## Summary
- clarify not-found errors in MoveClassToFileTool and SafeDeleteTool

## Testing
- `dotnet format --no-restore`
- `dotnet test RefactorMCP.Tests/RefactorMCP.Tests.csproj --no-build --verbosity minimal` *(fails: The argument ... is invalid)*

------
https://chatgpt.com/codex/tasks/task_e_68512b1e81888327a303ed00ac9ad7c2