### PR TITLE
Handle base property access in move rewriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The project includes the following refactorings and helpers:
 - MakeFieldReadonly
 - MoveClassToFile
 - MoveMethods (protected override methods cannot be moved)
-- MoveMethods now prefixes inherited members with `@this` when moving
+- MoveMethods now prefixes inherited members with `@this` when moving and handles base-qualified property access
 - MoveMultipleMethods
 - RenameSymbol
 - SafeDelete

--- a/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/InstanceMemberRewriterTests.cs
@@ -41,4 +41,24 @@ public partial class RoslynTransformationTests
         Assert.DoesNotContain("inst.SiteId", result);
         Assert.DoesNotContain("inst.GroupId", result);
     }
+
+    [Fact]
+    public void InstanceMemberRewriter_QualifiesBasePropertyAccess()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test(){ var n = base.Value; }") as MethodDeclarationSyntax;
+        var rewriter = new InstanceMemberRewriter("inst", new HashSet<string> { "Value" });
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("inst.Value", result);
+        Assert.DoesNotContain("base.Value", result);
+    }
+
+    [Fact]
+    public void InstanceMemberRewriter_IgnoresPropertyPatternNames()
+    {
+        var method = SyntaxFactory.ParseMemberDeclaration("void Test(){ if(this is { Value: > 0 }) { } }") as MethodDeclarationSyntax;
+        var rewriter = new InstanceMemberRewriter("inst", new HashSet<string> { "Value" });
+        var result = rewriter.Visit(method!)!.NormalizeWhitespace().ToFullString();
+        Assert.Contains("this is { Value: > 0 }", result);
+        Assert.DoesNotContain("inst.Value", result);
+    }
 }


### PR DESCRIPTION
## Summary
- improve InstanceMemberRewriter to rewrite `base` property access and ignore property patterns
- add tests for base-qualified property and property pattern handling
- update docs for MoveMethods bullet

## Testing
- `dotnet format --no-restore --verify-no-changes`
- `dotnet test RefactorMCP.sln -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_6855a904fa088327901abf51c3fc366d