### PR TITLE
Fix session log file naming

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1089,10 +1089,10 @@ The returned text begins with `// summary://...` and shows each method body as `
 
 ## Playback Log
 
-After each tool invocation in JSON mode (after running `load-solution`), the parameters are appended to `.refactor-mcp/tool-call-log.jsonl`. Replay them with:
+After each tool invocation in JSON mode (after running `load-solution`), the parameters are appended to a session log such as `.refactor-mcp/tool-call-log-YYYYMMDDHHMMSS.jsonl`. Replay them with:
 
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --cli play-log ./.refactor-mcp/tool-call-log.jsonl
+dotnet run --project RefactorMCP.ConsoleApp -- --cli play-log ./.refactor-mcp/tool-call-log-YYYYMMDDHHMMSS.jsonl
 ```
 
 ### JSON Logging Example

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The project includes the following refactorings and helpers:
 
 Metrics and code summaries are also available via the `metrics://` and `summary://` resource schemes. After loading a solution, metrics are cached under `.refactor-mcp/metrics/` mirroring the project structure so they can be served directly from disk.
 
-`load-solution` sets the `REFACTOR_MCP_LOG_DIR` environment variable so subsequent JSON invocations append their parameters to `.refactor-mcp/tool-call-log.jsonl`. Use `play-log` to replay these calls.
+`load-solution` sets the `REFACTOR_MCP_LOG_FILE` environment variable. Each session writes to a timestamped file like `.refactor-mcp/tool-call-log-YYYYMMDDHHMMSS.jsonl`; subsequent JSON invocations append to this file. Use `play-log` to replay these calls.
 
 ## Usage
 

--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -127,6 +127,9 @@ static RootCommand BuildCliRoot()
             {
                 Console.WriteLine(result.ToString());
             }
+
+            if (!string.Equals(method.Name, nameof(LoadSolutionTool.LoadSolution)))
+                ToolCallLogger.Log(method.Name, rawValues);
         });
 
         root.AddCommand(command);
@@ -231,9 +234,6 @@ static async Task RunJsonMode(string[] args)
         }
     }
 
-    if (!string.Equals(method.Name, nameof(LoadSolutionTool.LoadSolution)))
-        ToolCallLogger.Log(method.Name, rawValues);
-
     try
     {
         var result = method.Invoke(null, invokeArgs);
@@ -254,6 +254,11 @@ static async Task RunJsonMode(string[] args)
     catch (Exception ex)
     {
         Console.WriteLine($"Error executing tool: {ex.Message}");
+    }
+    finally
+    {
+        if (!string.Equals(method.Name, nameof(LoadSolutionTool.LoadSolution)))
+            ToolCallLogger.Log(method.Name, rawValues);
     }
 }
 

--- a/RefactorMCP.ConsoleApp/ToolCallLogger.cs
+++ b/RefactorMCP.ConsoleApp/ToolCallLogger.cs
@@ -9,22 +9,24 @@ using ModelContextProtocol.Server;
 
 internal static class ToolCallLogger
 {
-    private const string LogDirEnvVar = "REFACTOR_MCP_LOG_DIR";
+    private const string LogFileEnvVar = "REFACTOR_MCP_LOG_FILE";
     private static string _logFile = "tool-call-log.jsonl";
 
     public static string DefaultLogFile => _logFile;
 
     public static void SetLogDirectory(string directory)
     {
-        _logFile = Path.Combine(directory, "tool-call-log.jsonl");
-        Environment.SetEnvironmentVariable(LogDirEnvVar, directory);
+        Directory.CreateDirectory(directory);
+        var timestamp = DateTime.UtcNow.ToString("yyyyMMddHHmmss");
+        _logFile = Path.Combine(directory, $"tool-call-log-{timestamp}.jsonl");
+        Environment.SetEnvironmentVariable(LogFileEnvVar, _logFile);
     }
 
     public static void RestoreFromEnvironment()
     {
-        var dir = Environment.GetEnvironmentVariable(LogDirEnvVar);
-        if (!string.IsNullOrEmpty(dir))
-            SetLogDirectory(dir);
+        var file = Environment.GetEnvironmentVariable(LogFileEnvVar);
+        if (!string.IsNullOrEmpty(file))
+            _logFile = file;
     }
 
     public static void Log(string toolName, Dictionary<string, string?> parameters, string? logFile = null)


### PR DESCRIPTION
## Summary
- generate a timestamped JSONL log file on session start
- update README and examples for new `REFACTOR_MCP_LOG_FILE`
- log tool calls after invocation in CLI and JSON modes

## Testing
- `dotnet format --verify-no-changes --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68556c9f99dc832793134df35a4fa42e