### PR TITLE
Make moved methods static automatically

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -389,13 +389,13 @@ public class Logger
         Console.WriteLine($"[LOG] {message}");
     }
 
-    public void LogOperation(string operation)
+    public static void LogOperation(string operation)
     {
         Console.WriteLine($"[{DateTime.Now}] {operation}");
     }
 }
 ```
-The original method in `Calculator` now delegates to `Logger.LogOperation`, preserving existing call sites.
+The original method in `Calculator` now delegates to the static `Logger.LogOperation` method, preserving existing call sites.
 If you run `move-instance-method` again on this wrapper, an error will be reported. Use `inline-method` to remove the wrapper if desired.
 When a moved method references private fields from its original class, those values are passed as additional parameters.
 
@@ -1058,8 +1058,8 @@ Inherited members are automatically qualified when moved:
 {"tool":"move-instance-method","solutionPath":"./RefactorMCP.sln","filePath":"./RefactorMCP.Tests/ExampleCode.cs","sourceClass":"Derived","methodNames":"PrintName","targetClass":"Target"}
 ```
 
-### Static Suggestion Example
-When a moved instance method has no dependencies on instance members, the result advises it can be made static.
+### Automatic Static Conversion
+When a moved instance method has no dependencies on instance members, it is made static automatically.
 
 ## Metrics Resource
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ For usage examples see [EXAMPLES.md](./EXAMPLES.md).
 - **Introduce Field/Parameter/Variable** – turn expressions into new members; fails if a field already exists.
 - **Convert to Static** – make instance methods static using parameters or an instance argument.
 - **Move Static Method** – relocate a static method and keep a wrapper in the original class.
-- **Move Instance Method** – move an instance method to another class and delegate from the source.
+- **Move Instance Method** – move an instance method to another class and delegate from the source. If the moved method no longer accesses instance members, it is made static automatically.
 - **Make Field Readonly** – move initialization into constructors and mark the field readonly.
 - **Transform Setter to Init** – convert property setters to init-only and initialize in constructors.
 - **Safe Delete** – remove fields or variables only after dependency checks.

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -453,6 +453,11 @@ public static partial class MoveMethodsTool
             transformedMethod = (MethodDeclarationSyntax)nestedRewriter.Visit(transformedMethod)!;
         }
 
+        if (!needsThisParameter)
+        {
+            transformedMethod = AstTransformations.EnsureStaticModifier(transformedMethod);
+        }
+
         return EnsureMethodIsInternal(transformedMethod);
     }
 

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
@@ -152,7 +152,7 @@ public static partial class MoveMethodsTool
         var locationInfo = targetFilePath != null ? $" in {targetPath}" : string.Empty;
         var staticHint = moveResult.NeedsThisParameter
             ? string.Empty
-            : " As a next step it could be made static.";
+            : " It was made static.";
         return $"Successfully moved instance method {sourceClass}.{methodName} to {targetClass}{locationInfo}. A delegate method remains in the original class to preserve the interface.{staticHint}";
     }
 

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -354,7 +354,7 @@ public static partial class MoveMethodsTool
             var formatted = Formatter.Format(root, RefactoringHelpers.SharedWorkspace);
             await File.WriteAllTextAsync(filePath, formatted.ToFullString(), sourceEncoding, cancellationToken);
             progress?.Report(filePath);
-            var staticHint = suggestStatic ? " At least one moved method has no instance dependencies and could be made static." : string.Empty;
+            var staticHint = suggestStatic ? " At least one moved method had no instance dependencies and was made static." : string.Empty;
             return $"Successfully moved {methodNames.Length} methods from {sourceClass} to {targetClass} in {filePath}. Delegate methods remain in the original class to preserve the interface.{staticHint}";
         }
         else
@@ -390,7 +390,7 @@ public static partial class MoveMethodsTool
             await File.WriteAllTextAsync(targetPath, formattedTarget.ToFullString(), targetEncoding, cancellationToken);
             progress?.Report(targetPath);
 
