### PR TITLE
Fix event handler references when moving methods

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodAnalysisWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodAnalysisWalker.cs
@@ -31,6 +31,21 @@ internal class MethodAnalysisWalker : CSharpSyntaxWalker
                 UsesInstanceMembers = true;
             }
         }
+
+        if (_methodNames.Contains(node.Identifier.ValueText))
+        {
+            var parent = node.Parent;
+            if (parent is not InvocationExpressionSyntax &&
+                (parent is not MemberAccessExpressionSyntax ||
+                 (parent is MemberAccessExpressionSyntax ma && ma.Expression is ThisExpressionSyntax)))
+            {
+                if (node.Identifier.ValueText == _methodName)
+                    IsRecursive = true;
+                else
+                    CallsOtherMethods = true;
+            }
+        }
+
         base.VisitIdentifierName(node);
     }
 

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodReferenceRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodReferenceRewriter.cs
@@ -1,0 +1,46 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class MethodReferenceRewriter : CSharpSyntaxRewriter
+{
+    private readonly HashSet<string> _methodNames;
+    private readonly string _parameterName;
+
+    public MethodReferenceRewriter(HashSet<string> methodNames, string parameterName)
+    {
+        _methodNames = methodNames;
+        _parameterName = parameterName;
+    }
+
+    public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        if (_methodNames.Contains(node.Identifier.ValueText))
+        {
+            var parent = node.Parent;
+            if (parent is not InvocationExpressionSyntax && parent is not MemberAccessExpressionSyntax)
+            {
+                var memberAccess = SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(_parameterName),
+                    node.WithoutTrivia());
+                return memberAccess.WithTriviaFrom(node);
+            }
+        }
+        return base.VisitIdentifierName(node);
+    }
+
+    public override SyntaxNode VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+    {
+        if (node.Expression is ThisExpressionSyntax &&
+            node.Name is IdentifierNameSyntax id &&
+            _methodNames.Contains(id.Identifier.ValueText) &&
+            node.Parent is not InvocationExpressionSyntax)
+        {
+            var updated = node.WithExpression(SyntaxFactory.IdentifierName(_parameterName));
+            return base.VisitMemberAccessExpression(updated);
+        }
+        return base.VisitMemberAccessExpression(node);
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -398,12 +398,16 @@ public static partial class MoveMethodsTool
         {
             var methodCallRewriter = new MethodCallRewriter(otherMethodNames, parameterName);
             method = (MethodDeclarationSyntax)methodCallRewriter.Visit(method)!;
+            var methodRefRewriter = new MethodReferenceRewriter(otherMethodNames, parameterName);
+            method = (MethodDeclarationSyntax)methodRefRewriter.Visit(method)!;
         }
 
         if (isRecursive)
         {
             var recursiveCallRewriter = new MethodCallRewriter(new HashSet<string> { methodName }, parameterName);
             method = (MethodDeclarationSyntax)recursiveCallRewriter.Visit(method)!;
+            var recursiveRefRewriter = new MethodReferenceRewriter(new HashSet<string> { methodName }, parameterName);
+            method = (MethodDeclarationSyntax)recursiveRefRewriter.Visit(method)!;
         }
 
         return method;

--- a/RefactorMCP.Tests/Roslyn/Rewriters/MethodReferenceRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/MethodReferenceRewriterTests.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void MethodReferenceRewriter_QualifiesUnqualifiedReference()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test(){ obj.Evt += OnEvt; }") as MethodDeclarationSyntax;
+        var rewriter = new MethodReferenceRewriter(new HashSet<string> { "OnEvt" }, "inst");
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("obj.Evt += inst.OnEvt", result);
+    }
+
+    [Fact]
+    public void MethodReferenceRewriter_QualifiesThisReference()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test(){ obj.Evt += this.OnEvt; }") as MethodDeclarationSyntax;
+        var rewriter = new MethodReferenceRewriter(new HashSet<string> { "OnEvt" }, "inst");
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("obj.Evt += inst.OnEvt", result);
+        Assert.DoesNotContain("this.OnEvt", result);
+    }
+}


### PR DESCRIPTION
## Summary
- detect method group references in analysis for MoveMethods
- qualify event handler references with `@this` when moving methods
- add rewriter for method references
- test event handler prefixing

## Testing
- `dotnet format RefactorMCP.sln --no-restore`
- `dotnet build RefactorMCP.sln --no-restore`
- `dotnet test RefactorMCP.sln --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_685142e1cda88327b11dbf13b3eae613