### PR TITLE
Add summary resource docs and test

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -974,3 +974,12 @@ metrics://RefactorMCP.Tests/ExampleCode.cs/Calculator.Calculate
 This URI returns metrics for the `Calculate` method. Omitting the method name
 returns metrics for the whole class, and specifying only the file gives all
 classes and methods.
+
+## Summary Resource
+
+Retrieve a file with method bodies omitted using the `summary://` scheme:
+
+```
+summary://RefactorMCP.Tests/ExampleCode.cs
+```
+The returned text begins with `// summary://...` and shows each method body as `// ...`.

--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -1,0 +1,14 @@
+# RefactorMCP Quick Reference
+
+## Resources
+
+- `metrics://<file path>/[ClassName].[MethodName]` - retrieve metrics for a scope.
+- `summary://<file path>` - get the file with method bodies replaced by `// ...`.
+
+### Example
+
+Request a summary of `ExampleCode.cs`:
+
+```json
+{"role":"tool","name":"summary://RefactorMCP.Tests/ExampleCode.cs"}
+```

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Below is a quick reference of all tool classes provided by RefactorMCP. Each too
   Remove unused using directives from a C# file (preferred for large C# file refactoring).
 - **MetricsResource** `[McpServerResourceType]`
   Read metrics using `metrics://` URIs for directories, files, classes or methods.
+- **SummaryResources** `[McpServerResourceType]`
+  Return a code file with method bodies removed via the `summary://` scheme.
 - **ConvertToExtensionMethodTool** `[McpServerToolType]`  
   Convert an instance method to an extension method in a static class.
 - **ConvertToStaticWithInstanceTool** `[McpServerToolType]`  
@@ -298,8 +300,20 @@ solution and file paths return the cached JSON without recomputing. Delete this 
 Metrics can also be accessed via the `metrics://` resource scheme. Use a URI like
 `metrics://<file path>/[ClassName].[MethodName]` to retrieve metrics for a
 specific scope. Supplying only a directory lists all classes. Specifying a file
-returns metrics for all classes and methods, adding a class name narrows to that
-class, and appending a method name yields metrics just for that method.
+    returns metrics for all classes and methods, adding a class name narrows to that
+    class, and appending a method name yields metrics just for that method.
+
+### Summary Resource
+
+Use the `summary://` scheme to retrieve a code file with all method bodies replaced by
+`// ...`. This is useful for sharing context with an LLM without exposing implementation
+details.
+
+Example MCP request:
+
+```json
+{"role":"tool","name":"summary://RefactorMCP.Tests/ExampleCode.cs"}
+```
 
 ## Range Format
 

--- a/RefactorMCP.Tests/SummaryResourceTests.cs
+++ b/RefactorMCP.Tests/SummaryResourceTests.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class SummaryResourceTests : TestBase
+{
+    [Fact]
+    public async Task GetSummary_OmitsMethodBodies()
+    {
+        var result = await SummaryResources.GetSummary(ExampleFilePath);
+        Assert.Contains("public int Calculate(int a, int b)\n        {}", result);
+        Assert.DoesNotContain("throw new ArgumentException", result);
+    }
+}

--- a/RefactorMCP.Tests/TEST_SUMMARY.md
+++ b/RefactorMCP.Tests/TEST_SUMMARY.md
@@ -24,6 +24,7 @@ Unit tests for each refactoring tool in the `Tools` folder covering solution loa
 ### 4. Metrics and Analysis
 Tests covering metrics and refactoring suggestions:
 - ✅ `MetricsResourceTests` - Metrics resource returns JSON
+- ✅ `SummaryResourceTests` - Summary resource omits method bodies
 - ✅ `ClassLengthMetricsTests` - Class length listings
 - ✅ `AnalyzeRefactoringOpportunitiesTests` - Suggests safe deletions
 
@@ -94,6 +95,7 @@ RefactorMCP.Tests/
 ├── ExampleValidationTests.cs # Documentation validation
 ├── PerformanceTests.cs       # Performance tests
 ├── MetricsResourceTests.cs   # Metrics resource validation
+├── SummaryResourceTests.cs   # Summary resource validation
 ├── ClassLengthMetricsTests.cs # Class size metrics
 ├── AnalyzeRefactoringOpportunitiesTests.cs
 ├── ExampleCode.cs            # Sample code for testing


### PR DESCRIPTION
## Summary
- document `summary://` resource in README and EXAMPLES
- add new QUICK_REFERENCE.md explaining resources
- cover summary output with `SummaryResourceTests`
- mention documentation in TEST_SUMMARY

## Testing
- `dotnet format`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68512b0cbb7083279188248e24b740e9