### PR TITLE
Fix override removal when moving methods

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -594,9 +594,17 @@ public static partial class MoveMethodsTool
 
         if (targetClassDecl == null)
         {
+            var adjustedMethod = method;
+            if (method.Modifiers.Any(SyntaxKind.OverrideKeyword))
+            {
+                var mods = method.Modifiers
+                    .Where(m => !m.IsKind(SyntaxKind.OverrideKeyword));
+                adjustedMethod = method.WithModifiers(SyntaxFactory.TokenList(mods));
+            }
+
             var newClass = SyntaxFactory.ClassDeclaration(targetClass)
                 .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
-                .AddMembers(method.WithLeadingTrivia());
+                .AddMembers(adjustedMethod.WithLeadingTrivia());
             var compilationUnit = (CompilationUnitSyntax)targetRoot;
 
             var nsDecl = compilationUnit.Members.OfType<BaseNamespaceDeclarationSyntax>().FirstOrDefault();

--- a/RefactorMCP.Tests/Tools/MoveOverrideMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveOverrideMethodTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class MoveOverrideMethodTests
+{
+    [Fact]
+    public void MoveOverrideMethod_RemovesOverrideInNewClass()
+    {
+        var source = @"public class Base { public virtual void Foo() {} } public class Derived : Base { public override void Foo() {} }";
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+
+        var moveResult = MoveMethodsTool.MoveInstanceMethodAst(root, "Derived", "Foo", "Target", "", "");
+        var updatedRoot = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, "Target", moveResult.MovedMethod, moveResult.Namespace);
+        var formattedRoot = Formatter.Format(updatedRoot, new AdhocWorkspace());
+
+        var targetClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .First(c => c.Identifier.ValueText == "Target");
+        var movedMethod = targetClass.Members.OfType<MethodDeclarationSyntax>().First();
+        Assert.DoesNotContain("override", movedMethod.Modifiers.ToFullString());
+
+        var derivedClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .First(c => c.Identifier.ValueText == "Derived");
+        var stub = derivedClass.Members.OfType<MethodDeclarationSyntax>().First(m => m.Identifier.ValueText == "Foo");
+        Assert.Contains("override", stub.Modifiers.ToFullString());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure moved methods lose the `override` keyword if a new target class is created
- test that moved override methods drop the modifier while the stub keeps it

## Testing
- `dotnet build RefactorMCP.sln -clp:ErrorsOnly`
- `dotnet test RefactorMCP.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6851785823508327bc38a364888ba96b