### PR TITLE
Add decorator, adapter and observer tools

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -934,6 +934,108 @@ public void DoWork()
 }
 ```
 
+
+## 18. Extract Decorator
+
+**Purpose**: Generate a decorator class that delegates to an existing method.
+
+### Example
+**Before**:
+```csharp
+public class Greeter
+{
+    public void Greet(string name)
+    {
+        Console.WriteLine($"Hello {name}");
+    }
+}
+```
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli extract-decorator \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/Decorator.cs" \
+  Greeter \
+  Greet
+```
+**After**:
+```csharp
+public class GreeterDecorator
+{
+    private readonly Greeter _inner;
+    public GreeterDecorator(Greeter inner) { _inner = inner; }
+    public void Greet(string name) { _inner.Greet(name); }
+}
+```
+
+## 19. Create Adapter
+
+**Purpose**: Create an adapter class wrapping an existing method.
+
+### Example
+**Before**:
+```csharp
+public class LegacyLogger
+{
+    public void Write(string message)
+    {
+        Console.WriteLine(message);
+    }
+}
+```
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli create-adapter \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/Adapter.cs" \
+  LegacyLogger \
+  Write \
+  LoggerAdapter
+```
+**After**:
+```csharp
+public class LoggerAdapter
+{
+    private readonly LegacyLogger _inner;
+    public LoggerAdapter(LegacyLogger inner) { _inner = inner; }
+    public void Adapt(string message) { _inner.Write(message); }
+}
+```
+
+## 20. Add Observer
+
+**Purpose**: Add an event and raise it within a method.
+
+### Example
+**Before**:
+```csharp
+public class Counter
+{
+    private int _value;
+    public void Update(int value)
+    {
+        _value = value;
+    }
+}
+```
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli add-observer \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/Observer.cs" \
+  Counter \
+  Update \
+  Updated
+```
+**After**:
+```csharp
+public event Action<int> Updated;
+public void Update(int value)
+{
+    _value = value;
+    Updated?.Invoke(value);
+}
+```
 ## Range Format
 
 All refactoring commands that require selecting code use the range format:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ For usage examples see [EXAMPLES.md](./EXAMPLES.md).
 - **Safe Delete** – remove fields or variables only after dependency checks.
 - **Extract Class** – create a new class from selected members and compose it with the original.
 - **Inline Method** – replace calls with the method body and delete the original.
+- **Extract Decorator** – create a decorator class that delegates to an existing method.
+- **Create Adapter** – generate an adapter class wrapping an existing method.
+- **Add Observer** – introduce an event and raise it from a method.
 
 Metrics and summaries are also available via the `metrics://` and `summary://` resource schemes.
 

