### PR TITLE
Introduce common name tracking walker

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/CalledMethodCollector.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/CalledMethodCollector.cs
@@ -1,18 +1,13 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 
-internal class CalledMethodCollector : IdentifierUsageWalker
+internal class CalledMethodCollector : TrackedNameWalker
 {
-    public HashSet<string> CalledMethods { get; } = new();
+    public HashSet<string> CalledMethods => Matches;
 
     public CalledMethodCollector(HashSet<string> methodNames)
         : base(methodNames)
     {
-    }
-
-    protected override void RecordUsage(string name)
-    {
-        CalledMethods.Add(name);
     }
 
     protected override bool TryRecordInvocation(InvocationExpressionSyntax node)
@@ -20,7 +15,7 @@ internal class CalledMethodCollector : IdentifierUsageWalker
         var name = GetInvocationName(node);
         if (name != null && IsTarget(name))
         {
-            RecordUsage(name);
+            RecordMatch(name);
             return true;
         }
         return false;

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberUsageChecker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberUsageChecker.cs
@@ -1,16 +1,11 @@
 using System.Collections.Generic;
 
-internal class InstanceMemberUsageChecker : IdentifierUsageWalker
+internal class InstanceMemberUsageChecker : TrackedNameWalker
 {
-    public bool HasInstanceMemberUsage { get; private set; }
+    public bool HasInstanceMemberUsage => Matches.Count > 0;
 
     public InstanceMemberUsageChecker(HashSet<string> knownInstanceMembers)
         : base(knownInstanceMembers)
     {
-    }
-
-    protected override void RecordUsage(string name)
-    {
-        HasInstanceMemberUsage = true;
     }
 }

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodCallChecker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodCallChecker.cs
@@ -3,26 +3,23 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 
-internal class MethodCallChecker : CSharpSyntaxWalker
+internal class MethodCallChecker : TrackedNameWalker
 {
-    private readonly HashSet<string> _classMethodNames;
-    public bool HasMethodCalls { get; private set; }
+    public bool HasMethodCalls => Matches.Count > 0;
 
     public MethodCallChecker(HashSet<string> classMethodNames)
+        : base(classMethodNames)
     {
-        _classMethodNames = classMethodNames;
     }
 
-    public override void VisitInvocationExpression(InvocationExpressionSyntax node)
+    protected override bool TryRecordInvocation(InvocationExpressionSyntax node)
     {
-        if (node.Expression is IdentifierNameSyntax identifier)
+        if (node.Expression is IdentifierNameSyntax identifier && IsTarget(identifier.Identifier.ValueText))
         {
-            if (_classMethodNames.Contains(identifier.Identifier.ValueText))
-            {
-                HasMethodCalls = true;
-            }
+            RecordMatch(identifier.Identifier.ValueText);
+            return true;
         }
-        base.VisitInvocationExpression(node);
+        return false;
     }
 }
 

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/PrivateFieldUsageWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/PrivateFieldUsageWalker.cs
@@ -1,17 +1,12 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 
-internal class PrivateFieldUsageWalker : IdentifierUsageWalker
+internal class PrivateFieldUsageWalker : TrackedNameWalker
 {
-    public HashSet<string> UsedFields { get; } = new();
+    public HashSet<string> UsedFields => Matches;
 
     public PrivateFieldUsageWalker(HashSet<string> privateFieldNames)
         : base(privateFieldNames)
     {
-    }
-
-    protected override void RecordUsage(string name)
-    {
-        UsedFields.Add(name);
     }
 }


### PR DESCRIPTION
## Summary
- add `TrackedNameWalker` base class for tracking identifier usage
- refactor `InstanceMemberUsageChecker`, `PrivateFieldUsageWalker`, `CalledMethodCollector`, `StaticFieldChecker` and `MethodCallChecker` to inherit from it
- remove old `IdentifierUsageWalker`

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`
- `dotnet format --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_6851954068048327ae8f934092ab16de