### PR TITLE
Ensure moved methods are at least internal

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/CalledMethodCollector.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/CalledMethodCollector.cs
@@ -1,0 +1,46 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class CalledMethodCollector : CSharpSyntaxWalker
+{
+    private readonly HashSet<string> _methodNames;
+    public HashSet<string> CalledMethods { get; } = new();
+
+    public CalledMethodCollector(HashSet<string> methodNames)
+    {
+        _methodNames = methodNames;
+    }
+
+    public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        if (node.Expression is IdentifierNameSyntax id && _methodNames.Contains(id.Identifier.ValueText))
+        {
+            CalledMethods.Add(id.Identifier.ValueText);
+        }
+        else if (node.Expression is MemberAccessExpressionSyntax member &&
+                 member.Expression is ThisExpressionSyntax &&
+                 member.Name is IdentifierNameSyntax id2 &&
+                 _methodNames.Contains(id2.Identifier.ValueText))
+        {
+            CalledMethods.Add(id2.Identifier.ValueText);
+        }
+        base.VisitInvocationExpression(node);
+    }
+
+    public override void VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        if (_methodNames.Contains(node.Identifier.ValueText))
+        {
+            var parent = node.Parent;
+            if (parent is not InvocationExpressionSyntax &&
+                (parent is not MemberAccessExpressionSyntax ||
+                 (parent is MemberAccessExpressionSyntax ma && ma.Expression is ThisExpressionSyntax)))
+            {
+                CalledMethods.Add(node.Identifier.ValueText);
+            }
+        }
+        base.VisitIdentifierName(node);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -363,6 +363,34 @@ public class Target { }";
 
             Assert.Contains("Outer.Helper", formatted);
         }
+
+        [Fact]
+        public void MoveInstanceMethod_UpdatesPrivateDependencyAccess()
+        {
+            var source = @"public class A
+{ 
+    private void Helper() { }
+    public void Do() { Helper(); }
+}
+
+public class Target { }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var root = tree.GetRoot();
+
+            var result = MoveMethodsTool.MoveInstanceMethodAst(
+                root,
+                "A",
+                "Do",
+                "Target",
+                "_t",
+                "field");
+
+            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
+            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+
+            Assert.Contains("internal void Helper()", formatted);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- update MoveMethods transformations to keep methods internal unless already public
- adjust source updates to lift called private methods to internal visibility
- add CalledMethodCollector to gather method dependencies
- add test ensuring private helpers are made internal

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685173e957c883278068793916a26788