### PR TITLE
Add helper methods for invocation arguments

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/ParameterIntroductionRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/ParameterIntroductionRewriter.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Editing;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -11,17 +12,20 @@ internal class ParameterIntroductionRewriter : CSharpSyntaxRewriter
     private readonly string _methodName;
     private readonly ParameterSyntax _parameter;
     private readonly IdentifierNameSyntax _parameterReference;
+    private readonly SyntaxGenerator _generator;
 
     public ParameterIntroductionRewriter(
         ExpressionSyntax targetExpression,
         string methodName,
         ParameterSyntax parameter,
-        IdentifierNameSyntax parameterReference)
+        IdentifierNameSyntax parameterReference,
+        SyntaxGenerator generator)
     {
         _targetExpression = targetExpression;
         _methodName = methodName;
         _parameter = parameter;
         _parameterReference = parameterReference;
+        _generator = generator;
     }
 
     public override SyntaxNode Visit(SyntaxNode? node)
@@ -41,8 +45,10 @@ internal class ParameterIntroductionRewriter : CSharpSyntaxRewriter
 
         if (isTarget)
         {
-            var newArgs = visited.ArgumentList.AddArguments(SyntaxFactory.Argument(_targetExpression.WithoutTrivia()));
-            visited = visited.WithArgumentList(newArgs);
+            visited = AstTransformations.AddArgument(
+                visited,
+                _targetExpression.WithoutTrivia(),
+                _generator);
         }
 
         return visited;

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/ParameterRemovalRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/ParameterRemovalRewriter.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Editing;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -9,11 +10,13 @@ public class ParameterRemovalRewriter : CSharpSyntaxRewriter
 {
     private readonly string _methodName;
     private readonly int _parameterIndex;
+    private readonly SyntaxGenerator _generator;
 
-    public ParameterRemovalRewriter(string methodName, int parameterIndex)
+    public ParameterRemovalRewriter(string methodName, int parameterIndex, SyntaxGenerator generator)
     {
         _methodName = methodName;
         _parameterIndex = parameterIndex;
+        _generator = generator;
     }
 
     public override SyntaxNode VisitMethodDeclaration(MethodDeclarationSyntax node)
@@ -38,8 +41,7 @@ public class ParameterRemovalRewriter : CSharpSyntaxRewriter
 
         if (isTarget && _parameterIndex < visited.ArgumentList.Arguments.Count)
         {
-            var newArgs = visited.ArgumentList.Arguments.RemoveAt(_parameterIndex);
-            visited = visited.WithArgumentList(visited.ArgumentList.WithArguments(newArgs));
+            visited = AstTransformations.RemoveArgument(visited, _parameterIndex);
         }
 
         return visited;

--- a/RefactorMCP.ConsoleApp/Tools/AstTransformations.cs
+++ b/RefactorMCP.ConsoleApp/Tools/AstTransformations.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 using System.Linq;
 
 internal static class AstTransformations
@@ -52,5 +53,22 @@ internal static class AstTransformations
         if (!modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword)))
             modifiers = modifiers.Add(SyntaxFactory.Token(SyntaxKind.StaticKeyword));
         return method.WithModifiers(modifiers);
+    }
+
+    internal static InvocationExpressionSyntax AddArgument(
+        InvocationExpressionSyntax invocation,
+        ExpressionSyntax argumentExpression,
+        SyntaxGenerator generator)
+    {
+        var argument = (ArgumentSyntax)generator.Argument(argumentExpression);
+        return invocation.WithArgumentList(invocation.ArgumentList.AddArguments(argument));
+    }
+
+    internal static InvocationExpressionSyntax RemoveArgument(
+        InvocationExpressionSyntax invocation,
+        int argumentIndex)
+    {
+        var newArgs = invocation.ArgumentList.Arguments.RemoveAt(argumentIndex);
+        return invocation.WithArgumentList(invocation.ArgumentList.WithArguments(newArgs));
     }
 }

--- a/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
+++ b/RefactorMCP.ConsoleApp/Tools/IntroduceParameter.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
+using Microsoft.CodeAnalysis.Editing;
 
 [McpServerToolType]
 public static class IntroduceParameterTool
@@ -45,7 +46,8 @@ public static class IntroduceParameterTool
             .WithType(SyntaxFactory.ParseTypeName(typeName));
 
         var parameterReference = SyntaxFactory.IdentifierName(parameterName);
-        var rewriter = new ParameterIntroductionRewriter(selectedExpression, methodName, parameter, parameterReference);
+        var generator = SyntaxGenerator.GetGenerator(document.Project.Solution.Workspace, LanguageNames.CSharp);
+        var rewriter = new ParameterIntroductionRewriter(selectedExpression, methodName, parameter, parameterReference, generator);
         var newRoot = rewriter.Visit(syntaxRoot);
 
         var formattedRoot = Formatter.Format(newRoot, document.Project.Solution.Workspace);
@@ -102,7 +104,8 @@ public static class IntroduceParameterTool
             .WithType(SyntaxFactory.ParseTypeName("object"));
 
         var parameterReference = SyntaxFactory.IdentifierName(parameterName);
