### PR TITLE
Fix override move access level

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -515,7 +515,15 @@ public static partial class MoveMethodsTool
         var mods = method.Modifiers.Where(m => !m.IsKind(SyntaxKind.PrivateKeyword) &&
                                               !m.IsKind(SyntaxKind.ProtectedKeyword));
 
-        return method.WithModifiers(SyntaxFactory.TokenList(mods).Add(SyntaxFactory.Token(SyntaxKind.InternalKeyword)));
+        if (method.Modifiers.Any(SyntaxKind.ProtectedKeyword))
+        {
+            // Keep the protected modifier for overrides to avoid reducing
+            // accessibility but add internal for cross-class access
+            mods = mods.Append(SyntaxFactory.Token(SyntaxKind.ProtectedKeyword));
+        }
+
+        return method.WithModifiers(SyntaxFactory.TokenList(mods)
+            .Add(SyntaxFactory.Token(SyntaxKind.InternalKeyword)));
     }
 
     private static MethodDeclarationSyntax CreateStubMethod(

--- a/RefactorMCP.Tests/Tools/MoveProtectedOverrideDependencyTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveProtectedOverrideDependencyTests.cs
@@ -1,0 +1,30 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class MoveProtectedOverrideDependencyTests
+{
+    [Fact]
+    public void MoveMethod_UpdatesProtectedOverrideDependency()
+    {
+        var source = @"public class Base { protected virtual void DoIt() {} } public class Derived : Base { protected override void DoIt() {} public void Another() { DoIt(); } } public class Target { }";
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+
+        var moveResult = MoveMethodsTool.MoveInstanceMethodAst(root, "Derived", "Another", "Target", "", "");
+        var updatedRoot = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, "Target", moveResult.MovedMethod, moveResult.Namespace);
+        var formattedRoot = Formatter.Format(updatedRoot, new AdhocWorkspace());
+
+        var derivedClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>().First(c => c.Identifier.ValueText == "Derived");
+        var method = derivedClass.Members.OfType<MethodDeclarationSyntax>().First(m => m.Identifier.ValueText == "DoIt");
+        var mods = method.Modifiers.ToFullString();
+
+        Assert.Contains("protected", mods);
+        Assert.Contains("internal", mods);
+        Assert.Contains("override", mods);
+    }
+}


### PR DESCRIPTION
## Summary
- update method access handling when moving
- test `MoveMethod_UpdatesProtectedOverrideDependency`

## Testing
- `dotnet format`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6855260bf92483278f86bd95b0ae3bba