### PR TITLE
Refactor StaticConversionRewriter

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/IdentifierRenameRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/IdentifierRenameRewriter.cs
@@ -1,0 +1,36 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class IdentifierRenameRewriter : CSharpSyntaxRewriter
+{
+    private readonly SemanticModel? _semanticModel;
+    private readonly Dictionary<ISymbol, string>? _symbolMap;
+    private readonly Dictionary<string, string>? _nameMap;
+
+    public IdentifierRenameRewriter(
+        SemanticModel? semanticModel = null,
+        Dictionary<ISymbol, string>? symbolMap = null,
+        Dictionary<string, string>? nameMap = null)
+    {
+        _semanticModel = semanticModel;
+        _symbolMap = symbolMap;
+        _nameMap = nameMap;
+    }
+
+    public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        if (_semanticModel != null && _symbolMap != null)
+        {
+            var sym = _semanticModel.GetSymbolInfo(node).Symbol;
+            if (sym != null && _symbolMap.TryGetValue(sym, out var newName))
+                return SyntaxFactory.IdentifierName(newName).WithTriviaFrom(node);
+        }
+
+        if (_nameMap != null && _nameMap.TryGetValue(node.Identifier.ValueText, out var name))
+            return SyntaxFactory.IdentifierName(name).WithTriviaFrom(node);
+
+        return base.VisitIdentifierName(node);
+    }
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberQualifierRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberQualifierRewriter.cs
@@ -1,0 +1,86 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class InstanceMemberQualifierRewriter : CSharpSyntaxRewriter
+{
+    private readonly string _parameterName;
+    private readonly SemanticModel? _semanticModel;
+    private readonly INamedTypeSymbol? _typeSymbol;
+    private readonly HashSet<string>? _knownMembers;
+
+    public InstanceMemberQualifierRewriter(
+        string parameterName,
+        SemanticModel? semanticModel = null,
+        INamedTypeSymbol? typeSymbol = null,
+        HashSet<string>? knownMembers = null)
+    {
+        _parameterName = parameterName;
+        _semanticModel = semanticModel;
+        _typeSymbol = typeSymbol;
+        _knownMembers = knownMembers;
+    }
+
+    public override SyntaxNode VisitThisExpression(ThisExpressionSyntax node)
+        => SyntaxFactory.IdentifierName(_parameterName).WithTriviaFrom(node);
+
+    public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+    {
+        var parent = node.Parent;
+        if (parent is ParameterSyntax || parent is TypeSyntax)
+            return base.VisitIdentifierName(node);
+
+        bool qualify = false;
+        if (_semanticModel != null && _typeSymbol != null)
+        {
+            var sym = _semanticModel.GetSymbolInfo(node).Symbol;
+            if (sym is IFieldSymbol or IPropertySymbol or IMethodSymbol &&
+                !sym.IsStatic && parent is not MemberAccessExpressionSyntax &&
+                sym.ContainingType is INamedTypeSymbol ct &&
+                IsInTypeHierarchy(ct))
+            {
+                qualify = true;
+            }
+        }
+        else if (_knownMembers != null &&
+                 _knownMembers.Contains(node.Identifier.ValueText) &&
+                 parent is not MemberAccessExpressionSyntax)
+        {
+            qualify = true;
+        }
+
+        if (qualify)
+        {
+            return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(_parameterName),
+                    node.WithoutTrivia())
+                .WithTriviaFrom(node);
+        }
+
+        return base.VisitIdentifierName(node);
+    }
+
+    private bool IsInTypeHierarchy(INamedTypeSymbol containing)
+    {
+        if (_typeSymbol == null)
+            return false;
+
+        var current = _typeSymbol;
+        while (current != null)
+        {
+            if (SymbolEqualityComparer.Default.Equals(current, containing))
+                return true;
+            current = current.BaseType;
+        }
+
+        foreach (var iface in _typeSymbol.AllInterfaces)
+        {
+            if (SymbolEqualityComparer.Default.Equals(iface, containing))
+                return true;
+        }
+
+        return false;
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/IdentifierRenameRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/IdentifierRenameRewriterTests.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void IdentifierRenameRewriter_RenamesField()
+    {
+        var code = "class C{ int x; int M(){ return x; } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var compilation = CSharpCompilation.Create("test", new[] { tree });
+        var model = compilation.GetSemanticModel(tree);
+        var root = tree.GetRoot();
+        var field = root.DescendantNodes().OfType<VariableDeclaratorSyntax>().First();
+        var symbol = model.GetDeclaredSymbol(field)!;
+        var map = new Dictionary<ISymbol, string>(SymbolEqualityComparer.Default)
+        {
+            [symbol] = "p"
+        };
+        var rewriter = new IdentifierRenameRewriter(model, map, null);
+        var newRoot = rewriter.Visit(root)!;
+        Assert.Contains("p", newRoot.ToFullString());
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberQualifierRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberQualifierRewriterTests.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void InstanceMemberQualifierRewriter_QualifiesMember()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void M(){ Value = 1; }") as MethodDeclarationSyntax;
+        var rewriter = new InstanceMemberQualifierRewriter("inst", knownMembers: new HashSet<string> { "Value" });
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("inst.Value", result);
+    }
+}


### PR DESCRIPTION
## Summary
- break StaticConversionRewriter responsibilities into smaller rewriters
- add IdentifierRenameRewriter and InstanceMemberQualifierRewriter
- use new rewriters inside StaticConversionRewriter
- test the new rewriters

## Testing
- `dotnet format --verbosity diagnostic`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6851972979b48327b7d9dd3152f4c103