### PR TITLE
Add nested class move regression test

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Helpers.cs
@@ -252,10 +252,17 @@ public static partial class MoveMethodsTool
 
     private static HashSet<string> GetNestedClassNames(ClassDeclarationSyntax originClass)
     {
-        return originClass.Members
+        var names = originClass.Members
             .OfType<ClassDeclarationSyntax>()
             .Select(c => c.Identifier.ValueText)
             .ToHashSet();
+
+        foreach (var en in originClass.Members.OfType<EnumDeclarationSyntax>())
+        {
+            names.Add(en.Identifier.ValueText);
+        }
+
+        return names;
     }
 
     private static Dictionary<string, TypeSyntax> GetPrivateFieldInfos(ClassDeclarationSyntax originClass)


### PR DESCRIPTION
## Summary
- add regression test for nested enum references when moving methods
- support qualifying nested enums

## Testing
- `dotnet test --no-build --verbosity minimal`
- `dotnet format --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_685589b8bcd4832790b49ac685609b78