### PR TITLE
Ensure new namespaces are file‑scoped

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -979,6 +979,13 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method "./RefactorM
 dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-method "./RefactorMCP.sln" "./RefactorMCP.Tests/TestFile.cs" "5:1-8:10" "TestMethod"
 ```
 
+### File-Scoped Namespace Example
+When a tool needs to create a new file, the namespace uses the file-scoped style:
+
+```json
+{"tool":"move-static-method","solutionPath":"./RefactorMCP.sln","filePath":"./RefactorMCP.Tests/ExampleCode.cs","methodName":"Add","targetClass":"MathHelpers","targetFilePath":"./RefactorMCP.Tests/MathHelpers.cs"}
+```
+
 ## Metrics Resource
 
 Metrics can be queried using the resource scheme:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A Model Context Protocol (MCP) server providing automated refactoring tools for 
 - **MCP Compatible**: Works with any MCP-compatible client
 - **Preferred for Large Files**: Invoking these tools via MCP is recommended for large code files
 - **VS Code Extension**: Invoke refactoring tools directly from the editor
+- **File-Scoped Namespaces**: When a tool adds a namespace to a file, it uses
+  the modern file-scoped syntax
 ## Refactoring Tools
 
 Below is a quick reference of all tool classes provided by RefactorMCP. Each tool is decorated with `[McpServerToolType]` and some also include `[McpServerPromptType]` for prompt-based actions.

--- a/RefactorMCP.ConsoleApp/Tools/ExtractInterfaceTool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ExtractInterfaceTool.cs
@@ -71,10 +71,12 @@ public static class ExtractInterfaceTool
                 .WithMembers(SyntaxFactory.List(members));
 
             MemberDeclarationSyntax interfaceNode = iface;
-            if (classNode.Parent is NamespaceDeclarationSyntax ns)
+            string? nsName = (classNode.Parent as BaseNamespaceDeclarationSyntax)?.Name.ToString();
+            if (!string.IsNullOrEmpty(nsName))
             {
-                interfaceNode = SyntaxFactory.NamespaceDeclaration(ns.Name)
-                    .WithMembers(SyntaxFactory.SingletonList(interfaceNode));
+                interfaceNode = SyntaxFactory.FileScopedNamespaceDeclaration(
+                        SyntaxFactory.ParseName(nsName))
+                    .AddMembers(interfaceNode);
             }
 
             var ifaceUnit = SyntaxFactory.CompilationUnit()

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -579,7 +579,8 @@ public static partial class MoveMethodsTool
             }
             else if (!string.IsNullOrEmpty(namespaceName))
             {
-                var ns = SyntaxFactory.NamespaceDeclaration(SyntaxFactory.ParseName(namespaceName))
+                var ns = SyntaxFactory.FileScopedNamespaceDeclaration(
+                        SyntaxFactory.ParseName(namespaceName))
                     .AddMembers(newClass);
                 return compilationUnit.AddMembers(ns);
             }


### PR DESCRIPTION
## Summary
- generate file-scoped namespaces when new files are created
- propagate file-scoped namespaces in ExtractInterfaceTool
- document file-scoped namespace usage
- add example JSON invocation

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6851428f60bc832798b78fc4dba71ae7