### PR TITLE
Fix field argument naming when moving methods

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -352,7 +352,7 @@ public static partial class MoveMethodsTool
             isVoid,
             isAsync,
             typeParameters,
-            paramMap.Values);
+            paramMap.Keys);
 
         var dependencyUpdates = new Dictionary<string, MethodDeclarationSyntax>();
         foreach (var m in originClass.Members.OfType<MethodDeclarationSyntax>())

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -208,7 +208,7 @@ public class TargetClass
 
             Assert.Contains("public int GetValue(int value)", formatted);
             Assert.Contains("return value + 2", formatted);
-            Assert.Contains("return _target.GetValue(value)", formatted);
+            Assert.Contains("return _target.GetValue(_value)", formatted);
         }
 
         [Fact]
@@ -239,7 +239,7 @@ public class TargetClass
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("public int GetValue(int value, int n = 5)", formatted);
-            Assert.Contains("_target.GetValue(value, n)", formatted);
+            Assert.Contains("_target.GetValue(_value, n)", formatted);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- ensure stub methods keep underscore when passing private fields
- update MoveMethods tests

## Testing
- `dotnet format --no-restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_68555b6c64088327b4b524ce88f04460