### PR TITLE
Improve workspace check in VS Code extension

### DIFF
--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -34,7 +34,7 @@ version
 
 ## Requirements
 
-The workspace must contain the `RefactorMCP.ConsoleApp` project and `dotnet` must be available on your PATH. Use the setting `refactorMcp.dotnetPath` to override the path if necessary.
+The extension requires that you open a workspace containing the `RefactorMCP.ConsoleApp` project. `dotnet` must also be available on your PATH. Use the setting `refactorMcp.dotnetPath` to override the path if necessary.
 
 ## Development
 

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -2,10 +2,22 @@ import * as vscode from 'vscode';
 import { execFile } from 'child_process';
 import * as path from 'path';
 
+function getWorkspaceFolder(): string | undefined {
+    const folder = vscode.workspace.workspaceFolders?.[0];
+    if (!folder) {
+        vscode.window.showErrorMessage('RefactorMCP requires an open workspace containing RefactorMCP.ConsoleApp');
+        return undefined;
+    }
+    return folder.uri.fsPath;
+}
+
 function runCli(command: string, args: string[]): Thenable<string> {
     const config = vscode.workspace.getConfiguration();
     const dotnetPath = config.get<string>('refactorMcp.dotnetPath', 'dotnet');
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '';
+    const workspaceFolder = getWorkspaceFolder();
+    if (!workspaceFolder) {
+        return Promise.reject('No workspace');
+    }
     const projectPath = path.join(workspaceFolder, 'RefactorMCP.ConsoleApp');
     const commandArgs = ['run', '--project', projectPath, '--', '--cli', command, ...args];
     return new Promise((resolve, reject) => {
@@ -22,7 +34,10 @@ function runCli(command: string, args: string[]): Thenable<string> {
 function runJson(toolName: string, json: string): Thenable<string> {
     const config = vscode.workspace.getConfiguration();
     const dotnetPath = config.get<string>('refactorMcp.dotnetPath', 'dotnet');
-    const workspaceFolder = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? '';
+    const workspaceFolder = getWorkspaceFolder();
+    if (!workspaceFolder) {
+        return Promise.reject('No workspace');
+    }
     const projectPath = path.join(workspaceFolder, 'RefactorMCP.ConsoleApp');
     const commandArgs = ['run', '--project', projectPath, '--', '--json', toolName, json];
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- add helper to ensure a workspace folder is open
- prevent commands from running when no workspace is present
- clarify that a workspace with `RefactorMCP.ConsoleApp` must be open

## Testing
- `dotnet format --no-restore`
- `dotnet build`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68512b497b248327a3c01232e468667e