### PR TITLE
Refactor MoveMultipleMethods tool

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/AccessMemberTypeWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/AccessMemberTypeWalker.cs
@@ -1,0 +1,40 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    internal class AccessMemberTypeWalker : CSharpSyntaxWalker
+    {
+        private readonly string _memberName;
+        public string? MemberType { get; private set; }
+
+        public AccessMemberTypeWalker(string memberName)
+        {
+            _memberName = memberName;
+        }
+
+        public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+        {
+            foreach (var variable in node.Declaration.Variables)
+            {
+                if (variable.Identifier.ValueText == _memberName)
+                {
+                    MemberType = "field";
+                    return;
+                }
+            }
+            base.VisitFieldDeclaration(node);
+        }
+
+        public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+        {
+            if (node.Identifier.ValueText == _memberName)
+            {
+                MemberType = "property";
+                return;
+            }
+            base.VisitPropertyDeclaration(node);
+        }
+    }
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodStaticWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodStaticWalker.cs
@@ -1,0 +1,26 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    internal class MethodStaticWalker : CSharpSyntaxWalker
+    {
+        private readonly HashSet<string> _methodNames;
+        public Dictionary<string, bool> IsStaticMap { get; } = new();
+
+        public MethodStaticWalker(IEnumerable<string> methodNames)
+        {
+            _methodNames = new HashSet<string>(methodNames);
+        }
+
+        public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            var name = node.Identifier.ValueText;
+            if (_methodNames.Contains(name))
+                IsStaticMap[name] = node.Modifiers.Any(SyntaxKind.StaticKeyword);
+            base.VisitMethodDeclaration(node);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract MethodStaticWalker and AccessMemberTypeWalker helpers
- use new walkers in MoveMultipleMethods.Tool

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685183e3e3608327a278aa7113d117a1