### PR TITLE
Suggest static conversion after moving methods

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1000,6 +1000,13 @@ When a tool needs to create a new file, the namespace uses the file-scoped style
 {"tool":"move-multiple-methods","solutionPath":"./RefactorMCP.sln","filePath":"./RefactorMCP.Tests/ExampleCode.cs","sourceClass":"Helper","methodNames":["A","A"],"targetClass":"Target","targetFilePath":"./Target.cs"}
 ```
 
+### Static Suggestion Example
+When a moved instance method has no dependencies on instance members, the result advises it can be made static:
+
+```json
+{"tool":"move-instance-method","solutionPath":"./RefactorMCP.sln","filePath":"./RefactorMCP.Tests/ExampleCode.cs","sourceClass":"Calculator","methodNames":"LogOperation","targetClass":"Logger"}
+```
+
 ## Metrics Resource
 
 Metrics can be queried using the resource scheme:

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Below is a quick reference of all tool classes provided by RefactorMCP. Each too
   Move a static or instance method to another class (preferred for large C# file refactoring). Supports optional `IProgress<string>` and `CancellationToken` parameters.
   If the same method is moved again in one run, an error is raised. Use `InlineMethodTool` to remove the wrapper.
   Failed move attempts do not add to the session history, and `ResetMoveHistory` clears the record when needed.
+  When a moved method has no instance dependencies the result suggests it can be made static.
 - **MoveMultipleMethodsTool** `[McpServerToolType]`
   Move multiple methods from a source class to a target class, automatically ordering by dependencies. Overloaded method names are supported.
 - **RenameSymbolTool** `[McpServerToolType]`  

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
@@ -150,7 +150,10 @@ public static partial class MoveMethodsTool
         }
 
         var locationInfo = targetFilePath != null ? $" in {targetPath}" : string.Empty;
-        return $"Successfully moved instance method {sourceClass}.{methodName} to {targetClass}{locationInfo}. A delegate method remains in the original class to preserve the interface.";
+        var staticHint = moveResult.NeedsThisParameter
+            ? string.Empty
+            : " As a next step it could be made static.";
+        return $"Successfully moved instance method {sourceClass}.{methodName} to {targetClass}{locationInfo}. A delegate method remains in the original class to preserve the interface.{staticHint}";
     }
 
 

--- a/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
@@ -31,6 +31,7 @@ public class MoveInstanceMethodTests : TestBase
         Assert.Contains("Successfully moved", result);
         Assert.Contains("A.Do", result);
         Assert.Contains("B", result);
+        Assert.Contains("made static", result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- update MoveMethods tools to hint at static conversion when possible
- document new behavior in README and EXAMPLES
- test output includes static hint

## Testing
- `dotnet format --no-restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68516e2a336083278d4b1cea58a56f91