### PR TITLE
Refactor MoveMethods helpers with walkers

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberNameWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberNameWalker.cs
@@ -1,0 +1,21 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class InstanceMemberNameWalker : CSharpSyntaxWalker
+{
+    public HashSet<string> Names { get; } = new();
+
+    public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+    {
+        foreach (var variable in node.Declaration.Variables)
+            Names.Add(variable.Identifier.ValueText);
+        base.VisitFieldDeclaration(node);
+    }
+
+    public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
+    {
+        Names.Add(node.Identifier.ValueText);
+        base.VisitPropertyDeclaration(node);
+    }
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/InterfaceCollectorWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/InterfaceCollectorWalker.cs
@@ -1,0 +1,16 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class InterfaceCollectorWalker : CSharpSyntaxWalker
+{
+    public Dictionary<string, InterfaceDeclarationSyntax> Interfaces { get; } = new();
+
+    public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
+    {
+        var name = node.Identifier.ValueText;
+        if (!Interfaces.ContainsKey(name))
+            Interfaces[name] = node;
+        base.VisitInterfaceDeclaration(node);
+    }
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodNameWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodNameWalker.cs
@@ -1,0 +1,14 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class MethodNameWalker : CSharpSyntaxWalker
+{
+    public HashSet<string> Names { get; } = new();
+
+    public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+    {
+        Names.Add(node.Identifier.ValueText);
+        base.VisitMethodDeclaration(node);
+    }
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/NestedClassNameWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/NestedClassNameWalker.cs
@@ -1,0 +1,28 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class NestedClassNameWalker : CSharpSyntaxWalker
+{
+    private readonly ClassDeclarationSyntax _origin;
+    public HashSet<string> Names { get; } = new();
+
+    public NestedClassNameWalker(ClassDeclarationSyntax origin)
+    {
+        _origin = origin;
+    }
+
+    public override void VisitClassDeclaration(ClassDeclarationSyntax node)
+    {
+        if (node.Parent == _origin)
+            Names.Add(node.Identifier.ValueText);
+        base.VisitClassDeclaration(node);
+    }
+
+    public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
+    {
+        if (node.Parent == _origin)
+            Names.Add(node.Identifier.ValueText);
+        base.VisitEnumDeclaration(node);
+    }
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/PrivateFieldInfoWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/PrivateFieldInfoWalker.cs
@@ -1,0 +1,19 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class PrivateFieldInfoWalker : CSharpSyntaxWalker
+{
+    public Dictionary<string, TypeSyntax> Infos { get; } = new();
+
+    public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+    {
+        if (node.Modifiers.Any(SyntaxKind.PrivateKeyword))
+        {
+            foreach (var variable in node.Declaration.Variables)
+                Infos[variable.Identifier.ValueText] = node.Declaration.Type;
+        }
+        base.VisitFieldDeclaration(node);
+    }
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/StaticFieldNameWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/StaticFieldNameWalker.cs
@@ -1,0 +1,19 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class StaticFieldNameWalker : CSharpSyntaxWalker
+{
+    public HashSet<string> Names { get; } = new();
+
+    public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
+    {
+        if (node.Modifiers.Any(SyntaxKind.StaticKeyword))
+        {
+            foreach (var variable in node.Declaration.Variables)
+                Names.Add(variable.Identifier.ValueText);
+        }
+        base.VisitFieldDeclaration(node);
+    }
+}


### PR DESCRIPTION
## Summary
- create a set of SyntaxWalkers for collecting names and field info
- reimplement helper methods with walkers in `MoveMethods.Helpers`

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_6855d2188fe4832794f0c28a241f737d