### PR TITLE
Update VS Code extension publisher

### DIFF
--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "Refactor MCP",
   "description": "Invoke RefactorMCP refactoring tools from VS Code",
   "version": "0.0.1",
-  "publisher": "your-name",
+  "publisher": "dave-hillier",
   "engines": {
     "vscode": "^1.89.0"
   },


### PR DESCRIPTION
## Summary
- set the correct publisher name in package.json

## Testing
- `npm install`
- `npm run compile`
- `dotnet format --no-restore`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity normal`


------
https://chatgpt.com/codex/tasks/task_e_68526a2a67488327b92a736f14c87c68