--- a/RefactorMCP.ConsoleApp/Tools/AddObserverTool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/AddObserverTool.cs
@@ -1,0 +1,87 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.ComponentModel;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Text;
+
+[McpServerToolType]
+public static class AddObserverTool
+{
+    [McpServerTool, Description("Introduce a simple observer event and raise it in a method")]
+    public static async Task<string> AddObserver(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        [Description("Path to the C# file")] string filePath,
+        [Description("Name of the class containing the method")] string className,
+        [Description("Name of the method to raise the event from")] string methodName,
+        [Description("Name of the event to create")] string eventName)
+    {
+        try
+        {
+            return await RefactoringHelpers.RunWithSolutionOrFile(
+                solutionPath,
+                filePath,
+                doc => AddObserverWithSolution(doc, className, methodName, eventName),
+                path => AddObserverSingleFile(path, className, methodName, eventName));
+        }
+        catch (Exception ex)
+        {
+            throw new McpException($"Error adding observer: {ex.Message}", ex);
+        }
+    }
+
+    private static async Task<string> AddObserverWithSolution(Document document, string className, string methodName, string eventName)
+    {
+        var text = await document.GetTextAsync();
+        var newText = AddObserverInSource(text.ToString(), className, methodName, eventName);
+        var enc = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText, enc);
+        RefactoringHelpers.UpdateSolutionCache(document.WithText(SourceText.From(newText, enc)));
+        return $"Added observer {eventName} to {document.FilePath} (solution mode)";
+    }
+
+    private static Task<string> AddObserverSingleFile(string filePath, string className, string methodName, string eventName)
+    {
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => AddObserverInSource(text, className, methodName, eventName),
+            $"Added observer {eventName} to {filePath} (single file mode)");
+    }
+
+    public static string AddObserverInSource(string sourceText, string className, string methodName, string eventName)
+    {
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        var root = (CompilationUnitSyntax)tree.GetRoot();
+        var classNode = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .FirstOrDefault(c => c.Identifier.ValueText == className);
+        if (classNode == null)
+            throw new McpException($"Error: Class '{className}' not found");
+        var method = classNode.Members.OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            throw new McpException($"Error: Method '{methodName}' not found");
+
+        var param = method.ParameterList.Parameters.FirstOrDefault();
+        var eventType = param != null ? $"Action<{param.Type}>" : "Action";
+        var eventField = SyntaxFactory.EventFieldDeclaration(
+                SyntaxFactory.VariableDeclaration(SyntaxFactory.ParseTypeName(eventType))
+                    .AddVariables(SyntaxFactory.VariableDeclarator(eventName)))
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword));
+
+        var invocationArgs = param != null ? param.Identifier.ValueText : string.Empty;
+        var invokeStmt = SyntaxFactory.ParseStatement($"{eventName}?.Invoke({invocationArgs});");
+
+        var newMethod = method.WithBody(method.Body!.AddStatements(invokeStmt));
+        var newClass = classNode.ReplaceNode(method, newMethod).AddMembers(eventField);
+
+        var newRoot = root.ReplaceNode(classNode, newClass);
+        var formatted = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
+        return formatted.ToFullString();
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/CreateAdapterTool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/CreateAdapterTool.cs
@@ -1,0 +1,127 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using System.ComponentModel;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Text;
+
+[McpServerToolType]
+public static class CreateAdapterTool
+{
+    [McpServerTool, Description("Generate a simple adapter class that delegates to an existing method")]
+    public static async Task<string> CreateAdapter(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        [Description("Path to the C# file")] string filePath,
+        [Description("Name of the class containing the method")] string className,
+        [Description("Name of the method to adapt")] string methodName,
+        [Description("Name of the adapter class to create")] string adapterName)
+    {
+        try
+        {
+            return await RefactoringHelpers.RunWithSolutionOrFile(
+                solutionPath,
+                filePath,
+                doc => AdaptWithSolution(doc, className, methodName, adapterName),
+                path => AdaptSingleFile(path, className, methodName, adapterName));
+        }
+        catch (Exception ex)
+        {
+            throw new McpException($"Error creating adapter: {ex.Message}", ex);
+        }
+    }
+
+    private static async Task<string> AdaptWithSolution(Document document, string className, string methodName, string adapterName)
+    {
+        var text = await document.GetTextAsync();
+        var newText = CreateAdapterInSource(text.ToString(), className, methodName, adapterName);
+        var enc = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText, enc);
+        RefactoringHelpers.UpdateSolutionCache(document.WithText(SourceText.From(newText, enc)));
+        return $"Created adapter {adapterName} in {document.FilePath} (solution mode)";
+    }
+
+    private static Task<string> AdaptSingleFile(string filePath, string className, string methodName, string adapterName)
+    {
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => CreateAdapterInSource(text, className, methodName, adapterName),
+            $"Created adapter {adapterName} in {filePath} (single file mode)");
+    }
+
+    public static string CreateAdapterInSource(string sourceText, string className, string methodName, string adapterName)
+    {
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        var root = (CompilationUnitSyntax)tree.GetRoot();
+        var classNode = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .FirstOrDefault(c => c.Identifier.ValueText == className);
+        if (classNode == null)
+            throw new McpException($"Error: Class '{className}' not found");
+        var method = classNode.Members.OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            throw new McpException($"Error: Method '{methodName}' not found");
+
+        var adapter = CreateAdapterClass(className, adapterName, method);
+
+        SyntaxNode newRoot;
+        if (classNode.Parent is BaseNamespaceDeclarationSyntax ns)
+            newRoot = root.ReplaceNode(ns, ns.AddMembers(adapter));
+        else
+            newRoot = root.AddMembers(adapter);
+
+        var formatted = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
+        return formatted.ToFullString();
+    }
+
+    private static ClassDeclarationSyntax CreateAdapterClass(string className, string adapterName, MethodDeclarationSyntax method)
+    {
+        var fieldName = "_inner";
+        var field = SyntaxFactory.FieldDeclaration(
+                SyntaxFactory.VariableDeclaration(SyntaxFactory.IdentifierName(className))
+                    .AddVariables(SyntaxFactory.VariableDeclarator(fieldName)))
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword), SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
+
+        var ctor = SyntaxFactory.ConstructorDeclaration(adapterName)
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
+            .AddParameterListParameters(
+                SyntaxFactory.Parameter(SyntaxFactory.Identifier("inner"))
+                    .WithType(SyntaxFactory.IdentifierName(className)))
+            .WithBody(
+                SyntaxFactory.Block(
+                    SyntaxFactory.ExpressionStatement(
+                        SyntaxFactory.AssignmentExpression(
+                            SyntaxKind.SimpleAssignmentExpression,
+                            SyntaxFactory.IdentifierName(fieldName),
+                            SyntaxFactory.IdentifierName("inner")))));
+
+        var args = method.ParameterList.Parameters
+            .Select(p => SyntaxFactory.Argument(SyntaxFactory.IdentifierName(p.Identifier)));
+        var call = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(fieldName),
+                    SyntaxFactory.IdentifierName(method.Identifier)))
+            .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(args)));
+
+        StatementSyntax callStmt;
+        var isVoid = method.ReturnType is PredefinedTypeSyntax pts && pts.Keyword.IsKind(SyntaxKind.VoidKeyword);
+        if (isVoid)
+            callStmt = SyntaxFactory.ExpressionStatement(call);
+        else
+            callStmt = SyntaxFactory.ReturnStatement(call);
+
+        var adaptedMethod = method.WithIdentifier(SyntaxFactory.Identifier("Adapt"))
+            .WithBody(SyntaxFactory.Block(callStmt))
+            .WithSemicolonToken(default);
+
+        return SyntaxFactory.ClassDeclaration(adapterName)
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
+            .AddMembers(field, ctor, adaptedMethod);
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/ExtractDecoratorTool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ExtractDecoratorTool.cs
@@ -1,0 +1,128 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Text;
+using System.ComponentModel;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+
+[McpServerToolType]
+public static class ExtractDecoratorTool
+{
+    [McpServerTool, Description("Create a simple decorator class for a method")]
+    public static async Task<string> ExtractDecorator(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        [Description("Path to the C# file")] string filePath,
+        [Description("Name of the class containing the method")] string className,
+        [Description("Name of the method to decorate")] string methodName)
+    {
+        try
+        {
+            return await RefactoringHelpers.RunWithSolutionOrFile(
+                solutionPath,
+                filePath,
+                doc => DecorateWithSolution(doc, className, methodName),
+                path => DecorateSingleFile(path, className, methodName));
+        }
+        catch (Exception ex)
+        {
+            throw new McpException($"Error extracting decorator: {ex.Message}", ex);
+        }
+    }
+
+    private static async Task<string> DecorateWithSolution(Document document, string className, string methodName)
+    {
+        var sourceText = await document.GetTextAsync();
+        var newText = ExtractDecoratorInSource(sourceText.ToString(), className, methodName);
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, newText, encoding);
+        RefactoringHelpers.UpdateSolutionCache(document.WithText(SourceText.From(newText, encoding)));
+        return $"Created decorator for {className}.{methodName} in {document.FilePath} (solution mode)";
+    }
+
+    private static Task<string> DecorateSingleFile(string filePath, string className, string methodName)
+    {
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => ExtractDecoratorInSource(text, className, methodName),
+            $"Created decorator for {className}.{methodName} in {filePath} (single file mode)");
+    }
+
+    public static string ExtractDecoratorInSource(string sourceText, string className, string methodName)
+    {
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        var root = (CompilationUnitSyntax)tree.GetRoot();
+        var classNode = root.DescendantNodes().OfType<ClassDeclarationSyntax>()
+            .FirstOrDefault(c => c.Identifier.ValueText == className);
+        if (classNode == null)
+            throw new McpException($"Error: Class '{className}' not found");
+        var method = classNode.Members.OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            throw new McpException($"Error: Method '{methodName}' not found");
+
+        var decorator = CreateDecoratorClass(className, method);
+
+        SyntaxNode newRoot;
+        if (classNode.Parent is BaseNamespaceDeclarationSyntax ns)
+            newRoot = root.ReplaceNode(ns, ns.AddMembers(decorator));
+        else
+            newRoot = root.AddMembers(decorator);
+
+        var formatted = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
+        return formatted.ToFullString();
+    }
+
+    private static ClassDeclarationSyntax CreateDecoratorClass(string className, MethodDeclarationSyntax method)
+    {
+        var decoratorName = className + "Decorator";
+        var fieldName = "_inner";
+
+        var field = SyntaxFactory.FieldDeclaration(
+                SyntaxFactory.VariableDeclaration(SyntaxFactory.IdentifierName(className))
+                    .AddVariables(SyntaxFactory.VariableDeclarator(fieldName)))
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword), SyntaxFactory.Token(SyntaxKind.ReadOnlyKeyword));
+
+        var ctor = SyntaxFactory.ConstructorDeclaration(decoratorName)
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
+            .AddParameterListParameters(
+                SyntaxFactory.Parameter(SyntaxFactory.Identifier("inner"))
+                    .WithType(SyntaxFactory.IdentifierName(className)))
+            .WithBody(
+                SyntaxFactory.Block(
+                    SyntaxFactory.ExpressionStatement(
+                        SyntaxFactory.AssignmentExpression(
+                            SyntaxKind.SimpleAssignmentExpression,
+                            SyntaxFactory.IdentifierName(fieldName),
+                            SyntaxFactory.IdentifierName("inner")))));
+
+        var args = method.ParameterList.Parameters
+            .Select(p => SyntaxFactory.Argument(SyntaxFactory.IdentifierName(p.Identifier)));
+        var call = SyntaxFactory.InvocationExpression(
+                SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.IdentifierName(fieldName),
+                    SyntaxFactory.IdentifierName(method.Identifier)))
+            .WithArgumentList(SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(args)));
+
+        StatementSyntax callStmt;
+        var isVoid = method.ReturnType is PredefinedTypeSyntax pts && pts.Keyword.IsKind(SyntaxKind.VoidKeyword);
+        if (isVoid)
+            callStmt = SyntaxFactory.ExpressionStatement(call);
+        else
+            callStmt = SyntaxFactory.ReturnStatement(call);
+
+        var decoratedMethod = method.WithBody(SyntaxFactory.Block(callStmt))
+            .WithSemicolonToken(default);
+
+        return SyntaxFactory.ClassDeclaration(decoratorName)
+            .AddModifiers(SyntaxFactory.Token(SyntaxKind.PublicKeyword))
+            .AddMembers(field, ctor, decoratedMethod);
+    }
+}

