### PR TITLE
Add metrics resource tests

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MetricsResource.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MetricsResource.cs
@@ -25,7 +25,7 @@ public static class MetricsResource
                 using var metrics = await GetFileMetricsJson(solutionPath, file);
                 if (metrics.RootElement.TryGetProperty("classes", out var clsArray))
                 {
-                    classes.AddRange(clsArray.EnumerateArray());
+                    classes.AddRange(clsArray.EnumerateArray().Select(c => c.Clone()));
                 }
             }
             var json = JsonSerializer.Serialize(classes, new JsonSerializerOptions { WriteIndented = true });

--- a/RefactorMCP.Tests/MetricsResourceTests.cs
+++ b/RefactorMCP.Tests/MetricsResourceTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.IO;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -13,5 +14,50 @@ public class MetricsResourceTests : TestBase
         var result = await MetricsResource.ReadMetrics(ExampleFilePath, SolutionPath);
         using var doc = JsonDocument.Parse(result.Text);
         Assert.True(doc.RootElement.TryGetProperty("linesOfCode", out _));
+    }
+
+    [Fact]
+    public async Task ReadMetrics_Directory_ReturnsAggregatedJson()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var dir = Path.GetDirectoryName(ExampleFilePath)!;
+        var result = await MetricsResource.ReadMetrics(dir, SolutionPath);
+        using var doc = JsonDocument.Parse(result.Text);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+        Assert.Contains(doc.RootElement.EnumerateArray(), e =>
+            e.TryGetProperty("name", out var n) && n.GetString() == "Calculator");
+    }
+
+    [Fact]
+    public async Task ReadMetrics_Class_ReturnsClassMetrics()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var classPath = ExampleFilePath + Path.DirectorySeparatorChar + "Calculator";
+        var result = await MetricsResource.ReadMetrics(classPath, SolutionPath);
+        using var doc = JsonDocument.Parse(result.Text);
+        Assert.Equal("Calculator", doc.RootElement.GetProperty("name").GetString());
+        Assert.True(doc.RootElement.TryGetProperty("methods", out _));
+    }
+
+    [Fact]
+    public async Task ReadMetrics_Method_ReturnsMethodMetrics()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var methodPath = ExampleFilePath + Path.DirectorySeparatorChar + "Calculator.Calculate";
+        var result = await MetricsResource.ReadMetrics(methodPath, SolutionPath);
+        using var doc = JsonDocument.Parse(result.Text);
+        Assert.Equal("Calculate", doc.RootElement.GetProperty("name").GetString());
+        Assert.True(doc.RootElement.TryGetProperty("cyclomaticComplexity", out _));
+    }
+
+    [Fact]
+    public async Task ReadMetrics_InvalidPath_ReturnsError()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath);
+        var invalidPath = ExampleFilePath + Path.DirectorySeparatorChar + "Unknown";
+        var result = await MetricsResource.ReadMetrics(invalidPath, SolutionPath);
+        using var doc = JsonDocument.Parse(result.Text);
+        Assert.True(doc.RootElement.TryGetProperty("Error", out var err));
+        Assert.Contains("not found", err.GetString());
     }
 }


### PR DESCRIPTION
## Summary
- add new metrics tests for directory, class, method and errors
- fix MetricsResource directory aggregation

## Testing
- `dotnet format RefactorMCP.sln --no-restore -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6857b9a4facc8327937801d529993c42