### PR TITLE
Add reset move history tool

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -704,6 +704,21 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli clear-solution-cache
 Cleared all cached solutions
 ```
 
+## Reset Move History (Utility Command)
+
+**Purpose**: Allow previously moved methods to be moved again in the same session.
+
+### Example
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli reset-move-history
+```
+
+**Expected Output**:
+```
+Cleared move history
+```
+
 ## 11. List Tools (Utility Command)
 
 **Purpose**: Display all available refactoring tools and their status.

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -1,0 +1,24 @@
+# RefactorMCP Quick Reference
+
+Using these tools through the MCP interface is the preferred approach for refactoring **C# code**.
+
+## Basic Commands
+```bash
+# List all tools
+dotnet run --project RefactorMCP.ConsoleApp -- --cli list-tools
+# Load solution
+dotnet run --project RefactorMCP.ConsoleApp -- --cli load-solution ./RefactorMCP.sln
+# Unload solution
+dotnet run --project RefactorMCP.ConsoleApp -- --cli unload-solution ./RefactorMCP.sln
+# Clear all cached solutions
+dotnet run --project RefactorMCP.ConsoleApp -- --cli clear-solution-cache
+# Reset moved method tracking
+dotnet run --project RefactorMCP.ConsoleApp -- --cli reset-move-history
+```
+
+## Reset Move History
+Clears the internal record of moved methods so a method can be moved again without errors.
+
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli reset-move-history
+```

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Below is a quick reference of all tool classes provided by RefactorMCP. Each too
 - **MoveMethodsTool** `[McpServerToolType]`
   Move a static or instance method to another class (preferred for large C# file refactoring).
   If the same method is moved again in one run, an error is raised. Use `InlineMethodTool` to remove the wrapper.
+  Call `ResetMoveHistory` to clear the session history when needed.
 - **MoveMultipleMethodsTool** `[McpServerToolType]`  
   Move multiple methods from a source class to a target class, automatically ordering by dependencies.
 - **RenameSymbolTool** `[McpServerToolType]`  

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -33,6 +33,13 @@ public static partial class MoveMethodsTool
 
     private static void MarkMoved(string filePath, string methodName)
         => _movedMethods.Add(GetKey(filePath, methodName));
+
+    [McpServerTool, Description("Clear the record of moved methods so they can be moved again")]
+    public static string ResetMoveHistory()
+    {
+        _movedMethods.Clear();
+        return "Cleared move history";
+    }
     [McpServerTool, Description("Move a static method to another class (preferred for large C# file refactoring). " +
         "Leaves a delegating method in the original class to preserve the interface.")]
     public static async Task<string> MoveStaticMethod(

--- a/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
@@ -71,4 +71,33 @@ public class MoveInstanceMethodTests : TestBase
                 "Do",
                 "B"));
     }
+
+    [Fact]
+    public async Task ResetMoveHistory_AllowsRepeatMove()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "ResetMoveHistory.cs"));
+        await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public class B { }");
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+
+        var result1 = await MoveMethodsTool.MoveInstanceMethod(
+            SolutionPath,
+            testFile,
+            "A",
+            "Do",
+            "B");
+        Assert.Contains("Successfully moved", result1);
+
+        // Clear move tracking and try again
+        MoveMethodsTool.ResetMoveHistory();
+
+        var result2 = await MoveMethodsTool.MoveInstanceMethod(
+            SolutionPath,
+            testFile,
+            "A",
+            "Do",
+            "B");
+
+        Assert.Contains("Successfully moved", result2);
+    }
 }


### PR DESCRIPTION
## Summary
- add `ResetMoveHistory` tool to clear `_movedMethods`
- document the new command in README and QUICK_REFERENCE
- provide reset example in EXAMPLES
- test resetting the move history

## Testing
- `dotnet format --no-restore`
- `dotnet test`
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_68512b16776c83279aada04d0178dece