### PR TITLE
Fix build warnings

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/ReadonlyFieldRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/ReadonlyFieldRewriter.cs
@@ -16,7 +16,7 @@ internal class ReadonlyFieldRewriter : CSharpSyntaxRewriter
         _initializer = initializer;
     }
 
-    public override SyntaxNode VisitFieldDeclaration(FieldDeclarationSyntax node)
+    public override SyntaxNode? VisitFieldDeclaration(FieldDeclarationSyntax node)
     {
         var variable = node.Declaration.Variables.FirstOrDefault(v => v.Identifier.ValueText == _fieldName);
         if (variable == null)
@@ -31,9 +31,9 @@ internal class ReadonlyFieldRewriter : CSharpSyntaxRewriter
         return node.WithDeclaration(newDecl).WithModifiers(modifiers);
     }
 
-    public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+    public override SyntaxNode? VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
     {
-        var visited = (ConstructorDeclarationSyntax)base.VisitConstructorDeclaration(node);
+        var visited = (ConstructorDeclarationSyntax)base.VisitConstructorDeclaration(node)!;
         if (_initializer != null)
         {
             var assignment = SyntaxFactory.ExpressionStatement(

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/SetterToInitRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/SetterToInitRewriter.cs
@@ -13,7 +13,7 @@ internal class SetterToInitRewriter : CSharpSyntaxRewriter
         _propertyName = propertyName;
     }
 
-    public override SyntaxNode VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+    public override SyntaxNode? VisitPropertyDeclaration(PropertyDeclarationSyntax node)
     {
         if (node.Identifier.ValueText != _propertyName)
             return base.VisitPropertyDeclaration(node);
@@ -24,7 +24,7 @@ internal class SetterToInitRewriter : CSharpSyntaxRewriter
 
         var initAccessor = SyntaxFactory.AccessorDeclaration(SyntaxKind.InitAccessorDeclaration)
             .WithSemicolonToken(setter.SemicolonToken);
-        var newAccessorList = node.AccessorList.ReplaceNode(setter, initAccessor);
+        var newAccessorList = node.AccessorList!.ReplaceNode(setter, initAccessor);
         return node.WithAccessorList(newAccessorList);
     }
 }

--- a/RefactorMCP.ConsoleApp/Tools/CleanupUsings.cs
+++ b/RefactorMCP.ConsoleApp/Tools/CleanupUsings.cs
@@ -52,8 +52,8 @@ public static class CleanupUsingsTool
             .OfType<UsingDirectiveSyntax>()
             .ToList();
 
-        var newRoot = root.RemoveNodes(unused, SyntaxRemoveOptions.KeepNoTrivia);
-        var formatted = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
+        var newRoot = root!.RemoveNodes(unused, SyntaxRemoveOptions.KeepNoTrivia);
+        var formatted = Formatter.Format(newRoot!, RefactoringHelpers.SharedWorkspace);
         var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
         await File.WriteAllTextAsync(document.FilePath!, formatted.ToFullString(), encoding);
 

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
@@ -90,7 +90,7 @@ public static class ConvertToExtensionMethodTool
         }
         else
         {
-            var duplicateDoc = await RefactoringHelpers.FindClassInSolution(document.Project.Solution, extClassName, document.FilePath);
+            var duplicateDoc = await RefactoringHelpers.FindClassInSolution(document.Project.Solution, extClassName, document.FilePath!);
             if (duplicateDoc != null)
                 throw new McpException($"Error: Class {extClassName} already exists in {duplicateDoc.FilePath}");
             var extensionClassDecl = SyntaxFactory.ClassDeclaration(extClassName)

--- a/RefactorMCP.ConsoleApp/Tools/ExtractInterfaceTool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ExtractInterfaceTool.cs
@@ -24,7 +24,7 @@ public static class ExtractInterfaceTool
             if (document == null)
                 throw new McpException($"Error: File {filePath} not found in solution");
 
-            var root = (CompilationUnitSyntax)await document.GetSyntaxRootAsync();
+            var root = (CompilationUnitSyntax)(await document.GetSyntaxRootAsync())!;
             var classNode = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
                 .FirstOrDefault(c => c.Identifier.ValueText == className);
             if (classNode == null)

--- a/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/InlineMethod.cs
@@ -91,7 +91,7 @@ public static class InlineMethodTool
             .OfType<MethodDeclarationSyntax>()
             .First(m => m.Identifier.ValueText == methodName && m.ParameterList.Parameters.Count == 0);
         newRoot = newRoot.RemoveNode(updatedMethod, SyntaxRemoveOptions.KeepNoTrivia);
-        var formatted = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
+        var formatted = Formatter.Format(newRoot!, RefactoringHelpers.SharedWorkspace);
         return formatted.ToFullString();
     }
 

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -703,10 +703,10 @@ public static partial class MoveMethodsTool
         SyntaxNode targetRoot,
         string? namespaceName = null)
     {
-        var sourceCompilationUnit = (CompilationUnitSyntax)sourceRoot;
+        var sourceCompilationUnit = sourceRoot as CompilationUnitSyntax ?? throw new InvalidOperationException("Expected compilation unit");
         var sourceUsings = sourceCompilationUnit.Usings.ToList();
 
-        var targetCompilationUnit = (CompilationUnitSyntax)targetRoot;
+        var targetCompilationUnit = targetRoot as CompilationUnitSyntax ?? throw new InvalidOperationException("Expected compilation unit");
         var targetUsingNames = targetCompilationUnit.Usings
             .Select(u => u.Name.ToString())
             .ToHashSet();

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -181,7 +181,7 @@ public static partial class MoveMethodsTool
 
     private static SyntaxNode PropagateUsingsToTarget(StaticMethodMoveContext context, SyntaxNode targetRoot)
     {
-        var targetCompilationUnit = (CompilationUnitSyntax)targetRoot;
+        var targetCompilationUnit = targetRoot as CompilationUnitSyntax ?? throw new InvalidOperationException("Expected compilation unit");
         var targetUsingNames = targetCompilationUnit.Usings
             .Select(u => u.Name.ToString())
             .ToHashSet();
@@ -426,7 +426,7 @@ public static partial class MoveMethodsTool
             {
                 var (newText, _) = await RefactoringHelpers.ReadFileWithEncodingAsync(targetPath, cancellationToken);
                 var newRoot = await CSharpSyntaxTree.ParseText(newText).GetRootAsync(cancellationToken);
-                currentDocument = document.Project.Solution.WithDocumentSyntaxRoot(currentDocument.Id, newRoot).GetDocument(currentDocument.Id);
+                currentDocument = document.Project.Solution.WithDocumentSyntaxRoot(currentDocument.Id, newRoot).GetDocument(currentDocument.Id)!;
             }
             else
             {
@@ -449,10 +449,10 @@ public static partial class MoveMethodsTool
                     var targetSourceText = SourceText.From(targetText, targetEnc);
                     solution = solution.WithDocumentText(targetDocument.Id, targetSourceText);
                 }
-                currentDocument = solution.GetDocument(currentDocument.Id);
+                currentDocument = solution.GetDocument(currentDocument.Id)!;
             }
 
-            RefactoringHelpers.UpdateSolutionCache(currentDocument);
+            RefactoringHelpers.UpdateSolutionCache(currentDocument!);
             messages.Add(message);
         }
 

--- a/RefactorMCP.ConsoleApp/Tools/RenameSymbol.cs
+++ b/RefactorMCP.ConsoleApp/Tools/RenameSymbol.cs
@@ -31,7 +31,8 @@ public static class RenameSymbolTool
             if (symbol == null)
                 throw new McpException($"Error: Symbol '{oldName}' not found");
 
-            var renamed = await Renamer.RenameSymbolAsync(solution, symbol, newName, solution.Workspace.Options);
+            var options = new SymbolRenameOptions();
+            var renamed = await Renamer.RenameSymbolAsync(solution, symbol, options, newName, cancellationToken: default);
             var changes = renamed.GetChanges(solution);
             foreach (var projectChange in changes.GetProjectChanges())
             {


### PR DESCRIPTION
## Summary
- clean up nullability warnings in rewriters and tools
- use new `Renamer.RenameSymbolAsync` API
- enforce non-null usage across MoveMethods helpers

## Testing
- `dotnet format --no-restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68527371e98c8327b8b13a3762565d9c