-        var rewriter = new ParameterIntroductionRewriter(selectedExpression, methodName, parameter, parameterReference);
+        var generator = SyntaxGenerator.GetGenerator(RefactoringHelpers.SharedWorkspace, LanguageNames.CSharp);
+        var rewriter = new ParameterIntroductionRewriter(selectedExpression, methodName, parameter, parameterReference, generator);
         var newRoot = rewriter.Visit(syntaxRoot);
 
         var formattedRoot = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);

--- a/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SafeDelete.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Editing;
 
 [McpServerToolType]
 public static class SafeDeleteTool
@@ -233,7 +234,8 @@ public static class SafeDeleteTool
         if (!docs.Contains(document))
             docs.Add(document);
 
-        var rewriter = new ParameterRemovalRewriter(methodName, paramIndex);
+        var generator = SyntaxGenerator.GetGenerator(document.Project.Solution.Workspace, LanguageNames.CSharp);
+        var rewriter = new ParameterRemovalRewriter(methodName, paramIndex, generator);
 
         foreach (var doc in docs)
         {
@@ -271,7 +273,8 @@ public static class SafeDeleteTool
             throw new McpException($"Error: Parameter '{parameterName}' not found. Verify the parameter name and ensure the file is part of the loaded solution.");
 
         var paramIndex = method.ParameterList.Parameters.IndexOf(parameter);
-        var rewriter = new ParameterRemovalRewriter(methodName, paramIndex);
+        var generator = SyntaxGenerator.GetGenerator(RefactoringHelpers.SharedWorkspace, LanguageNames.CSharp);
+        var rewriter = new ParameterRemovalRewriter(methodName, paramIndex, generator);
         var newRoot = rewriter.Visit(root)!;
         var formatted = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
         return formatted.ToFullString();

--- a/RefactorMCP.Tests/Roslyn/AstTransformationsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/AstTransformationsTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Editing;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -52,5 +53,25 @@ public partial class RoslynTransformationTests
         var updated = AstTransformations.EnsureStaticModifier(method!);
 
         Assert.Contains("static", updated.Modifiers.ToFullString());
+    }
+
+    [Fact]
+    public void AddArgument_AddsArgumentToInvocation()
+    {
+        var invocation = SyntaxFactory.ParseExpression("M()") as InvocationExpressionSyntax;
+        var expr = SyntaxFactory.IdentifierName("x");
+        var generator = SyntaxGenerator.GetGenerator(new AdhocWorkspace(), LanguageNames.CSharp);
+        var updated = AstTransformations.AddArgument(invocation!, expr, generator);
+
+        Assert.Equal("M(x)", updated.NormalizeWhitespace().ToFullString());
+    }
+
+    [Fact]
+    public void RemoveArgument_RemovesArgumentFromInvocation()
+    {
+        var invocation = SyntaxFactory.ParseExpression("M(a, b)") as InvocationExpressionSyntax;
+        var updated = AstTransformations.RemoveArgument(invocation!, 0);
+
+        Assert.Equal("M(b)", updated.NormalizeWhitespace().ToFullString());
     }
 }

--- a/RefactorMCP.Tests/Roslyn/Rewriters/ParameterIntroductionRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ParameterIntroductionRewriterTests.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Editing;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -18,7 +19,8 @@ public partial class RoslynTransformationTests
         var expr = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1));
         var parameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier("p")).WithType(SyntaxFactory.ParseTypeName("int"));
         var paramRef = SyntaxFactory.IdentifierName("p");
-        var rewriter = new ParameterIntroductionRewriter(expr, "M", parameter, paramRef);
+        var generator = SyntaxGenerator.GetGenerator(new AdhocWorkspace(), LanguageNames.CSharp);
+        var rewriter = new ParameterIntroductionRewriter(expr, "M", parameter, paramRef, generator);
         var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
         var text = newRoot.ToFullString();
         Assert.Contains("void M(int p)", text);

--- a/RefactorMCP.Tests/Roslyn/Rewriters/ParameterRemovalRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ParameterRemovalRewriterTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Editing;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -10,10 +11,14 @@ public partial class RoslynTransformationTests
     [Fact]
     public void ParameterRemovalRewriter_RemovesParameter()
     {
-        var tree = CSharpSyntaxTree.ParseText("class A{void M(int a,int b){}} ");
+        var tree = CSharpSyntaxTree.ParseText("class A{void M(int a,int b){}} class B{void Call(){new A().M(1,2);}} ");
         var root = tree.GetRoot();
-        var rewriter = new ParameterRemovalRewriter("M", 1);
+        var generator = SyntaxGenerator.GetGenerator(new AdhocWorkspace(), LanguageNames.CSharp);
+        var rewriter = new ParameterRemovalRewriter("M", 1, generator);
         var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
-        Assert.Contains("void M(int a)", newRoot.ToFullString());
+        var text = newRoot.ToFullString();
+        Assert.Contains("void M(int a)", text);
+        Assert.Contains("M(1)", text);
+        Assert.DoesNotContain("2)", text);
     }
 }


### PR DESCRIPTION
## Summary
- add AddArgument and RemoveArgument helpers to `AstTransformations`
- replace direct argument edits in `ParameterIntroductionRewriter` and `ParameterRemovalRewriter`
- generate arguments using `SyntaxGenerator`
- update related tools and tests

## Testing
- `dotnet format RefactorMCP.sln --no-restore -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68518e848c848327bd5678c369d75409