### PR TITLE
Fix MoveMultipleMethods nested generics

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/NestedClassRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/NestedClassRewriter.cs
@@ -28,7 +28,7 @@ internal class NestedClassRewriter : CSharpSyntaxRewriter
                 return qualified.WithTriviaFrom(node);
             }
 
-            if (IsTypeContext(node))
+            if (IsTypeContext(node) || parent is TypeArgumentListSyntax)
             {
                 var qualified = SyntaxFactory.QualifiedName(
                     SyntaxFactory.IdentifierName(_outerClass),

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsBugTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsBugTests.cs
@@ -9,7 +9,7 @@ namespace RefactorMCP.Tests;
 
 public class MoveMultipleMethodsBugTests : TestBase
 {
-    [Fact(Skip = "Demonstrates bug: MoveMultipleMethods fails with nested class generics")]
+    [Fact]
     public async Task MoveMultipleMethods_NestedClassGenerics_Fails()
     {
         UnloadSolutionTool.ClearSolutionCache();
@@ -22,7 +22,7 @@ public class Outer
     public int CountList(List<Inner> items) => items.Count;
 }
 public class Target { }";
-        await File.WriteAllTextAsync(testFile, code);
+        await TestUtilities.CreateTestFile(testFile, code);
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
         var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);
         var project = solution.Projects.First();

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsToolTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsToolTests.cs
@@ -12,7 +12,7 @@ public class MoveMultipleMethodsToolTests : TestBase
     {
         UnloadSolutionTool.ClearSolutionCache();
         var testFile = Path.Combine(TestOutputPath, "MoveMultiFailHistory.cs");
-        File.Copy(ExampleFilePath, testFile, true);
+        await TestUtilities.CreateTestFile(testFile, File.ReadAllText(ExampleFilePath));
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
         var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);
         var project = solution.Projects.First();


### PR DESCRIPTION
## Summary
- unskip MoveMultipleMethods bug test
- fix `NestedClassRewriter` to handle generic type arguments
- use helper for creating temporary files in MoveMultipleMethods tests

## Testing
- `dotnet format --no-restore`
- `dotnet build`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_6851e73407488327868fd0e8714123e2