--- a/RefactorMCP.Tests/Tools/AddObserverTests.cs
+++ b/RefactorMCP.Tests/Tools/AddObserverTests.cs
@@ -1,0 +1,29 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class AddObserverTests : TestBase
+{
+    [Fact]
+    public async Task AddObserver_AddsEvent()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var testFile = Path.Combine(TestOutputPath, "Observer.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForObserver());
+
+        var result = await AddObserverTool.AddObserver(
+            SolutionPath,
+            testFile,
+            "Counter",
+            "Update",
+            "Updated");
+
+        Assert.Contains("Added observer", result);
+        var text = await File.ReadAllTextAsync(testFile);
+        Assert.Contains("event", text);
+        Assert.Contains("Updated?.Invoke", text);
+    }
+}

--- a/RefactorMCP.Tests/Tools/CreateAdapterTests.cs
+++ b/RefactorMCP.Tests/Tools/CreateAdapterTests.cs
@@ -1,0 +1,28 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class CreateAdapterTests : TestBase
+{
+    [Fact]
+    public async Task CreateAdapter_AddsClass()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var testFile = Path.Combine(TestOutputPath, "Adapter.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForAdapter());
+
+        var result = await CreateAdapterTool.CreateAdapter(
+            SolutionPath,
+            testFile,
+            "LegacyLogger",
+            "Write",
+            "LoggerAdapter");
+
+        Assert.Contains("Created adapter", result);
+        var text = await File.ReadAllTextAsync(testFile);
+        Assert.Contains("LoggerAdapter", text);
+    }
+}

