### PR TITLE
Fix interface conversion visibility

### DIFF
--- a/RefactorMCP.Tests/Roslyn/ConvertTests.cs
+++ b/RefactorMCP.Tests/Roslyn/ConvertTests.cs
@@ -138,4 +138,32 @@ public static class StringProcessorExtensions
         var output = ConvertToStaticWithParametersTool.ConvertToStaticWithParametersInSource(input, "MultiplyValue");
         Assert.Equal(expected, output.Trim());
     }
+
+    [Fact]
+    public void ConvertToStaticWithInstanceInSource_HandlesExplicitInterface()
+    {
+        var input = @"public class cResRoom : IRoomPick
+{
+    object IRoomPick.GetResProfile(int id) => GetResProfile(id);
+    public object GetResProfile(int id) => null;
+}
+
+public interface IRoomPick
+{
+    object GetResProfile(int id);
+}";
+        var expected = @"public class cResRoom : IRoomPick
+{
+    public static object GetResProfile(cResRoom room, int id) => room.GetResProfile(id);
+    public object GetResProfile(int id) => null;
+}
+
+public interface IRoomPick
+{
+    object GetResProfile(int id);
+}";
+        var output = ConvertToStaticWithInstanceTool.ConvertToStaticWithInstanceInSource(input, "GetResProfile", "room");
+        Assert.Equal(expected, output.Trim());
+        Assert.DoesNotContain("IRoomPick.", output);
+    }
 }


### PR DESCRIPTION
## Summary
- ensure StaticConversionRewriter drops explicit interface specifiers and keeps accessibility
- test conversion on explicit interface methods

## Testing
- `dotnet format --no-restore`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6852e9586e3c8327b4e8d6c4c8682611