### PR TITLE
Add skipped failing test for MoveMultipleMethods bug

### DIFF
--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsBugTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsBugTests.cs
@@ -1,0 +1,40 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class MoveMultipleMethodsBugTests : TestBase
+{
+    [Fact(Skip = "Demonstrates bug: MoveMultipleMethods fails with nested class generics")]
+    public async Task MoveMultipleMethods_NestedClassGenerics_Fails()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.Combine(TestOutputPath, "NestedGeneric.cs");
+        var code = @"using System.Collections.Generic;
+public class Outer
+{
+    public class Inner { }
+    public List<Inner> MakeList() => new List<Inner>();
+    public int CountList(List<Inner> items) => items.Count;
+}
+public class Target { }";
+        await File.WriteAllTextAsync(testFile, code);
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);
+        var project = solution.Projects.First();
+        RefactoringHelpers.AddDocumentToProject(project, testFile);
+
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+            SolutionPath,
+            testFile,
+            "Outer",
+            new[] { "MakeList", "CountList" },
+            "Target");
+
+        Assert.Contains("Successfully moved", result);
+    }
+}


### PR DESCRIPTION
## Summary
- add failing (skipped) unit test showing MoveMultipleMethods bug when methods use nested class generics

## Testing
- `dotnet format`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6851dcd121188327b51fdf6ea85ddd74