### PR TITLE
Make moved methods static when possible

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Ast.cs
@@ -454,10 +454,8 @@ public static partial class MoveMethodsTool
             transformedMethod = (MethodDeclarationSyntax)nestedRewriter.Visit(transformedMethod)!;
         }
 
-        if (!needsThisParameter)
-        {
-            transformedMethod = AstTransformations.EnsureStaticModifier(transformedMethod);
-        }
+
+        transformedMethod = AstTransformations.EnsureStaticModifier(transformedMethod);
 
         return EnsureMethodIsInternal(transformedMethod);
     }

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.File.cs
@@ -150,9 +150,9 @@ public static partial class MoveMethodsTool
         }
 
         var locationInfo = targetFilePath != null ? $" in {targetPath}" : string.Empty;
-        var staticHint = moveResult.NeedsThisParameter
-            ? string.Empty
-            : " It was made static.";
+        var staticHint = moveResult.MovedMethod.Modifiers.Any(SyntaxKind.StaticKeyword)
+            ? " It was made static."
+            : string.Empty;
         return $"Successfully moved instance method {sourceClass}.{methodName} to {targetClass}{locationInfo}. A delegate method remains in the original class to preserve the interface.{staticHint}";
     }
 

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethods.Tool.cs
@@ -347,7 +347,7 @@ public static partial class MoveMethodsTool
             foreach (var methodName in methodNames)
             {
                 var moveResult = MoveInstanceMethodAst(root, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
-                suggestStatic |= !moveResult.NeedsThisParameter;
+                suggestStatic |= moveResult.MovedMethod.Modifiers.Any(SyntaxKind.StaticKeyword);
                 root = AddMethodToTargetClass(moveResult.NewSourceRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
             }
 
@@ -373,7 +373,7 @@ public static partial class MoveMethodsTool
             foreach (var methodName in methodNames)
             {
                 var moveResult = MoveInstanceMethodAst(sourceRoot, sourceClass, methodName, targetClass, accessMemberName, accessMemberType);
-                suggestStatic2 |= !moveResult.NeedsThisParameter;
+                suggestStatic2 |= moveResult.MovedMethod.Modifiers.Any(SyntaxKind.StaticKeyword);
                 sourceRoot = moveResult.NewSourceRoot;
                 targetRoot = AddMethodToTargetClass(targetRoot, targetClass, moveResult.MovedMethod, moveResult.Namespace);
             }

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -165,8 +165,8 @@ public class TargetClass
             var sourceClassCode = result.Split(new[] { "public class SourceClass" }, StringSplitOptions.None)[1].Split(new[] { "public class TargetClass" }, StringSplitOptions.None)[0];
 
             Assert.Contains("public static int Method1(int field1)", targetClassCode);
-            Assert.Contains("public int Method2(SourceClass @this)", targetClassCode);
-            Assert.Contains("public int Method3(SourceClass @this)", targetClassCode);
+            Assert.Contains("public static int Method2(SourceClass @this)", targetClassCode);
+            Assert.Contains("public static int Method3(SourceClass @this)", targetClassCode);
             Assert.Contains("return @this.Method1() + 1", targetClassCode);
             Assert.Contains("return @this.Method2() + 1", targetClassCode);
 


### PR DESCRIPTION
## Summary
- ensure moved instance methods become static by default
- update bulk move static hints
- update tests for new static method behavior

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68568ea215188327bdfe1d225c549fd2