### PR TITLE
Refactor walkers for DRYness

### DIFF
--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/BaseCallRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/BaseCallRewriter.cs
@@ -19,10 +19,7 @@ namespace RefactorMCP.ConsoleApp.SyntaxRewriters
 
         public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
         {
-            if (node.Expression is MemberAccessExpressionSyntax ma &&
-                ma.Expression is BaseExpressionSyntax &&
-                ma.Name is IdentifierNameSyntax id &&
-                id.Identifier.ValueText == _methodName)
+            if (InvocationHelpers.IsBaseInvocationOf(node, _methodName))
             {
                 var memberAccess = SyntaxFactory.MemberAccessExpression(
                     SyntaxKind.SimpleMemberAccessExpression,

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/ClassCollectorWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/ClassCollectorWalker.cs
@@ -1,20 +1,10 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 
 namespace RefactorMCP.ConsoleApp.SyntaxRewriters
 {
-    internal class ClassCollectorWalker : CSharpSyntaxWalker
+    internal class ClassCollectorWalker : TypeCollectorWalker<ClassDeclarationSyntax>
     {
-        public Dictionary<string, ClassDeclarationSyntax> Classes { get; } = new();
-
-        public override void VisitClassDeclaration(ClassDeclarationSyntax node)
-        {
-            var name = node.Identifier.ValueText;
-            if (!Classes.ContainsKey(name))
-                Classes[name] = node;
-            base.VisitClassDeclaration(node);
-        }
+        public Dictionary<string, ClassDeclarationSyntax> Classes => Types;
     }
 }

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberNameWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/InstanceMemberNameWalker.cs
@@ -1,21 +1,18 @@
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Generic;
 
-internal class InstanceMemberNameWalker : CSharpSyntaxWalker
+internal class InstanceMemberNameWalker : NameCollectorWalker
 {
-    public HashSet<string> Names { get; } = new();
-
     public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
     {
         foreach (var variable in node.Declaration.Variables)
-            Names.Add(variable.Identifier.ValueText);
+            Add(variable.Identifier.ValueText);
         base.VisitFieldDeclaration(node);
     }
 
     public override void VisitPropertyDeclaration(PropertyDeclarationSyntax node)
     {
-        Names.Add(node.Identifier.ValueText);
+        Add(node.Identifier.ValueText);
         base.VisitPropertyDeclaration(node);
     }
 }

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/InterfaceCollectorWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/InterfaceCollectorWalker.cs
@@ -1,16 +1,7 @@
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
 
-internal class InterfaceCollectorWalker : CSharpSyntaxWalker
+internal class InterfaceCollectorWalker : TypeCollectorWalker<InterfaceDeclarationSyntax>
 {
-    public Dictionary<string, InterfaceDeclarationSyntax> Interfaces { get; } = new();
-
-    public override void VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
-    {
-        var name = node.Identifier.ValueText;
-        if (!Interfaces.ContainsKey(name))
-            Interfaces[name] = node;
-        base.VisitInterfaceDeclaration(node);
-    }
+    public Dictionary<string, InterfaceDeclarationSyntax> Interfaces => Types;
 }

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/InvocationHelpers.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/InvocationHelpers.cs
@@ -1,0 +1,18 @@
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+internal static class InvocationHelpers
+{
+    internal static string? GetInvokedMethodName(InvocationExpressionSyntax node)
+        => node.Expression switch
+        {
+            IdentifierNameSyntax id => id.Identifier.ValueText,
+            MemberAccessExpressionSyntax ma when ma.Name is IdentifierNameSyntax id => id.Identifier.ValueText,
+            _ => null
+        };
+
+    internal static bool IsInvocationOf(InvocationExpressionSyntax node, string methodName)
+        => GetInvokedMethodName(node) == methodName;
+
+    internal static bool IsBaseInvocationOf(InvocationExpressionSyntax node, string methodName)
+        => node.Expression is MemberAccessExpressionSyntax { Expression: BaseExpressionSyntax, Name: IdentifierNameSyntax id } && id.Identifier.ValueText == methodName;
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodNameWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodNameWalker.cs
@@ -1,14 +1,10 @@
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Generic;
 
-internal class MethodNameWalker : CSharpSyntaxWalker
+internal class MethodNameWalker : NameCollectorWalker
 {
-    public HashSet<string> Names { get; } = new();
-
     public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
     {
-        Names.Add(node.Identifier.ValueText);
+        Add(node.Identifier.ValueText);
         base.VisitMethodDeclaration(node);
     }
 }

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/NameCollectorWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/NameCollectorWalker.cs
@@ -1,0 +1,10 @@
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal abstract class NameCollectorWalker : CSharpSyntaxWalker
+{
+    public HashSet<string> Names { get; } = new();
+
+    protected void Add(string name) => Names.Add(name);
+}

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/NestedClassNameWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/NestedClassNameWalker.cs
@@ -1,11 +1,8 @@
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Generic;
 
-internal class NestedClassNameWalker : CSharpSyntaxWalker
+internal class NestedClassNameWalker : NameCollectorWalker
 {
     private readonly ClassDeclarationSyntax _origin;
-    public HashSet<string> Names { get; } = new();
 
     public NestedClassNameWalker(ClassDeclarationSyntax origin)
     {
@@ -15,14 +12,14 @@ internal class NestedClassNameWalker : CSharpSyntaxWalker
     public override void VisitClassDeclaration(ClassDeclarationSyntax node)
     {
         if (node.Parent == _origin)
-            Names.Add(node.Identifier.ValueText);
+            Add(node.Identifier.ValueText);
         base.VisitClassDeclaration(node);
     }
 
     public override void VisitEnumDeclaration(EnumDeclarationSyntax node)
     {
         if (node.Parent == _origin)
-            Names.Add(node.Identifier.ValueText);
+            Add(node.Identifier.ValueText);
         base.VisitEnumDeclaration(node);
     }
 }

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/ParameterIntroductionRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/ParameterIntroductionRewriter.cs
@@ -1,5 +1,4 @@
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Editing;
 
@@ -25,15 +24,10 @@ internal class ParameterIntroductionRewriter : ExpressionIntroductionRewriter<Me
         return node.AddParameterListParameters((ParameterSyntax)declaration);
     }
 
-
     public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
     {
         var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
-        var isTarget =
-            (visited.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == _methodName) ||
-            (visited.Expression is MemberAccessExpressionSyntax ma && ma.Name.Identifier.ValueText == _methodName);
-
-        if (isTarget)
+        if (InvocationHelpers.IsInvocationOf(visited, _methodName))
         {
             visited = AstTransformations.AddArgument(
                 visited,
@@ -49,7 +43,5 @@ internal class ParameterIntroductionRewriter : ExpressionIntroductionRewriter<Me
         var visited = (MethodDeclarationSyntax)base.VisitMethodDeclaration(node)!;
         bool shouldInsert = node.Identifier.ValueText == _methodName;
         return MaybeInsertDeclaration(node, visited, shouldInsert);
-
     }
 }
-

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/ParameterRemovalRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/ParameterRemovalRewriter.cs
@@ -1,10 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Text;
 using Microsoft.CodeAnalysis.Editing;
-using System.Collections.Generic;
-using System.Linq;
 
 public class ParameterRemovalRewriter : CSharpSyntaxRewriter
 {
@@ -33,13 +30,7 @@ public class ParameterRemovalRewriter : CSharpSyntaxRewriter
     public override SyntaxNode VisitInvocationExpression(InvocationExpressionSyntax node)
     {
         var visited = (InvocationExpressionSyntax)base.VisitInvocationExpression(node)!;
-        bool isTarget = false;
-        if (visited.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == _methodName)
-            isTarget = true;
-        else if (visited.Expression is MemberAccessExpressionSyntax ma && ma.Name.Identifier.ValueText == _methodName)
-            isTarget = true;
-
-        if (isTarget && _parameterIndex < visited.ArgumentList.Arguments.Count)
+        if (InvocationHelpers.IsInvocationOf(visited, _methodName) && _parameterIndex < visited.ArgumentList.Arguments.Count)
         {
             visited = AstTransformations.RemoveArgument(visited, _parameterIndex);
         }
@@ -47,4 +38,3 @@ public class ParameterRemovalRewriter : CSharpSyntaxRewriter
         return visited;
     }
 }
-

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/StaticFieldNameWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/StaticFieldNameWalker.cs
@@ -1,18 +1,15 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System.Collections.Generic;
 
-internal class StaticFieldNameWalker : CSharpSyntaxWalker
+internal class StaticFieldNameWalker : NameCollectorWalker
 {
-    public HashSet<string> Names { get; } = new();
-
     public override void VisitFieldDeclaration(FieldDeclarationSyntax node)
     {
         if (node.Modifiers.Any(SyntaxKind.StaticKeyword))
         {
             foreach (var variable in node.Declaration.Variables)
-                Names.Add(variable.Identifier.ValueText);
+                Add(variable.Identifier.ValueText);
         }
         base.VisitFieldDeclaration(node);
     }

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/TypeCollectorWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/TypeCollectorWalker.cs
@@ -1,0 +1,20 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+
+internal class TypeCollectorWalker<T> : CSharpSyntaxWalker where T : TypeDeclarationSyntax
+{
+    public Dictionary<string, T> Types { get; } = new();
+
+    public override void Visit(SyntaxNode? node)
+    {
+        if (node is T typed)
+        {
+            var name = typed.Identifier.ValueText;
+            if (!Types.ContainsKey(name))
+                Types[name] = typed;
+        }
+        base.Visit(node);
+    }
+}


### PR DESCRIPTION
## Summary
- add `TypeCollectorWalker` and `NameCollectorWalker` base helpers
- unify existing collectors on new helpers
- add `InvocationHelpers` and reuse in rewriters
- simplify parameter rewriters using helper methods

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build --logger "console;verbosity=minimal"` *(fails: Build failed with 1 warning(s) in 11.5s)*

------
https://chatgpt.com/codex/tasks/task_e_6855d77bd57c8327851c238ac0bd76e2