### PR TITLE
Add MakeStaticThenMove tool

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -399,6 +399,49 @@ The original method in `Calculator` now delegates to the static `Logger.LogOpera
 If you run `move-instance-method` again on this wrapper, an error will be reported. Use `inline-method` to remove the wrapper if desired.
 When a moved method references private fields from its original class, those values are passed as additional parameters.
 
+## 10. Make Static Then Move
+
+**Purpose**: Convert an instance method to static with an explicit instance parameter and move it to another class.
+
+### Example
+**Before** (in `ExampleCode.cs` line 46):
+```csharp
+public string GetFormattedNumber(int number)
+{
+    return $"{operatorSymbol}: {number}";
+}
+```
+
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli make-static-then-move \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  GetFormattedNumber \
+  MathUtilities \
+  calculator
+```
+
+**After**:
+```csharp
+public class Calculator
+{
+    public string GetFormattedNumber(int number)
+    {
+        return MathUtilities.GetFormattedNumber(this, number);
+    }
+}
+
+public class MathUtilities
+{
+    public static string GetFormattedNumber(Calculator calculator, int number)
+    {
+        return $"{calculator.operatorSymbol}: {number}";
+    }
+}
+```
+The wrapper in `Calculator` preserves call sites while the actual logic moves to `MathUtilities`.
+
 ## 10. Move Multiple Methods
 
 **Purpose**: Move several methods at once, ordered by dependencies.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ For usage examples see [EXAMPLES.md](./EXAMPLES.md).
 - **Convert to Static** – make instance methods static using parameters or an instance argument.
 - **Move Static Method** – relocate a static method and keep a wrapper in the original class.
 - **Move Instance Method** – move an instance method to another class and delegate from the source. If the moved method no longer accesses instance members, it is made static automatically.
+- **Make Static Then Move** – convert an instance method to static and relocate it to another class in one step.
 - **Make Field Readonly** – move initialization into constructors and mark the field readonly.
 - **Transform Setter to Init** – convert property setters to init-only and initialize in constructors.
 - **Safe Delete** – remove fields or variables only after dependency checks.

--- a/RefactorMCP.ConsoleApp/ToolCallLogger.cs
+++ b/RefactorMCP.ConsoleApp/ToolCallLogger.cs
@@ -32,7 +32,9 @@ internal static class ToolCallLogger
     public static void Log(string toolName, Dictionary<string, string?> parameters, string? logFile = null)
     {
         var file = logFile ?? DefaultLogFile;
-        Directory.CreateDirectory(Path.GetDirectoryName(file)!);
+        var dir = Path.GetDirectoryName(file);
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
 
         var record = new ToolCallRecord
         {

--- a/RefactorMCP.ConsoleApp/Tools/MakeStaticThenMove.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MakeStaticThenMove.cs
@@ -1,0 +1,36 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using System.ComponentModel;
+using System.Threading;
+using System.Threading.Tasks;
+
+[McpServerToolType]
+public static class MakeStaticThenMoveTool
+{
+    [McpServerTool, Description("Convert an instance method to static and move it to another class (preferred for large C# file refactoring)")]
+    public static async Task<string> MakeStaticThenMove(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        [Description("Path to the C# file containing the method")] string filePath,
+        [Description("Name of the method to convert and move")] string methodName,
+        [Description("Name of the target class")] string targetClass,
+        [Description("Name for the instance parameter (optional)")] string instanceParameterName = "instance",
+        [Description("Path to the target file (optional, will create if doesn't exist or unspecified)")] string? targetFilePath = null,
+        IProgress<string>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        await ConvertToStaticWithInstanceTool.ConvertToStaticWithInstance(
+            solutionPath,
+            filePath,
+            methodName,
+            instanceParameterName);
+
+        return await MoveMethodsTool.MoveStaticMethod(
+            solutionPath,
+            filePath,
+            methodName,
+            targetClass,
+            targetFilePath,
+            progress,
+            cancellationToken);
+    }
+}

--- a/RefactorMCP.Tests/Tools/MakeStaticThenMoveTests.cs
+++ b/RefactorMCP.Tests/Tools/MakeStaticThenMoveTests.cs
@@ -1,0 +1,41 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class MakeStaticThenMoveTests : TestBase
+{
+    [Fact]
+    public async Task MakeStaticThenMove_ReturnsSuccess()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.Combine(TestOutputPath, "MakeStaticThenMove.cs");
+        await TestUtilities.CreateTestFile(testFile, @"public class SourceClass
+{
+    public string Value = ""x"";
+    public string GetValueWithSuffix(string suffix)
+    {
+        return Value + suffix;
+    }
+}
+
+public class NewMathUtils { }");
+
+        var result = await MakeStaticThenMoveTool.MakeStaticThenMove(
+            SolutionPath,
+            testFile,
+            "GetValueWithSuffix",
+            "NewMathUtils",
+            "source",
+            null,
+            null,
+            CancellationToken.None);
+
+        Assert.Contains("Successfully moved static method", result);
+        var newFile = Path.Combine(Path.GetDirectoryName(testFile)!, "NewMathUtils.cs");
+        Assert.True(File.Exists(newFile));
+    }
+}


### PR DESCRIPTION
## Summary
- add `MakeStaticThenMoveTool` for converting an instance method to static and moving it
- document new tool in README and EXAMPLES
- test `MakeStaticThenMoveTool`
- fix logging when log path has no directory

## Testing
- `dotnet format --no-restore`
- `dotnet build`
- `dotnet test --no-build --filter MakeStaticThenMove`
- `dotnet test` *(fails: timeout)*

------
https://chatgpt.com/codex/tasks/task_e_6856e6b73100832783d5c2028104c9ff