### PR TITLE
Handle overloaded methods in MoveMultipleMethods

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -986,6 +986,13 @@ When a tool needs to create a new file, the namespace uses the file-scoped style
 {"tool":"move-static-method","solutionPath":"./RefactorMCP.sln","filePath":"./RefactorMCP.Tests/ExampleCode.cs","methodName":"Add","targetClass":"MathHelpers","targetFilePath":"./RefactorMCP.Tests/MathHelpers.cs"}
 ```
 
+### Overloaded Methods Example
+`move-multiple-methods` now works when the source class contains overloaded methods:
+
+```json
+{"tool":"move-multiple-methods","solutionPath":"./RefactorMCP.sln","filePath":"./RefactorMCP.Tests/ExampleCode.cs","sourceClass":"Helper","methodNames":["A","A"],"targetClass":"Target","targetFilePath":"./Target.cs"}
+```
+
 ## Metrics Resource
 
 Metrics can be queried using the resource scheme:

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Below is a quick reference of all tool classes provided by RefactorMCP. Each too
   Move a static or instance method to another class (preferred for large C# file refactoring). Supports optional `IProgress<string>` and `CancellationToken` parameters.
   If the same method is moved again in one run, an error is raised. Use `InlineMethodTool` to remove the wrapper.
   Call `ResetMoveHistory` to clear the session history when needed.
-- **MoveMultipleMethodsTool** `[McpServerToolType]`  
-  Move multiple methods from a source class to a target class, automatically ordering by dependencies.
+- **MoveMultipleMethodsTool** `[McpServerToolType]`
+  Move multiple methods from a source class to a target class, automatically ordering by dependencies. Overloaded method names are supported.
 - **RenameSymbolTool** `[McpServerToolType]`  
   Rename a symbol across the solution using Roslyn.
 - **SafeDeleteTool** `[McpServerToolType]`  

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Helpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Helpers.cs
@@ -25,7 +25,8 @@ public static partial class MoveMultipleMethodsTool
             .SelectMany(cls => cls.Members.OfType<MethodDeclarationSyntax>()
                 .Select(m => new { Key = $"{cls.Identifier.ValueText}.{m.Identifier.ValueText}", Method = m }))
             .Where(x => opSet.Contains(x.Key))
-            .ToDictionary(x => x.Key, x => x.Method);
+            .GroupBy(x => x.Key)
+            .ToDictionary(g => g.Key, g => g.First().Method);
 
         var methodNameSet = methodNames.ToHashSet();
         var deps = new Dictionary<string, HashSet<string>>();

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -98,7 +98,10 @@ public static partial class MoveMultipleMethodsTool
                 if (root == null)
                     throw new McpException("Error: Could not get syntax root");
 
-                var classNodes = root.DescendantNodes().OfType<ClassDeclarationSyntax>().ToDictionary(c => c.Identifier.ValueText);
+                var classNodes = root.DescendantNodes()
+                    .OfType<ClassDeclarationSyntax>()
+                    .GroupBy(c => c.Identifier.ValueText)
+                    .ToDictionary(g => g.Key, g => g.First());
 
                 if (!classNodes.TryGetValue(sourceClass, out var sourceClassNode))
                     throw new McpException($"Error: Source class '{sourceClass}' not found");

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
@@ -154,4 +154,26 @@ public class TargetClass
         Assert.Contains("return TargetClass.Method1()", sourceClassCode);
         Assert.Contains("return field1.Method2(field1)", sourceClassCode);
     }
+
+    [Fact]
+    public void OrderOperations_WithOverloadedMethods_ShouldHandleDuplicates()
+    {
+        var source = @"
+class SourceClass
+{
+    public void Foo() { }
+    public void Foo(int x) { }
+}
+";
+
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+
+        var indices = MoveMultipleMethodsTool.OrderOperations(
+            root,
+            new[] { "SourceClass", "SourceClass" },
+            new[] { "Foo", "Foo" });
+
+        Assert.Equal(2, indices.Count);
+    }
 }


### PR DESCRIPTION
## Summary
- allow duplicate method keys when building dependency map
- guard against partial classes with same name
- add regression test for overloaded methods
- document overload support in README and EXAMPLES

## Testing
- `dotnet format --no-restore`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_685158c424f08327820c8735b15a23b7