### PR TITLE
Fix MoveMultipleMethods history on failure

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -66,7 +66,6 @@ public static partial class MoveMultipleMethodsTool
         var updatedDoc = solution.GetDocument(document.Id)!;
         RefactoringHelpers.UpdateSolutionCache(updatedDoc);
 
-        MoveMethodsTool.MarkMoved(document.FilePath!, methodName);
         return (message, updatedDoc);
     }
 
@@ -135,6 +134,7 @@ public static partial class MoveMultipleMethodsTool
                 var orderedIndices = OrderOperations(root, sourceClasses, methodNames);
 
                 var results = new List<string>();
+                var moved = new List<(string file, string method)>();
                 var currentDoc = document;
                 var targetPath = targetFilePath ?? Path.Combine(Path.GetDirectoryName(document.FilePath!)!, $"{targetClass}.cs");
 
@@ -150,8 +150,12 @@ public static partial class MoveMultipleMethodsTool
                         accessMemberTypes[idx],
                         targetPath);
                     currentDoc = result.updatedDocument;
+                    moved.Add((document.FilePath!, methodNames[idx]));
                     results.Add(result.message);
                 }
+
+                foreach (var (file, method) in moved)
+                    MoveMethodsTool.MarkMoved(file, method);
 
                 return string.Join("\n", results);
             }

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsToolTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsToolTests.cs
@@ -1,0 +1,38 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class MoveMultipleMethodsToolTests : TestBase
+{
+    [Fact]
+    public async Task MoveMultipleMethods_FailureDoesNotRecordHistory()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.Combine(TestOutputPath, "MoveMultiFailHistory.cs");
+        File.Copy(ExampleFilePath, testFile, true);
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);
+        var project = solution.Projects.First();
+        RefactoringHelpers.AddDocumentToProject(project, testFile);
+
+        var error = await MoveMultipleMethodsTool.MoveMultipleMethods(
+            SolutionPath,
+            testFile,
+            "Calculator",
+            new[] { "FormatCurrency", "Wrong" },
+            "MathUtilities");
+        Assert.Contains("Error:", error);
+
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+            SolutionPath,
+            testFile,
+            "Calculator",
+            new[] { "FormatCurrency", "LogOperation" },
+            "MathUtilities");
+
+        Assert.Contains("Successfully moved", result);
+    }
+}


### PR DESCRIPTION
## Summary
- avoid recording move attempts inside MoveMultipleMethods until all succeed
- track moves in MoveMultipleMethods and mark them after completion
- add regression test for failure history

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685198294aa08327aaf1f072cd93dece