-            var staticHint2 = suggestStatic2 ? " At least one moved method has no instance dependencies and could be made static." : string.Empty;
+            var staticHint2 = suggestStatic2 ? " At least one moved method had no instance dependencies and was made static." : string.Empty;
             return $"Successfully moved {methodNames.Length} methods from {sourceClass} to {targetClass} in {targetPath}. Delegate methods remain in the original class to preserve the interface.{staticHint2}";
         }
     }

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -164,7 +164,7 @@ public class TargetClass
             var targetClassCode = result.Split(new[] { "public class TargetClass" }, StringSplitOptions.None)[1];
             var sourceClassCode = result.Split(new[] { "public class SourceClass" }, StringSplitOptions.None)[1].Split(new[] { "public class TargetClass" }, StringSplitOptions.None)[0];
 
-            Assert.Contains("public int Method1(int field1)", targetClassCode);
+            Assert.Contains("public static int Method1(int field1)", targetClassCode);
             Assert.Contains("public int Method2(SourceClass @this)", targetClassCode);
             Assert.Contains("public int Method3(SourceClass @this)", targetClassCode);
             Assert.Contains("return @this.Method1() + 1", targetClassCode);
@@ -206,7 +206,7 @@ public class TargetClass
             var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
-            Assert.Contains("public int GetValue(int value)", formatted);
+            Assert.Contains("public static int GetValue(int value)", formatted);
             Assert.Contains("return value + 2", formatted);
             Assert.Contains("return _target.GetValue(_value)", formatted);
         }
@@ -238,7 +238,7 @@ public class TargetClass
             var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
-            Assert.Contains("public int GetValue(int value, int n = 5)", formatted);
+            Assert.Contains("public static int GetValue(int value, int n = 5)", formatted);
             Assert.Contains("_target.GetValue(_value, n)", formatted);
         }
 

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
@@ -108,8 +108,8 @@ public class TargetClass
         var targetClassCode = result.Split(new[] { "public class TargetClass" }, StringSplitOptions.None)[1];
         var sourceClassCode = result.Split(new[] { "public class SourceClass" }, StringSplitOptions.None)[1].Split(new[] { "public class TargetClass" }, StringSplitOptions.None)[0];
 
-        Assert.Contains("public int Method1(int field1)", targetClassCode);
-        Assert.Contains("public int Method2(int field1)", targetClassCode);
+        Assert.Contains("public static int Method1(int field1)", targetClassCode);
+        Assert.Contains("public static int Method2(int field1)", targetClassCode);
         Assert.DoesNotContain("public int Method1() { return field1; }", sourceClassCode);
         Assert.DoesNotContain("public int Method2() { return field1 + 1; }", sourceClassCode);
         Assert.Contains("return field1.Method1(field1)", sourceClassCode);
@@ -148,7 +148,7 @@ public class TargetClass
         var sourceClassCode = result.Split(new[] { "public class SourceClass" }, StringSplitOptions.None)[1].Split(new[] { "public class TargetClass" }, StringSplitOptions.None)[0];
 
         Assert.Contains("public static int Method1()", targetClassCode);
-        Assert.Contains("public int Method2(int field1)", targetClassCode);
+        Assert.Contains("public static int Method2(int field1)", targetClassCode);
         Assert.DoesNotContain("public static int Method1() { return 1; }", sourceClassCode);
         Assert.DoesNotContain("public int Method2() { return field1; }", sourceClassCode);
         Assert.Contains("return TargetClass.Method1()", sourceClassCode);


### PR DESCRIPTION
## Summary
- automatically add static modifier to moved methods when possible
- update move tool messages
- adjust move instance method behavior for static targets
- document automatic static conversion
- update examples to show method made static
- expand tests for moved static methods

## Testing
- `dotnet build`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6855d5c0ac508327aaeb27f2c401c650