### PR TITLE
Handle protected override methods in move tool

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -344,7 +344,7 @@ Running `move-static-method` again on this wrapper will now fail. Use `inline-me
 
 ## 10. Move Instance Method
 
-**Purpose**: Move an instance method to another class while leaving a wrapper behind.
+**Purpose**: Move an instance method to another class while leaving a wrapper behind. Protected override methods cannot be moved and will result in an error.
 
 ### Example
 **Before** (in `ExampleCode.cs` line 69):

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The project includes the following refactorings and helpers:
 - LoadSolution / UnloadSolution
 - MakeFieldReadonly
 - MoveClassToFile
-- MoveMethods
+- MoveMethods (protected override methods cannot be moved)
 - MoveMultipleMethods
 - RenameSymbol
 - SafeDelete

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -41,6 +41,9 @@ public static partial class MoveMethodsTool
         string targetClass)
     {
         var method = FindStaticMethod(sourceRoot, methodName);
+        if (method.Modifiers.Any(SyntaxKind.ProtectedKeyword) &&
+            method.Modifiers.Any(SyntaxKind.OverrideKeyword))
+            throw new McpException($"Error: Cannot move protected override method '{methodName}'");
         var sourceClass = FindSourceClassForMethod(sourceRoot, method);
         var methodNames = GetMethodNames(sourceClass);
         var collector = new CalledMethodCollector(methodNames);
@@ -257,6 +260,9 @@ public static partial class MoveMethodsTool
     {
         var originClass = FindSourceClass(sourceRoot, sourceClass);
         var method = FindMethodInClass(originClass, methodName);
+        if (method.Modifiers.Any(SyntaxKind.ProtectedKeyword) &&
+            method.Modifiers.Any(SyntaxKind.OverrideKeyword))
+            throw new McpException($"Error: Cannot move protected override method '{methodName}'");
 
         var nestedClassNames = GetNestedClassNames(originClass);
 

--- a/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
@@ -55,6 +55,26 @@ public class MoveInstanceMethodTests : TestBase
     }
 
     [Fact]
+    public async Task MoveInstanceMethod_FailsWhenMethodIsProtectedOverride()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "MoveInstanceProtectedOverride.cs"));
+        await TestUtilities.CreateTestFile(testFile, @"public class Base { protected virtual void Do(){} } public class A : Base { protected override void Do(){} } public class B { }");
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+
+        await Assert.ThrowsAsync<McpException>(() =>
+            MoveMethodsTool.MoveInstanceMethod(
+                SolutionPath,
+                testFile,
+                "A",
+                "Do",
+                "B",
+                null,
+                null,
+                CancellationToken.None));
+    }
+
+    [Fact]
     public async Task MoveInstanceMethod_FailsOnSecondMove()
     {
         UnloadSolutionTool.ClearSolutionCache();


### PR DESCRIPTION
## Summary
- disallow moving protected override methods in MoveMethods
- document that protected override methods can't be moved
- update example documentation
- adjust unit test to check protected override scenario

## Testing
- `dotnet format --no-restore`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6853fdf3ad108327ac4d5d771baf0633