### PR TITLE
Fix JSON mode logging persistence

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1038,8 +1038,14 @@ The returned text begins with `// summary://...` and shows each method body as `
 
 ## Playback Log
 
-After each CLI tool invocation, the parameters are appended to `.refactor-mcp/tool-call-log.jsonl`. Replay them with:
+After each tool invocation in JSON mode (after running `load-solution`), the parameters are appended to `.refactor-mcp/tool-call-log.jsonl`. Replay them with:
 
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --cli play-log ./.refactor-mcp/tool-call-log.jsonl
+```
+
+### JSON Logging Example
+Invoking tools in JSON mode is also recorded once `load-solution` has been run:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --json cleanup-usings '{"solutionPath":"./RefactorMCP.sln","documentPath":"./RefactorMCP.Tests/ExampleCode.cs"}'
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The project includes the following refactorings and helpers:
 
 Metrics and code summaries are also available via the `metrics://` and `summary://` resource schemes. After loading a solution, metrics are cached under `.refactor-mcp/metrics/` mirroring the project structure so they can be served directly from disk.
 
+`load-solution` sets the `REFACTOR_MCP_LOG_DIR` environment variable so subsequent JSON invocations append their parameters to `.refactor-mcp/tool-call-log.jsonl`. Use `play-log` to replay these calls.
+
 ## Usage
 
 Run the console application directly or start it as an MCP server to integrate with other clients:

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -115,9 +115,6 @@ static RootCommand BuildCliRoot()
                 }
             }
 
-            if (!string.Equals(method.Name, nameof(LoadSolutionTool.LoadSolution)))
-                ToolCallLogger.Log(method.Name, rawValues);
-
             var result = method.Invoke(null, values);
             if (result is Task<string> taskStr)
                 Console.WriteLine(await taskStr);
@@ -174,6 +171,8 @@ static async Task RunJsonMode(string[] args)
         Console.WriteLine("Usage: --json <ToolName> '{\"param\":\"value\"}'");
         return;
     }
+
+    ToolCallLogger.RestoreFromEnvironment();
 
     var toolName = args[1];
     var json = string.Join(" ", args.Skip(2));

--- a/RefactorMCP.ConsoleApp/ToolCallLogger.cs
+++ b/RefactorMCP.ConsoleApp/ToolCallLogger.cs
@@ -9,6 +9,7 @@ using ModelContextProtocol.Server;
 
 internal static class ToolCallLogger
 {
+    private const string LogDirEnvVar = "REFACTOR_MCP_LOG_DIR";
     private static string _logFile = "tool-call-log.jsonl";
 
     public static string DefaultLogFile => _logFile;
@@ -16,6 +17,14 @@ internal static class ToolCallLogger
     public static void SetLogDirectory(string directory)
     {
         _logFile = Path.Combine(directory, "tool-call-log.jsonl");
+        Environment.SetEnvironmentVariable(LogDirEnvVar, directory);
+    }
+
+    public static void RestoreFromEnvironment()
+    {
+        var dir = Environment.GetEnvironmentVariable(LogDirEnvVar);
+        if (!string.IsNullOrEmpty(dir))
+            SetLogDirectory(dir);
     }
 
     public static void Log(string toolName, Dictionary<string, string?> parameters, string? logFile = null)


### PR DESCRIPTION
## Summary
- use `REFACTOR_MCP_LOG_DIR` only for JSON logging
- clarify logging behaviour in docs

## Testing
- `dotnet format --no-restore`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68530f6482388327a7b191098b647bea