### PR TITLE
Fix object initializer rewriting

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberRewriter.cs
@@ -35,6 +35,15 @@ internal class InstanceMemberRewriter : CSharpSyntaxRewriter
         if (parent is ParameterSyntax || parent is TypeSyntax)
             return base.VisitIdentifierName(node);
 
+        if (parent is AssignmentExpressionSyntax assign &&
+            assign.Left == node &&
+            assign.Parent is InitializerExpressionSyntax init &&
+            init.IsKind(SyntaxKind.ObjectInitializerExpression))
+        {
+            // Property names in object initializers should not be qualified
+            return base.VisitIdentifierName(node);
+        }
+
         if (_knownInstanceMembers.Contains(node.Identifier.ValueText))
         {
             if (parent is MemberAccessExpressionSyntax memberAccess && memberAccess.Expression == node)

--- a/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberRewriterTests.cs
@@ -26,4 +26,19 @@ public partial class RoslynTransformationTests
         Assert.Contains("inst.Value", result);
         Assert.DoesNotContain("this.Value", result);
     }
+
+    [Fact]
+    public void InstanceMemberRewriter_IgnoresObjectInitializerPropertyNames()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration(@"void Test(){ var h = new RequestHeaders{ Username = strCurrentOperatorCode, SiteId = ConnectedSiteID, GroupId = ConnectedGroupID }; }") as MethodDeclarationSyntax;
+        var members = new HashSet<string> { "strCurrentOperatorCode", "ConnectedSiteID", "ConnectedGroupID" };
+        var rewriter = new InstanceMemberRewriter("inst", members);
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("Username = inst.strCurrentOperatorCode", result);
+        Assert.Contains("SiteId = inst.ConnectedSiteID", result);
+        Assert.Contains("GroupId = inst.ConnectedGroupID", result);
+        Assert.DoesNotContain("inst.Username", result);
+        Assert.DoesNotContain("inst.SiteId", result);
+        Assert.DoesNotContain("inst.GroupId", result);
+    }
 }


### PR DESCRIPTION
## Summary
- avoid prefixing property names in object initializers when converting instance references
- add test to guard against regression

## Testing
- `dotnet format --no-restore`
- `dotnet test -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_68554254a2688327ad335382e96f26dd