### PR TITLE
Ensure failed moves don't pollute history

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -719,6 +719,13 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli reset-move-history
 Cleared move history
 ```
 
+### Failed Move Example
+A failed move does not record the method:
+```json
+{"tool":"move-instance-method","solutionPath":"./RefactorMCP.sln","filePath":"./RefactorMCP.Tests/ExampleCode.cs","sourceClass":"Wrong","methodNames":"LogOperation","targetClass":"Logger"}
+```
+Running the command again with the correct `sourceClass` succeeds.
+
 ## 11. List Tools (Utility Command)
 
 **Purpose**: Display all available refactoring tools and their status.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Below is a quick reference of all tool classes provided by RefactorMCP. Each too
 - **MoveMethodsTool** `[McpServerToolType]`
   Move a static or instance method to another class (preferred for large C# file refactoring). Supports optional `IProgress<string>` and `CancellationToken` parameters.
   If the same method is moved again in one run, an error is raised. Use `InlineMethodTool` to remove the wrapper.
-  Call `ResetMoveHistory` to clear the session history when needed.
+  Failed move attempts do not add to the session history, and `ResetMoveHistory` clears the record when needed.
 - **MoveMultipleMethodsTool** `[McpServerToolType]`
   Move multiple methods from a source class to a target class, automatically ordering by dependencies. Overloaded method names are supported.
 - **RenameSymbolTool** `[McpServerToolType]`  

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
@@ -67,7 +67,6 @@ public static partial class MoveMethodsTool
             progress?.Report(filePath);
         }
 
-        MarkMoved(filePath, methodName);
         return $"Successfully moved static method '{methodName}' to {targetClass} in {targetPath}. A delegate method remains in the original class to preserve the interface.";
     }
 
@@ -151,7 +150,6 @@ public static partial class MoveMethodsTool
         }
 
         var locationInfo = targetFilePath != null ? $" in {targetPath}" : string.Empty;
-        MarkMoved(filePath, methodName);
         return $"Successfully moved instance method {sourceClass}.{methodName} to {targetClass}{locationInfo}. A delegate method remains in the original class to preserve the interface.";
     }
 

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -32,7 +32,7 @@ public static partial class MoveMethodsTool
         }
     }
 
-    private static void MarkMoved(string filePath, string methodName)
+    internal static void MarkMoved(string filePath, string methodName)
         => _movedMethods.Add(GetKey(filePath, methodName));
 
     [McpServerTool, Description("Clear the record of moved methods so they can be moved again. Do not use unless explicitly asked to.")]

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -66,6 +66,7 @@ public static partial class MoveMultipleMethodsTool
         var updatedDoc = solution.GetDocument(document.Id)!;
         RefactoringHelpers.UpdateSolutionCache(updatedDoc);
 
+        MoveMethodsTool.MarkMoved(document.FilePath!, methodName);
         return (message, updatedDoc);
     }
 

--- a/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
@@ -112,4 +112,36 @@ public class MoveInstanceMethodTests : TestBase
 
         Assert.Contains("Successfully moved", result2);
     }
+
+    [Fact]
+    public async Task MoveInstanceMethod_FailureDoesNotRecordHistory()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MoveFailHistory.cs"));
+        await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public class B { }");
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+
+        await Assert.ThrowsAsync<McpException>(() =>
+            MoveMethodsTool.MoveInstanceMethod(
+                SolutionPath,
+                testFile,
+                "Wrong",
+                "Do",
+                "B",
+                null,
+                null,
+                CancellationToken.None));
+
+        var result = await MoveMethodsTool.MoveInstanceMethod(
+            SolutionPath,
+            testFile,
+            "A",
+            "Do",
+            "B",
+            null,
+            null,
+            CancellationToken.None);
+
+        Assert.Contains("Successfully moved", result);
+    }
 }


### PR DESCRIPTION
## Summary
- avoid recording moves until after a successful operation
- expose `MarkMoved` internally so tools can record moves
- add tests for move history on failure
- document failed move behavior in README and EXAMPLES

## Testing
- `dotnet format --no-restore --verbosity diagnostic`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6851602446388327916b285df60de951