### PR TITLE
Extract walkers for MoveMultipleMethods

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/ClassCollectorWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/ClassCollectorWalker.cs
@@ -1,0 +1,20 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    internal class ClassCollectorWalker : CSharpSyntaxWalker
+    {
+        public Dictionary<string, ClassDeclarationSyntax> Classes { get; } = new();
+
+        public override void VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            var name = node.Identifier.ValueText;
+            if (!Classes.ContainsKey(name))
+                Classes[name] = node;
+            base.VisitClassDeclaration(node);
+        }
+    }
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodCollectorWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodCollectorWalker.cs
@@ -1,0 +1,31 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    internal class MethodCollectorWalker : CSharpSyntaxWalker
+    {
+        private readonly HashSet<string> _targets;
+        public Dictionary<string, MethodDeclarationSyntax> Methods { get; } = new();
+
+        public MethodCollectorWalker(HashSet<string> targets)
+        {
+            _targets = targets;
+        }
+
+        public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            if (node.Parent is ClassDeclarationSyntax cls)
+            {
+                var key = $"{cls.Identifier.ValueText}.{node.Identifier.ValueText}";
+                if (_targets.Contains(key) && !Methods.ContainsKey(key))
+                {
+                    Methods[key] = node;
+                }
+            }
+            base.VisitMethodDeclaration(node);
+        }
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Helpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Helpers.cs
@@ -21,12 +21,9 @@ public static partial class MoveMultipleMethodsTool
     {
         // Build map keyed by "Class.Method" to support duplicate method names in different classes
         var opSet = sourceClasses.Zip(methodNames, (c, m) => $"{c}.{m}").ToHashSet();
-        var map = sourceRoot.DescendantNodes().OfType<ClassDeclarationSyntax>()
-            .SelectMany(cls => cls.Members.OfType<MethodDeclarationSyntax>()
-                .Select(m => new { Key = $"{cls.Identifier.ValueText}.{m.Identifier.ValueText}", Method = m }))
-            .Where(x => opSet.Contains(x.Key))
-            .GroupBy(x => x.Key)
-            .ToDictionary(g => g.Key, g => g.First().Method);
+        var collector = new RefactorMCP.ConsoleApp.SyntaxRewriters.MethodCollectorWalker(opSet);
+        collector.Visit(sourceRoot);
+        var map = collector.Methods;
 
         var methodNameSet = methodNames.ToHashSet();
         var deps = new Dictionary<string, HashSet<string>>();

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -99,10 +99,9 @@ public static partial class MoveMultipleMethodsTool
                 if (root == null)
                     throw new McpException("Error: Could not get syntax root");
 
-                var classNodes = root.DescendantNodes()
-                    .OfType<ClassDeclarationSyntax>()
-                    .GroupBy(c => c.Identifier.ValueText)
-                    .ToDictionary(g => g.Key, g => g.First());
+                var collector = new ClassCollectorWalker();
+                collector.Visit(root);
+                var classNodes = collector.Classes;
 
                 if (!classNodes.TryGetValue(sourceClass, out var sourceClassNode))
                     throw new McpException($"Error: Source class '{sourceClass}' not found");


### PR DESCRIPTION
## Summary
- extract `ClassCollectorWalker` for locating class declarations
- extract `MethodCollectorWalker` for gathering specific methods
- use the new walkers in `MoveMultipleMethods` helpers and tool

## Testing
- `dotnet format --no-restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_685183e3e3608327a278aa7113d117a1