### PR TITLE
Add GenerateAccessMemberName tests

### DIFF
--- a/RefactorMCP.Tests/MoveMethodsHelpersTests.cs
+++ b/RefactorMCP.Tests/MoveMethodsHelpersTests.cs
@@ -1,0 +1,29 @@
+using Xunit;
+using System.Collections.Generic;
+
+namespace RefactorMCP.Tests;
+
+public class MoveMethodsHelpersTests
+{
+    [Fact]
+    public void GenerateAccessMemberName_UnusedName_ReturnsBaseName()
+    {
+        var existing = new HashSet<string> { "field1", "field2" };
+
+        var result = MoveMethodsTool.GenerateAccessMemberName(existing, "TargetClass");
+
+        Assert.Equal("_targetClass", result);
+        Assert.DoesNotContain(result, existing);
+    }
+
+    [Fact]
+    public void GenerateAccessMemberName_ExistingNamesForceNumericSuffixes_ReturnsUniqueName()
+    {
+        var existing = new HashSet<string> { "_targetClass", "_targetClass1" };
+
+        var result = MoveMethodsTool.GenerateAccessMemberName(existing, "TargetClass");
+
+        Assert.Equal("_targetClass2", result);
+        Assert.DoesNotContain(result, existing);
+    }
+}


### PR DESCRIPTION
## Summary
- add new MoveMethodsHelpersTests for GenerateAccessMemberName

## Testing
- `dotnet format --no-restore`
- `dotnet test -v diag`

------
https://chatgpt.com/codex/tasks/task_e_6857b9a07a488327b5f431e8d4f7fdac