### PR TITLE
Fix interface property qualification when moving methods

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -256,7 +256,8 @@ public static partial class MoveMethodsTool
         string methodName,
         string targetClass,
         string accessMemberName,
-        string accessMemberType)
+        string accessMemberType,
+        SemanticModel? semanticModel = null)
     {
         var originClass = FindSourceClass(sourceRoot, sourceClass);
         var method = FindMethodInClass(originClass, methodName);
@@ -266,7 +267,7 @@ public static partial class MoveMethodsTool
 
         var nestedClassNames = GetNestedClassNames(originClass);
 
-        var instanceMembers = GetInstanceMemberNames(originClass);
+        var instanceMembers = GetInstanceMemberNames(originClass, semanticModel);
         var methodNames = GetMethodNames(originClass);
         var privateFieldInfos = GetPrivateFieldInfos(originClass);
         var usedPrivateFields = GetUsedPrivateFields(method, new HashSet<string>(privateFieldInfos.Keys));

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
@@ -103,7 +103,8 @@ public static partial class MoveMethodsTool
         string accessMemberType,
         string? targetFilePath = null,
         IProgress<string>? progress = null,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        SemanticModel? semanticModel = null)
     {
         EnsureNotAlreadyMoved(filePath, methodName);
         ValidateFileExists(filePath);
@@ -115,7 +116,7 @@ public static partial class MoveMethodsTool
         var sourceRoot = (await CSharpSyntaxTree.ParseText(sourceText).GetRootAsync(cancellationToken));
 
         var moveResult = MoveInstanceMethodAst(
-            sourceRoot, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
+            sourceRoot, sourceClass, methodName, targetClass, accessMemberName, accessMemberType, semanticModel);
 
         if (sameFile)
         {

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
@@ -88,8 +88,41 @@ public static partial class MoveMethodsTool
         };
     }
 
-    private static HashSet<string> GetInstanceMemberNames(ClassDeclarationSyntax originClass)
+    private static HashSet<string> GetInstanceMemberNames(
+        ClassDeclarationSyntax originClass,
+        SemanticModel? model = null)
     {
+        if (model != null)
+        {
+            var symbol = model.GetDeclaredSymbol(originClass) as INamedTypeSymbol;
+            if (symbol != null)
+            {
+                var names = new HashSet<string>();
+                var visitedTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+                var stack = new Stack<INamedTypeSymbol>();
+                stack.Push(symbol);
+                while (stack.Count > 0)
+                {
+                    var current = stack.Pop();
+                    if (!visitedTypes.Add(current))
+                        continue;
+
+                    foreach (var member in current.GetMembers())
+                    {
+                        if (!member.IsStatic && member is IFieldSymbol or IPropertySymbol)
+                            names.Add(member.Name);
+                    }
+
+                    if (current.BaseType != null)
+                        stack.Push(current.BaseType);
+                    foreach (var iface in current.Interfaces)
+                        stack.Push(iface);
+                }
+
+                return names;
+            }
+        }
+
         var knownMembers = new HashSet<string>();
         var root = originClass.SyntaxTree.GetRoot();
         var queue = new Queue<MemberDeclarationSyntax>();

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -415,6 +415,7 @@ public static partial class MoveMethodsTool
             var targetPath = targetFilePath ?? currentDocument.FilePath!;
             var sameFile = targetPath == currentDocument.FilePath;
 
+            var semanticModel = await currentDocument.GetSemanticModelAsync(cancellationToken);
             var message = await MoveInstanceMethodInFile(
                 currentDocument.FilePath!,
                 sourceClassName,
@@ -424,7 +425,8 @@ public static partial class MoveMethodsTool
                 accessMemberType,
                 targetFilePath,
                 progress,
-                cancellationToken);
+                cancellationToken,
+                semanticModel);
 
             if (sameFile)
             {

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -33,6 +33,7 @@ public static partial class MoveMultipleMethodsTool
         }
         else
         {
+            var model = await document.GetSemanticModelAsync();
             message = await MoveMethodsTool.MoveInstanceMethodInFile(
                 document.FilePath!,
                 sourceClass,
@@ -40,7 +41,10 @@ public static partial class MoveMultipleMethodsTool
                 targetClass,
                 accessMember,
                 accessMemberType,
-                targetPath);
+                targetPath,
+                null,
+                default,
+                model);
         }
 
         var (newText, _) = await RefactoringHelpers.ReadFileWithEncodingAsync(document.FilePath!);


### PR DESCRIPTION
## Summary
- detect instance members via semantic model when available
- wire semantic model through file and solution helpers
- add failing cross-file test for interface property

## Testing
- `dotnet test --filter "MoveInstanceMethod_QualifiesInheritedInterfaceProperty" -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6855722e8ce883278b7936cd7942d272