### PR TITLE
Add nested enum move test

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
@@ -252,10 +252,15 @@ public static partial class MoveMethodsTool
 
     private static HashSet<string> GetNestedClassNames(ClassDeclarationSyntax originClass)
     {
-        return originClass.Members
+        var names = originClass.Members
             .OfType<ClassDeclarationSyntax>()
             .Select(c => c.Identifier.ValueText)
             .ToHashSet();
+
+        foreach (var e in originClass.Members.OfType<EnumDeclarationSyntax>())
+            names.Add(e.Identifier.ValueText);
+
+        return names;
     }
 
     private static Dictionary<string, TypeSyntax> GetPrivateFieldInfos(ClassDeclarationSyntax originClass)

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -434,6 +434,74 @@ class B { }";
         }
 
         [Fact]
+        public void MoveInstanceMethod_QualifiesPublicNestedClass()
+        {
+            var source = @"public class A
+{
+    public class Nested { }
+
+    public Nested GetNested()
+    {
+        return new Nested();
+    }
+}
+
+public class B { }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var root = tree.GetRoot();
+
+            var result = MoveMethodsTool.MoveInstanceMethodAst(
+                root,
+                "A",
+                "GetNested",
+                "B",
+                "_b",
+                "field");
+
+            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "B", result.MovedMethod, result.Namespace);
+            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+
+            Assert.Contains("A.Nested GetNested()", formatted);
+            Assert.Contains("new A.Nested()", formatted);
+            Assert.Contains("return _b.GetNested()", formatted);
+        }
+
+        [Fact]
+        public void MoveInstanceMethod_QualifiesPublicNestedEnum()
+        {
+            var source = @"public class A
+{
+    public enum Kind { A, B }
+
+    public Kind GetKind()
+    {
+        return Kind.A;
+    }
+}
+
+public class B { }";
+
+            var tree = CSharpSyntaxTree.ParseText(source);
+            var root = tree.GetRoot();
+
+            var result = MoveMethodsTool.MoveInstanceMethodAst(
+                root,
+                "A",
+                "GetKind",
+                "B",
+                "_b",
+                "field");
+
+            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "B", result.MovedMethod, result.Namespace);
+            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+
+            Assert.Contains("A.Kind GetKind()", formatted);
+            Assert.Contains("A.Kind.A", formatted);
+            Assert.Contains("return _b.GetKind()", formatted);
+        }
+
+        [Fact]
         public void MoveInstanceMethod_UpdatesPrivateDependencyAccess()
         {
             var source = @"public class A


### PR DESCRIPTION
## Summary
- add regression test for nested enum references when moving instance methods
- qualify nested enum names during move

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685589b8bcd4832790b49ac685609b78