### PR TITLE
Fix nested class return type for moved methods

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/NestedClassRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/NestedClassRewriter.cs
@@ -63,6 +63,8 @@ internal class NestedClassRewriter : CSharpSyntaxRewriter
         var parent = node.Parent;
         return (parent is VariableDeclarationSyntax v && v.Type == node)
             || (parent is ParameterSyntax p && p.Type == node)
+            || (parent is MethodDeclarationSyntax md && md.ReturnType == node)
+            || (parent is LocalFunctionStatementSyntax lf && lf.ReturnType == node)
             || (parent is ObjectCreationExpressionSyntax o && o.Type == node)
             || (parent is ForEachStatementSyntax f && f.Type == node)
             || (parent is ForEachVariableStatementSyntax fv && fv.Variable == node)

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -22,7 +22,7 @@ public static partial class MoveMethodsTool
     private static string GetKey(string filePath, string methodName) =>
         $"{Path.GetFullPath(filePath)}::{methodName}";
 
-    private static void EnsureNotAlreadyMoved(string filePath, string methodName)
+    internal static void EnsureNotAlreadyMoved(string filePath, string methodName)
     {
         if (_movedMethods.Contains(GetKey(filePath, methodName)))
         {


### PR DESCRIPTION
## Summary
- qualify nested classes used in method return types
- expose `EnsureNotAlreadyMoved` for reuse
- add regression test verifying nested type qualification

## Testing
- `dotnet format --no-restore`
- `dotnet build RefactorMCP.sln --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68529105cf4c8327aa277fda529f8ef5