### PR TITLE
Add use-interface analysis and tool

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1145,6 +1145,40 @@ class C
 }
 ```
 
+## 22. Use Interface
+
+**Purpose**: Change a method parameter type to an implemented interface when only interface members are used.
+
+### Example
+**Before**:
+```csharp
+public interface IWriter { void Write(string value); }
+public class FileWriter : IWriter { public void Write(string value) { } }
+public class C
+{
+    public void DoWork(FileWriter writer)
+    {
+        writer.Write("hi");
+    }
+}
+```
+**Command**:
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli use-interface \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/Writer.cs" \
+  DoWork \
+  writer \
+  IWriter
+```
+**After**:
+```csharp
+public void DoWork(IWriter writer)
+{
+    writer.Write("hi");
+}
+```
+
 ## Range Format
 
 All refactoring commands that require selecting code use the range format:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For usage examples see [EXAMPLES.md](./EXAMPLES.md).
 - **Extract Decorator** – create a decorator class that delegates to an existing method.
 - **Create Adapter** – generate an adapter class wrapping an existing method.
 - **Add Observer** – introduce an event and raise it from a method.
+- **Use Interface** – change a method parameter type to one of its implemented interfaces.
 
 Metrics and summaries are also available via the `metrics://` and `summary://` resource schemes.
 

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodMetricsWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodMetricsWalker.cs
@@ -34,7 +34,7 @@ namespace RefactorMCP.ConsoleApp.SyntaxRewriters
                 var accessesInstance = node.DescendantNodes().Any(n => n is ThisExpressionSyntax ||
                     n is MemberAccessExpressionSyntax ma && _model.GetSymbolInfo(ma).Symbol is { IsStatic: false });
                 if (!accessesInstance)
-                    Suggestions.Add($"Method '{node.Identifier}' does not access instance state -> convert-to-static-with-parameters");
+                    Suggestions.Add($"Method '{node.Identifier}' does not access instance state -> make-static");
             }
         }
     }

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/RefactoringOpportunityWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/RefactoringOpportunityWalker.cs
@@ -9,6 +9,7 @@ namespace RefactorMCP.ConsoleApp.SyntaxRewriters
         private readonly MethodMetricsWalker _methodMetrics;
         private readonly ClassMetricsWalker _classMetrics;
         private readonly UnusedMembersWalker _unusedMembers;
+        private readonly UseInterfaceWalker _useInterface;
 
         public List<string> Suggestions { get; } = new();
 
@@ -17,6 +18,7 @@ namespace RefactorMCP.ConsoleApp.SyntaxRewriters
             _methodMetrics = new MethodMetricsWalker(model);
             _classMetrics = new ClassMetricsWalker();
             _unusedMembers = new UnusedMembersWalker(model, solution);
+            _useInterface = new UseInterfaceWalker(model);
         }
 
         public void Visit(SyntaxNode root)
@@ -24,6 +26,7 @@ namespace RefactorMCP.ConsoleApp.SyntaxRewriters
             _methodMetrics.Visit(root);
             _classMetrics.Visit(root);
             _unusedMembers.Visit(root);
+            _useInterface.Visit(root);
         }
 
         public async Task PostProcessAsync()
@@ -32,6 +35,7 @@ namespace RefactorMCP.ConsoleApp.SyntaxRewriters
             Suggestions.AddRange(_methodMetrics.Suggestions);
             Suggestions.AddRange(_classMetrics.Suggestions);
             Suggestions.AddRange(_unusedMembers.Suggestions);
