### PR TITLE
Store tool replay logs in solution folder

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1038,8 +1038,8 @@ The returned text begins with `// summary://...` and shows each method body as `
 
 ## Playback Log
 
-After each CLI tool invocation, the parameters are appended to `tool-call-log.jsonl`. Replay them with:
+After each CLI tool invocation, the parameters are appended to `.refactor-mcp/tool-call-log.jsonl`. Replay them with:
 
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --cli play-log ./tool-call-log.jsonl
+dotnet run --project RefactorMCP.ConsoleApp -- --cli play-log ./.refactor-mcp/tool-call-log.jsonl
 ```

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -115,7 +115,8 @@ static RootCommand BuildCliRoot()
                 }
             }
 
-            ToolCallLogger.Log(method.Name, rawValues);
+            if (!string.Equals(method.Name, nameof(LoadSolutionTool.LoadSolution)))
+                ToolCallLogger.Log(method.Name, rawValues);
 
             var result = method.Invoke(null, values);
             if (result is Task<string> taskStr)
@@ -231,7 +232,8 @@ static async Task RunJsonMode(string[] args)
         }
     }
 
-    ToolCallLogger.Log(method.Name, rawValues);
+    if (!string.Equals(method.Name, nameof(LoadSolutionTool.LoadSolution)))
+        ToolCallLogger.Log(method.Name, rawValues);
 
     try
     {

--- a/RefactorMCP.ConsoleApp/ToolCallLogger.cs
+++ b/RefactorMCP.ConsoleApp/ToolCallLogger.cs
@@ -9,10 +9,20 @@ using ModelContextProtocol.Server;
 
 internal static class ToolCallLogger
 {
-    private const string DefaultLogFile = "tool-call-log.jsonl";
+    private static string _logFile = "tool-call-log.jsonl";
+
+    public static string DefaultLogFile => _logFile;
+
+    public static void SetLogDirectory(string directory)
+    {
+        _logFile = Path.Combine(directory, "tool-call-log.jsonl");
+    }
 
     public static void Log(string toolName, Dictionary<string, string?> parameters, string? logFile = null)
     {
+        var file = logFile ?? DefaultLogFile;
+        Directory.CreateDirectory(Path.GetDirectoryName(file)!);
+
         var record = new ToolCallRecord
         {
             Tool = toolName,
@@ -20,7 +30,7 @@ internal static class ToolCallLogger
             Timestamp = DateTime.UtcNow
         };
         var json = JsonSerializer.Serialize(record);
-        File.AppendAllText(logFile ?? DefaultLogFile, json + Environment.NewLine);
+        File.AppendAllText(file, json + Environment.NewLine);
     }
 
     public static async Task Playback(string logFilePath)

--- a/RefactorMCP.ConsoleApp/Tools/LoadSolution.cs
+++ b/RefactorMCP.ConsoleApp/Tools/LoadSolution.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.Extensions.Caching.Memory;
 using System.ComponentModel;
 using System.IO;
+using System.Collections.Generic;
 using System.Threading;
 
 
@@ -23,6 +24,11 @@ public static class LoadSolutionTool
             {
                 throw new McpException($"Error: Solution file not found at {solutionPath}");
             }
+
+            var logDir = Path.Combine(Path.GetDirectoryName(solutionPath)!, ".refactor-mcp");
+            ToolCallLogger.SetLogDirectory(logDir);
+            ToolCallLogger.Log(nameof(LoadSolution), new Dictionary<string, string?> { ["solutionPath"] = solutionPath });
+
             Directory.SetCurrentDirectory(Path.GetDirectoryName(solutionPath)!);
             progress?.Report($"Loading {solutionPath}");
 


### PR DESCRIPTION
## Summary
- set log folder on solution load
- don't log LoadSolution twice
- document new log path
- ensure log directory exists when logging

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6852a03e067483278e4d881dc13b1dcb