--- a/RefactorMCP.Tests/Tools/ExtractDecoratorTests.cs
+++ b/RefactorMCP.Tests/Tools/ExtractDecoratorTests.cs
@@ -1,0 +1,27 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class ExtractDecoratorTests : TestBase
+{
+    [Fact]
+    public async Task ExtractDecorator_AddsClass()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var testFile = Path.Combine(TestOutputPath, "Decorator.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForDecorator());
+
+        var result = await ExtractDecoratorTool.ExtractDecorator(
+            SolutionPath,
+            testFile,
+            "Greeter",
+            "Greet");
+
+        Assert.Contains("Created decorator", result);
+        var text = await File.ReadAllTextAsync(testFile);
+        Assert.Contains("GreeterDecorator", text);
+    }
+}

--- a/RefactorMCP.Tests/Tools/TestUtilities.cs
+++ b/RefactorMCP.Tests/Tools/TestUtilities.cs
@@ -213,5 +213,36 @@ public interface IFeatureFlags
     bool IsEnabled(string name);
 }
 """;
+
+    public static string GetSampleCodeForDecorator() => """
+public class Greeter
+{
+    public void Greet(string name)
+    {
+        Console.WriteLine("Hello {name}");
+    }
+}
+""";
+
+    public static string GetSampleCodeForAdapter() => """
+public class LegacyLogger
+{
+    public void Write(string message)
+    {
+        Console.WriteLine(message);
+    }
+}
+""";
+
+    public static string GetSampleCodeForObserver() => """
+public class Counter
+{
+    private int _value;
+    public void Update(int value)
+    {
+        _value = value;
+    }
+}
+""";
 }
 


### PR DESCRIPTION
## Summary
- implement ExtractDecoratorTool, CreateAdapterTool and AddObserverTool
- provide tests for new high level tools
- document new tools in README
- add runnable examples for each new feature

## Testing
- `dotnet format --no-restore`
- `dotnet build`
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6856e77fcd408327908627cfb01e63a1