### PR TITLE
Return business error strings

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
@@ -42,7 +42,7 @@ public static class ConvertToExtensionMethodTool
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: No method named '{methodName}' found");
+            return $"Error: No method named '{methodName}' found";
 
         var semanticModel = await document.GetSemanticModelAsync();
         var classDecl = method.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
@@ -134,7 +134,7 @@ public static class ConvertToExtensionMethodTool
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: No method named '{methodName}' found");
+            return $"Error: No method named '{methodName}' found";
 
         var classDecl = method.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
         if (classDecl == null)

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
@@ -86,7 +86,7 @@ public static class ConvertToStaticWithInstanceTool
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: No method named '{methodName}' found");
+            return $"Error: No method named '{methodName}' found";
 
         var semanticModel = await document.GetSemanticModelAsync();
         var newRoot = ConvertToStaticWithInstanceAst(syntaxRoot!, method, instanceParameterName, semanticModel);
@@ -117,7 +117,7 @@ public static class ConvertToStaticWithInstanceTool
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: No method named '{methodName}' found");
+            return $"Error: No method named '{methodName}' found";
 
         var classDecl = method.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
         if (classDecl == null)

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
@@ -138,7 +138,7 @@ public static class ConvertToStaticWithParametersTool
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: No method named '{methodName}' found");
+            return $"Error: No method named '{methodName}' found";
 
         var semanticModel = await document.GetSemanticModelAsync();
         var newRoot = ConvertToStaticWithParametersAst(syntaxRoot!, method, semanticModel);
@@ -169,7 +169,7 @@ public static class ConvertToStaticWithParametersTool
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: No method named '{methodName}' found");
+            return $"Error: No method named '{methodName}' found";
 
         var classDecl = method.Ancestors().OfType<ClassDeclarationSyntax>().FirstOrDefault();
         if (classDecl == null)

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceField.cs
@@ -84,7 +84,7 @@ public static class IntroduceFieldTool
         {
             var classSymbol = semanticModel.GetDeclaredSymbol(containingClass);
             if (classSymbol?.GetMembers().OfType<IFieldSymbol>().Any(f => f.Name == fieldName) == true)
-                throw new McpException($"Error: Field '{fieldName}' already exists");
+                return $"Error: Field '{fieldName}' already exists";
         }
         var rewriter = new FieldIntroductionRewriter(selectedExpression, fieldReference, fieldDeclaration, containingClass);
         var newRoot = rewriter.Visit(syntaxRoot);
@@ -109,6 +109,9 @@ public static class IntroduceFieldTool
         var (sourceText, encoding) = await RefactoringHelpers.ReadFileWithEncodingAsync(filePath);
         var model = await RefactoringHelpers.GetOrCreateSemanticModelAsync(filePath);
         var newText = IntroduceFieldInSource(sourceText, selectionRange, fieldName, accessModifier, model);
+        if (newText.StartsWith("Error:"))
+            return newText;
+
         await File.WriteAllTextAsync(filePath, newText, encoding);
         RefactoringHelpers.UpdateFileCaches(filePath, newText);
         return $"Successfully introduced {accessModifier} field '{fieldName}' from {selectionRange} in {filePath} (single file mode)";
@@ -172,7 +175,7 @@ public static class IntroduceFieldTool
                 .SelectMany(f => f.Declaration.Variables)
                 .Any(v => v.Identifier.ValueText == fieldName);
             if (exists)
-                throw new McpException($"Error: Field '{fieldName}' already exists");
+                return $"Error: Field '{fieldName}' already exists";
         }
         var rewriter = new FieldIntroductionRewriter(selectedExpression, fieldReference, fieldDeclaration, containingClass);
         var newRoot = rewriter.Visit(syntaxRoot);

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
@@ -21,7 +21,7 @@ public static class IntroduceParameterTool
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: No method named '{methodName}' found");
+            return $"Error: No method named '{methodName}' found";
 
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var startLine, out var startColumn, out var endLine, out var endColumn))
             throw new McpException("Error: Invalid selection range format");
@@ -77,7 +77,7 @@ public static class IntroduceParameterTool
             .OfType<MethodDeclarationSyntax>()
             .FirstOrDefault(m => m.Identifier.ValueText == methodName);
         if (method == null)
-            throw new McpException($"Error: No method named '{methodName}' found");
+            return $"Error: No method named '{methodName}' found";
 
         if (!RefactoringHelpers.TryParseRange(selectionRange, out var startLine, out var startColumn, out var endLine, out var endColumn))
             throw new McpException("Error: Invalid selection range format");

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -114,7 +114,7 @@ public static partial class MoveMultipleMethodsTool
                 {
                     var methodName = methodNames[i];
                     if (!visitor.Methods.TryGetValue(methodName, out var methodInfo))
-                        throw new McpException($"Error: No method named '{methodName}' in class '{sourceClass}'");
+                        return $"Error: No method named '{methodName}' in class '{sourceClass}'";
 
                     isStatic[i] = methodInfo.IsStatic;
 

--- a/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/RefactoringHelpers.cs
@@ -140,6 +140,10 @@ internal static class RefactoringHelpers
 
         var (sourceText, encoding) = await ReadFileWithEncodingAsync(filePath);
         var newText = transform(sourceText);
+
+        if (newText.StartsWith("Error:"))
+            return newText;
+
         await File.WriteAllTextAsync(filePath, newText, encoding);
         UpdateFileCaches(filePath, newText);
         return successMessage;

--- a/RefactorMCP.Tests/Tools/IntroduceFieldTests.cs
+++ b/RefactorMCP.Tests/Tools/IntroduceFieldTests.cs
@@ -77,12 +77,12 @@ public class IntroduceFieldTests : TestBase
         var testFile = Path.Combine(TestOutputPath, "IntroduceFieldDuplicate.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForIntroduceField());
 
-        await Assert.ThrowsAsync<McpException>(async () =>
-            await IntroduceFieldTool.IntroduceField(
-                SolutionPath,
-                testFile,
-                "36:20-36:56",
-                "numbers",
-                "private"));
+        var result = await IntroduceFieldTool.IntroduceField(
+            SolutionPath,
+            testFile,
+            "36:20-36:56",
+            "numbers",
+            "private");
+        Assert.Equal("Error: Field 'numbers' already exists", result);
     }
 }

--- a/RefactorMCP.Tests/Tools/IntroduceParameterTests.cs
+++ b/RefactorMCP.Tests/Tools/IntroduceParameterTests.cs
@@ -30,12 +30,12 @@ public class IntroduceParameterTests : TestBase
     public async Task IntroduceParameter_InvalidMethod_ReturnsError()
     {
         await LoadSolutionTool.LoadSolution(SolutionPath);
-        await Assert.ThrowsAsync<McpException>(async () =>
-            await IntroduceParameterTool.IntroduceParameter(
-                SolutionPath,
-                ExampleFilePath,
-                "Nonexistent",
-                "1:1-1:2",
-                "param"));
+        var result = await IntroduceParameterTool.IntroduceParameter(
+            SolutionPath,
+            ExampleFilePath,
+            "Nonexistent",
+            "1:1-1:2",
+            "param");
+        Assert.Equal("Error: No method named 'Nonexistent' found", result);
     }
 }


### PR DESCRIPTION
## Summary
- return error messages from tools when a duplicate field or unknown method is encountered
- adjust test helpers so single-file operations don't overwrite on errors
- verify error messages in IntroduceFieldTests and IntroduceParameterTests

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68512e139408832790a9e246c6559bd2