### PR TITLE
Implement IdentifierUsageWalker

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/CalledMethodCollector.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/CalledMethodCollector.cs
@@ -1,46 +1,28 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 
-internal class CalledMethodCollector : CSharpSyntaxWalker
+internal class CalledMethodCollector : IdentifierUsageWalker
 {
-    private readonly HashSet<string> _methodNames;
     public HashSet<string> CalledMethods { get; } = new();
 
     public CalledMethodCollector(HashSet<string> methodNames)
+        : base(methodNames)
     {
-        _methodNames = methodNames;
     }
 
-    public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+    protected override void RecordUsage(string name)
     {
-        if (node.Expression is IdentifierNameSyntax id && _methodNames.Contains(id.Identifier.ValueText))
-        {
-            CalledMethods.Add(id.Identifier.ValueText);
-        }
-        else if (node.Expression is MemberAccessExpressionSyntax member &&
-                 member.Expression is ThisExpressionSyntax &&
-                 member.Name is IdentifierNameSyntax id2 &&
-                 _methodNames.Contains(id2.Identifier.ValueText))
-        {
-            CalledMethods.Add(id2.Identifier.ValueText);
-        }
-        base.VisitInvocationExpression(node);
+        CalledMethods.Add(name);
     }
 
-    public override void VisitIdentifierName(IdentifierNameSyntax node)
+    protected override bool TryRecordInvocation(InvocationExpressionSyntax node)
     {
-        if (_methodNames.Contains(node.Identifier.ValueText))
+        var name = GetInvocationName(node);
+        if (name != null && IsTarget(name))
         {
-            var parent = node.Parent;
-            if (parent is not InvocationExpressionSyntax &&
-                (parent is not MemberAccessExpressionSyntax ||
-                 (parent is MemberAccessExpressionSyntax ma && ma.Expression is ThisExpressionSyntax)))
-            {
-                CalledMethods.Add(node.Identifier.ValueText);
-            }
+            RecordUsage(name);
+            return true;
         }
-        base.VisitIdentifierName(node);
+        return false;
     }
 }

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/IdentifierUsageWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/IdentifierUsageWalker.cs
@@ -1,0 +1,71 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal abstract class IdentifierUsageWalker : CSharpSyntaxWalker
+{
+    private readonly HashSet<string> _identifiers;
+
+    protected IdentifierUsageWalker(HashSet<string> identifiers)
+    {
+        _identifiers = identifiers;
+    }
+
+    protected bool IsTarget(string name) => _identifiers.Contains(name);
+
+    protected static bool IsParameterOrType(SyntaxNode? node) =>
+        node is ParameterSyntax || node is TypeSyntax;
+
+    protected static bool IsThisMember(MemberAccessExpressionSyntax ma, IdentifierNameSyntax node) =>
+        ma.Expression is ThisExpressionSyntax && ma.Name == node;
+
+    protected static bool IsMemberExpression(IdentifierNameSyntax node, MemberAccessExpressionSyntax ma) =>
+        ma.Expression == node;
+
+    protected static string? GetInvocationName(InvocationExpressionSyntax node)
+    {
+        return node.Expression switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            MemberAccessExpressionSyntax { Expression: ThisExpressionSyntax, Name: IdentifierNameSyntax id } => id.Identifier.ValueText,
+            _ => null
+        };
+    }
+
+    protected virtual bool ShouldRecordIdentifier(IdentifierNameSyntax node)
+    {
+        var parent = node.Parent;
+        if (!IsTarget(node.Identifier.ValueText) || IsParameterOrType(parent))
+            return false;
+
+        if (parent is MemberAccessExpressionSyntax memberAccess)
+        {
+            if (IsThisMember(memberAccess, node) || IsMemberExpression(node, memberAccess))
+                return true;
+            return false;
+        }
+
+        if (parent is InvocationExpressionSyntax)
+            return false;
+
+        return true;
+    }
+
+    public override void VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        if (ShouldRecordIdentifier(node))
+            RecordUsage(node.Identifier.ValueText);
+        base.VisitIdentifierName(node);
+    }
+
+    protected virtual bool TryRecordInvocation(InvocationExpressionSyntax node) => false;
+
+    public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+    {
+        if (!TryRecordInvocation(node))
+            base.VisitInvocationExpression(node);
+    }
+
+    protected abstract void RecordUsage(string name);
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberUsageChecker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberUsageChecker.cs
@@ -1,49 +1,16 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 
-internal class InstanceMemberUsageChecker : CSharpSyntaxWalker
+internal class InstanceMemberUsageChecker : IdentifierUsageWalker
 {
-    private readonly HashSet<string> _knownInstanceMembers;
     public bool HasInstanceMemberUsage { get; private set; }
 
     public InstanceMemberUsageChecker(HashSet<string> knownInstanceMembers)
+        : base(knownInstanceMembers)
     {
-        _knownInstanceMembers = knownInstanceMembers;
     }
 
-    public override void VisitIdentifierName(IdentifierNameSyntax node)
+    protected override void RecordUsage(string name)
     {
-        var parent = node.Parent;
-        if (parent is ParameterSyntax || parent is TypeSyntax)
-        {
-            base.VisitIdentifierName(node);
-            return;
-        }
-
-        if (_knownInstanceMembers.Contains(node.Identifier.ValueText))
-        {
-            if (parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Expression == node)
-            {
-                HasInstanceMemberUsage = true;
-            }
-            else if (parent is not MemberAccessExpressionSyntax && parent is not InvocationExpressionSyntax)
-            {
-                HasInstanceMemberUsage = true;
-            }
-        }
-
-        base.VisitIdentifierName(node);
-    }
-
-    public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
-    {
-        if (node.Expression is ThisExpressionSyntax && _knownInstanceMembers.Contains(node.Name.Identifier.ValueText))
-        {
-            HasInstanceMemberUsage = true;
-        }
-        base.VisitMemberAccessExpression(node);
+        HasInstanceMemberUsage = true;
     }
 }
-

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/PrivateFieldUsageWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/PrivateFieldUsageWalker.cs
@@ -1,34 +1,17 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 
-internal class PrivateFieldUsageWalker : CSharpSyntaxWalker
+internal class PrivateFieldUsageWalker : IdentifierUsageWalker
 {
-    private readonly HashSet<string> _privateFieldNames;
     public HashSet<string> UsedFields { get; } = new();
 
     public PrivateFieldUsageWalker(HashSet<string> privateFieldNames)
+        : base(privateFieldNames)
     {
-        _privateFieldNames = privateFieldNames;
     }
 
-    public override void VisitIdentifierName(IdentifierNameSyntax node)
+    protected override void RecordUsage(string name)
     {
-        var parent = node.Parent;
-        if (_privateFieldNames.Contains(node.Identifier.ValueText))
-        {
-            if (parent is MemberAccessExpressionSyntax ma && ma.Expression is ThisExpressionSyntax && ma.Name == node)
-            {
-                UsedFields.Add(node.Identifier.ValueText);
-            }
-            else if (parent is not MemberAccessExpressionSyntax ||
-                     (parent is MemberAccessExpressionSyntax ma2 && ma2.Expression == node))
-            {
-                UsedFields.Add(node.Identifier.ValueText);
-            }
-        }
-
-        base.VisitIdentifierName(node);
+        UsedFields.Add(name);
     }
 }


### PR DESCRIPTION
## Summary
- add generic `IdentifierUsageWalker`
- refactor `CalledMethodCollector`, `PrivateFieldUsageWalker` and `InstanceMemberUsageChecker` to use new walker
- remove duplicate logic

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685192e348cc8327bd2d9c8a09a27130