### PR TITLE
Add CancellationToken overload for GetSummary

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/SummaryResources.cs
+++ b/RefactorMCP.ConsoleApp/Tools/SummaryResources.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -12,7 +13,7 @@ using ModelContextProtocol.Server;
 public static class SummaryResources
 {
     [McpServerResource(UriTemplate = "summary://{*file}", MimeType = "text/plain")]
-    public static async Task<string> GetSummary(string file)
+    public static async Task<string> GetSummary(string file, CancellationToken cancellationToken = default)
     {
         var normalized = file.Replace('/', Path.DirectorySeparatorChar);
         if (!File.Exists(normalized))
@@ -20,9 +21,9 @@ public static class SummaryResources
             return $"// File not found: {file}";
         }
 
-        var text = await File.ReadAllTextAsync(normalized);
+        var text = await File.ReadAllTextAsync(normalized, cancellationToken);
         var tree = CSharpSyntaxTree.ParseText(text);
-        var root = await tree.GetRootAsync();
+        var root = await tree.GetRootAsync(cancellationToken);
         var summarized = new BodyOmitter().Visit(root);
         var workspace = new AdhocWorkspace();
         var formatted = Formatter.Format(summarized, workspace);

--- a/RefactorMCP.Tests/SummaryResourceTests.cs
+++ b/RefactorMCP.Tests/SummaryResourceTests.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -8,7 +9,7 @@ public class SummaryResourceTests : TestBase
     [Fact]
     public async Task GetSummary_OmitsMethodBodies()
     {
-        var result = await SummaryResources.GetSummary(ExampleFilePath);
+        var result = await SummaryResources.GetSummary(ExampleFilePath, CancellationToken.None);
         Assert.Contains("public int Calculate(int a, int b)\n        {}", result);
         Assert.DoesNotContain("throw new ArgumentException", result);
     }


### PR DESCRIPTION
## Summary
- allow callers to cancel SummaryResources.GetSummary
- test the new CancellationToken parameter

## Testing
- `dotnet format --no-restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68526a2e3fc48327922d99a4d6bee571