### PR TITLE
Fix duplicate handling in MoveMultipleMethods

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -89,6 +89,14 @@ public static partial class MoveMultipleMethodsTool
             if (methodNames.Length == 0)
                 throw new McpException("Error: No method names provided");
 
+            var dupes = methodNames
+                .GroupBy(m => m)
+                .Where(g => g.Count() > 1)
+                .Select(g => g.Key)
+                .ToList();
+            if (dupes.Count > 0)
+                return $"Error: Duplicate method names are not supported: {string.Join(", ", dupes)}";
+
             // Check upfront if any methods have already been moved
             foreach (var methodName in methodNames)
                 MoveMethodsTool.EnsureNotAlreadyMoved(filePath, methodName);

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsDuplicateTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsDuplicateTests.cs
@@ -1,0 +1,33 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class MoveMultipleMethodsDuplicateTests : TestBase
+{
+    [Fact]
+    public async Task MoveMultipleMethods_DuplicateNames_Fails()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.Combine(TestOutputPath, "DupMethods.cs");
+        var code = @"public class Source { public void A() { } } public class Target { }";
+        await TestUtilities.CreateTestFile(testFile, code);
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);
+        var project = solution.Projects.First();
+        RefactoringHelpers.AddDocumentToProject(project, testFile);
+
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+            SolutionPath,
+            testFile,
+            "Source",
+            new[] { "A", "A" },
+            "Target");
+
+        Assert.Contains("Duplicate method names", result);
+    }
+}


### PR DESCRIPTION
## Summary
- prevent duplicate method names in MoveMultipleMethods
- add regression test for duplicate method names

## Testing
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_68556ee67fe4832783905aaf83dc3890