+            Suggestions.AddRange(_useInterface.Suggestions);
         }
     }
 }

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/UseInterfaceWalker.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/UseInterfaceWalker.cs
@@ -1,0 +1,72 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace RefactorMCP.ConsoleApp.SyntaxRewriters
+{
+    internal class UseInterfaceWalker : CSharpSyntaxWalker
+    {
+        private readonly SemanticModel? _model;
+        public List<string> Suggestions { get; } = new();
+
+        public UseInterfaceWalker(SemanticModel? model)
+        {
+            _model = model;
+        }
+
+        public override void VisitMethodDeclaration(MethodDeclarationSyntax node)
+        {
+            base.VisitMethodDeclaration(node);
+            if (_model == null) return;
+
+            foreach (var param in node.ParameterList.Parameters)
+            {
+                if (param.Type == null) continue;
+                var typeInfo = _model.GetTypeInfo(param.Type);
+                if (typeInfo.Type is not INamedTypeSymbol named || named.TypeKind != TypeKind.Class)
+                    continue;
+                var interfaces = named.AllInterfaces;
+                if (interfaces.Length == 0) continue;
+
+                var collector = new ParameterMemberCollector(_model, param.Identifier.ValueText);
+                collector.Visit(node);
+                if (collector.Members.Count == 0) continue;
+
+                foreach (var iface in interfaces)
+                {
+                    if (collector.Members.All(m => iface.GetMembers(m.Name).Any()))
+                    {
+                        Suggestions.Add($"Parameter '{param.Identifier.ValueText}' in method '{node.Identifier.ValueText}' only uses members of interface '{iface.Name}' -> use-interface");
+                        break;
+                    }
+                }
+            }
+        }
+
+        private class ParameterMemberCollector : CSharpSyntaxWalker
+        {
+            private readonly SemanticModel _model;
+            private readonly string _name;
+            public List<ISymbol> Members { get; } = new();
+
+            public ParameterMemberCollector(SemanticModel model, string name)
+            {
+                _model = model;
+                _name = name;
+            }
+
+            public override void VisitMemberAccessExpression(MemberAccessExpressionSyntax node)
+            {
+                if (node.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == _name)
+                {
+                    var symbol = _model.GetSymbolInfo(node).Symbol;
+                    if (symbol != null)
+                        Members.Add(symbol);
+                }
+                base.VisitMemberAccessExpression(node);
+            }
+        }
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/UseInterfaceTool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/UseInterfaceTool.cs
@@ -1,0 +1,87 @@
+using ModelContextProtocol.Server;
+using ModelContextProtocol;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using System.ComponentModel;
+
+[McpServerToolType]
+public static class UseInterfaceTool
+{
+    private static async Task<string> UseInterfaceWithSolution(Document document, string methodName, string parameterName, string interfaceName)
+    {
+        var root = await document.GetSyntaxRootAsync();
+        var method = root!.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            return $"Error: No method named '{methodName}' found";
+        var param = method.ParameterList.Parameters
+            .FirstOrDefault(p => p.Identifier.ValueText == parameterName);
+        if (param == null)
+            return $"Error: No parameter named '{parameterName}' found";
+
+        var newParam = param.WithType(SyntaxFactory.ParseTypeName(interfaceName));
+        var newMethod = method.ReplaceNode(param, newParam);
+        var newRoot = root.ReplaceNode(method, newMethod);
+        var formatted = Formatter.Format(newRoot, document.Project.Solution.Workspace);
+        var newDoc = document.WithSyntaxRoot(formatted);
+        var text = await newDoc.GetTextAsync();
+        var encoding = await RefactoringHelpers.GetFileEncodingAsync(document.FilePath!);
+        await File.WriteAllTextAsync(document.FilePath!, text.ToString(), encoding);
+        RefactoringHelpers.UpdateSolutionCache(newDoc);
+        return $"Successfully changed parameter '{parameterName}' to interface '{interfaceName}' in method '{methodName}' in {document.FilePath} (solution mode)";
+    }
+
+    private static Task<string> UseInterfaceSingleFile(string filePath, string methodName, string parameterName, string interfaceName)
+    {
+        return RefactoringHelpers.ApplySingleFileEdit(
+            filePath,
+            text => UseInterfaceInSource(text, methodName, parameterName, interfaceName),
+            $"Successfully changed parameter '{parameterName}' to interface '{interfaceName}' in method '{methodName}' in {filePath} (single file mode)");
+    }
+
+    public static string UseInterfaceInSource(string sourceText, string methodName, string parameterName, string interfaceName)
+    {
+        var tree = CSharpSyntaxTree.ParseText(sourceText);
+        var root = tree.GetRoot();
+        var method = root.DescendantNodes()
+            .OfType<MethodDeclarationSyntax>()
+            .FirstOrDefault(m => m.Identifier.ValueText == methodName);
+        if (method == null)
+            return $"Error: No method named '{methodName}' found";
+        var param = method.ParameterList.Parameters
+            .FirstOrDefault(p => p.Identifier.ValueText == parameterName);
+        if (param == null)
+            return $"Error: No parameter named '{parameterName}' found";
+
+        var newParam = param.WithType(SyntaxFactory.ParseTypeName(interfaceName));
+        var newMethod = method.ReplaceNode(param, newParam);
+        var newRoot = root.ReplaceNode(method, newMethod);
+        var formatted = Formatter.Format(newRoot, RefactoringHelpers.SharedWorkspace);
+        return formatted.ToFullString();
+    }
+
+    [McpServerTool, Description("Change a method parameter type to an interface (preferred for large C# file refactoring)")]
+    public static async Task<string> UseInterface(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        [Description("Path to the C# file")] string filePath,
+        [Description("Name of the method containing the parameter")] string methodName,
+        [Description("Name of the parameter to change")] string parameterName,
+        [Description("Interface type name to use")] string interfaceName)
+    {
+        try
+        {
+            return await RefactoringHelpers.RunWithSolutionOrFile(
+                solutionPath,
+                filePath,
+                doc => UseInterfaceWithSolution(doc, methodName, parameterName, interfaceName),
+                path => UseInterfaceSingleFile(path, methodName, parameterName, interfaceName));
+        }
+        catch (Exception ex)
+        {
+            throw new McpException($"Error applying interface: {ex.Message}", ex);
+        }
+    }
+}

--- a/RefactorMCP.Tests/AnalyzeRefactoringOpportunitiesTests.cs
+++ b/RefactorMCP.Tests/AnalyzeRefactoringOpportunitiesTests.cs
@@ -24,5 +24,6 @@ public class AnalyzeRefactoringOpportunitiesTests : IDisposable
         var result = await AnalyzeRefactoringOpportunitiesTool.AnalyzeRefactoringOpportunities(SolutionPath, ExampleFilePath);
         Assert.Contains("safe-delete-field", result, StringComparison.OrdinalIgnoreCase);
         Assert.Contains("safe-delete-method", result, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("make-static", result, StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/RefactorMCP.Tests/Tools/TestUtilities.cs
+++ b/RefactorMCP.Tests/Tools/TestUtilities.cs
@@ -244,5 +244,17 @@ public class Counter
     }
 }
 """;
+
+    public static string GetSampleCodeForUseInterface() => """
+public interface IWriter { void Write(string value); }
+public class FileWriter : IWriter { public void Write(string value) { } }
+public class C
+{
+    public void DoWork(FileWriter writer)
+    {
+        writer.Write("hi");
+    }
+}
+""";
 }
 

--- a/RefactorMCP.Tests/Tools/UseInterfaceTests.cs
+++ b/RefactorMCP.Tests/Tools/UseInterfaceTests.cs
@@ -1,0 +1,28 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class UseInterfaceTests : TestBase
+{
+    [Fact]
+    public async Task UseInterface_ChangesParameterType()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var testFile = Path.Combine(TestOutputPath, "UseInterface.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForUseInterface());
+
+        var result = await UseInterfaceTool.UseInterface(
+            SolutionPath,
+            testFile,
+            "DoWork",
+            "writer",
+            "IWriter");
+
+        Assert.Contains("Successfully changed parameter", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.Contains("DoWork(IWriter writer)", fileContent);
+    }
+}

--- a/functionality.md
+++ b/functionality.md
@@ -46,3 +46,6 @@ Creates a new class from selected fields and methods, establishing a composition
 
 ### Inline Method
 Replaces method calls with the method's body content, removing the method definition.
+
+### Use Interface
+Changes a method parameter type to one of its implemented interfaces when possible.


### PR DESCRIPTION
## Summary
- add `UseInterfaceTool` to replace concrete parameters with interface types
- implement `UseInterfaceWalker` for refactoring suggestions
- include new suggestion in refactoring opportunity walker and update existing static suggestion
- document the new tool in README, examples and functionality docs
- add tests and sample code for `use-interface`

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68570cedc8748327bb4e0e1846c18608