### PR TITLE
Reset move history on LoadSolution

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -666,7 +666,7 @@ public class CleanupSample
 
 ## 6. Load Solution (Utility Command)
 
-**Purpose**: Clear previous caches and load a solution file before performing refactorings.
+**Purpose**: Clear previous caches, reset move history, and load a solution file before performing refactorings.
 
 ### Example
 **Command**:
@@ -714,7 +714,7 @@ Cleared all cached solutions
 
 ## Reset Move History (Utility Command)
 
-**Purpose**: Allow previously moved methods to be moved again in the same session.
+**Purpose**: Allow previously moved methods to be moved again in the same session. Loading a solution automatically clears this history.
 
 ### Example
 **Command**:

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The project includes the following refactorings and helpers:
 - IntroduceField
 - IntroduceParameter
 - IntroduceVariable
-- LoadSolution (clears caches) / UnloadSolution
+- LoadSolution (clears caches and move history) / UnloadSolution
 - MakeFieldReadonly
 - MoveClassToFile
 - MoveMethods (protected override methods cannot be moved)

--- a/RefactorMCP.ConsoleApp/Tools/LoadSolution.cs
+++ b/RefactorMCP.ConsoleApp/Tools/LoadSolution.cs
@@ -26,6 +26,7 @@ public static class LoadSolutionTool
             }
 
             RefactoringHelpers.ClearAllCaches();
+            MoveMethodsTool.ResetMoveHistory();
 
             var logDir = Path.Combine(Path.GetDirectoryName(solutionPath)!, ".refactor-mcp");
             ToolCallLogger.SetLogDirectory(logDir);

--- a/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
@@ -135,6 +135,34 @@ public class MoveInstanceMethodTests : TestBase
     }
 
     [Fact]
+    public async Task LoadSolution_ResetsMoveHistory()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "LoadSolutionReset.cs"));
+        await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public class B { }");
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+
+        var result1 = await MoveMethodsTool.MoveInstanceMethod(
+            SolutionPath,
+            testFile,
+            "A",
+            "Do",
+            "B");
+        Assert.Contains("Successfully moved", result1);
+
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+
+        var result2 = await MoveMethodsTool.MoveInstanceMethod(
+            SolutionPath,
+            testFile,
+            "A",
+            "Do",
+            "B");
+
+        Assert.Contains("Successfully moved", result2);
+    }
+
+    [Fact]
     public async Task MoveInstanceMethod_FailureDoesNotRecordHistory()
     {
         UnloadSolutionTool.ClearSolutionCache();


### PR DESCRIPTION
## Summary
- clear move history whenever a solution loads
- document automatic clearing in README and examples
- add regression test showing `LoadSolution` resets move history

## Testing
- `dotnet format --no-restore`
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68556c10ca4c8327af63c84da2d1c6c3