### PR TITLE
Introduce MoveMethodAst and service

### DIFF
--- a/RefactorMCP.ConsoleApp/Move/MoveMethodAst.cs
+++ b/RefactorMCP.ConsoleApp/Move/MoveMethodAst.cs
@@ -11,7 +11,9 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
 using RefactorMCP.ConsoleApp.SyntaxRewriters;
 
-public static partial class MoveMethodsTool
+namespace RefactorMCP.ConsoleApp.Move;
+
+public static partial class MoveMethodAst
 {
     // ===== AST TRANSFORMATION LAYER =====
     // Pure syntax tree operations with no file I/O

--- a/RefactorMCP.ConsoleApp/Move/MoveMethodHelpers.cs
+++ b/RefactorMCP.ConsoleApp/Move/MoveMethodHelpers.cs
@@ -12,7 +12,9 @@ using Microsoft.CodeAnalysis.Text;
 using System.IO;
 using RefactorMCP.ConsoleApp.SyntaxRewriters;
 
-public static partial class MoveMethodsTool
+namespace RefactorMCP.ConsoleApp.Move;
+
+public static partial class MoveMethodAst
 {
     // ===== HELPER METHODS =====
 

--- a/RefactorMCP.ConsoleApp/Tools/LoadSolution.cs
+++ b/RefactorMCP.ConsoleApp/Tools/LoadSolution.cs
@@ -3,6 +3,7 @@ using ModelContextProtocol;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.Extensions.Caching.Memory;
+using RefactorMCP.ConsoleApp.Move;
 using System.ComponentModel;
 using System.IO;
 using System.Collections.Generic;
@@ -26,7 +27,7 @@ public static class LoadSolutionTool
             }
 
             RefactoringHelpers.ClearAllCaches();
-            MoveMethodsTool.ResetMoveHistory();
+            MoveMethodTool.ResetMoveHistory();
 
             var logDir = Path.Combine(Path.GetDirectoryName(solutionPath)!, ".refactor-mcp");
             ToolCallLogger.SetLogDirectory(logDir);

--- a/RefactorMCP.ConsoleApp/Tools/MakeStaticThenMove.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MakeStaticThenMove.cs
@@ -3,6 +3,7 @@ using ModelContextProtocol;
 using System.ComponentModel;
 using System.Threading;
 using System.Threading.Tasks;
+using RefactorMCP.ConsoleApp.Move;
 
 [McpServerToolType]
 public static class MakeStaticThenMoveTool
@@ -24,7 +25,7 @@ public static class MakeStaticThenMoveTool
             methodName,
             instanceParameterName);
 
-        return await MoveMethodsTool.MoveStaticMethod(
+        return await MoveMethodTool.MoveStaticMethod(
             solutionPath,
             filePath,
             methodName,

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -12,6 +12,7 @@ using System.IO;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.Text;
 using RefactorMCP.ConsoleApp.SyntaxRewriters;
+using RefactorMCP.ConsoleApp.Move;
 
 [McpServerToolType]
 public static partial class MoveMultipleMethodsTool
@@ -29,11 +30,11 @@ public static partial class MoveMultipleMethodsTool
         string message;
         if (isStatic)
         {
-            message = await MoveMethodsTool.MoveStaticMethodInFile(document.FilePath!, methodName, targetClass, targetPath);
+            message = await MoveMethodFileService.MoveStaticMethodInFile(document.FilePath!, methodName, targetClass, targetPath);
         }
         else
         {
-            message = await MoveMethodsTool.MoveInstanceMethodInFile(
+            message = await MoveMethodFileService.MoveInstanceMethodInFile(
                 document.FilePath!,
                 sourceClass,
                 methodName,
@@ -99,7 +100,7 @@ public static partial class MoveMultipleMethodsTool
 
             // Check upfront if any methods have already been moved
             foreach (var methodName in methodNames)
-                MoveMethodsTool.EnsureNotAlreadyMoved(filePath, methodName);
+                MoveMethodTool.EnsureNotAlreadyMoved(filePath, methodName);
 
             var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
             var document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
@@ -120,7 +121,7 @@ public static partial class MoveMultipleMethodsTool
                 var visitor = new MethodAndMemberVisitor();
                 visitor.Visit(sourceClassNode);
 
-                var accessMemberName = MoveMethodsTool.GenerateAccessMemberName(visitor.Members.Keys, targetClass);
+                var accessMemberName = MoveMethodAst.GenerateAccessMemberName(visitor.Members.Keys, targetClass);
 
                 var staticWalker = new MethodStaticWalker(methodNames);
                 staticWalker.Visit(sourceClassNode);
@@ -175,7 +176,7 @@ public static partial class MoveMultipleMethodsTool
                 }
 
                 foreach (var (file, method) in moved)
-                    MoveMethodsTool.MarkMoved(file, method);
+                    MoveMethodTool.MarkMoved(file, method);
 
                 return string.Join("\n", results);
             }

--- a/RefactorMCP.Tests/MoveMethodsHelpersTests.cs
+++ b/RefactorMCP.Tests/MoveMethodsHelpersTests.cs
@@ -1,5 +1,6 @@
 using Xunit;
 using System.Collections.Generic;
+using RefactorMCP.ConsoleApp.Move;
 
 namespace RefactorMCP.Tests;
 
@@ -10,7 +11,7 @@ public class MoveMethodsHelpersTests
     {
         var existing = new HashSet<string> { "field1", "field2" };
 
-        var result = MoveMethodsTool.GenerateAccessMemberName(existing, "TargetClass");
+        var result = MoveMethodAst.GenerateAccessMemberName(existing, "TargetClass");
 
         Assert.Equal("_targetClass", result);
         Assert.DoesNotContain(result, existing);
@@ -21,7 +22,7 @@ public class MoveMethodsHelpersTests
     {
         var existing = new HashSet<string> { "_targetClass", "_targetClass1" };
 
-        var result = MoveMethodsTool.GenerateAccessMemberName(existing, "TargetClass");
+        var result = MoveMethodAst.GenerateAccessMemberName(existing, "TargetClass");
 
         Assert.Equal("_targetClass2", result);
         Assert.DoesNotContain(result, existing);

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Formatting;
+using RefactorMCP.ConsoleApp.Move;
 
 namespace RefactorMCP.Tests.Roslyn
 {
@@ -27,13 +28,13 @@ namespace RefactorMCP.Tests.Roslyn
             {
                 if (isStatic[i])
                 {
-                    var moveResult = MoveMethodsTool.MoveStaticMethodAst(root, methodNames[i], targetClasses[i]);
-                    root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
+                    var moveResult = MoveMethodAst.MoveStaticMethodAst(root, methodNames[i], targetClasses[i]);
+                    root = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
                 }
                 else
                 {
-                    var moveResult = MoveMethodsTool.MoveInstanceMethodAst(root, sourceClasses[i], methodNames[i], targetClasses[i], accessMembers[i], accessMemberTypes[i]);
-                    root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
+                    var moveResult = MoveMethodAst.MoveInstanceMethodAst(root, sourceClasses[i], methodNames[i], targetClasses[i], accessMembers[i], accessMemberTypes[i]);
+                    root = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
                 }
             }
 
@@ -195,7 +196,7 @@ public class TargetClass
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "SourceClass",
                 "GetValue",
@@ -203,7 +204,7 @@ public class TargetClass
                 "_target",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("public static int GetValue(int value)", formatted);
@@ -227,7 +228,7 @@ public class TargetClass
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "SourceClass",
                 "GetValue",
@@ -235,7 +236,7 @@ public class TargetClass
                 "_target",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("public static int GetValue(int value, int n = 5)", formatted);
@@ -257,7 +258,7 @@ public class TargetClass
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "SourceClass",
                 "Say",
@@ -265,7 +266,7 @@ public class TargetClass
                 "_target",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("public void Say()", formatted);
@@ -294,7 +295,7 @@ public class TargetClass
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "SourceClass",
                 "AddResProduct",
@@ -302,7 +303,7 @@ public class TargetClass
                 "_target",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("resProduct.Modified += @this.Child_Modified", formatted);
@@ -330,7 +331,7 @@ class Target { }";
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "Derived",
                 "Method1",
@@ -338,7 +339,7 @@ class Target { }";
                 "_t",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("@this.Name", formatted);
@@ -357,7 +358,7 @@ public class Extracted { }";
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "A",
                 "MethodBefore",
@@ -365,7 +366,7 @@ public class Extracted { }";
                 "_extracted",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "Extracted", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Extracted", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("Extracted.MethodBefore(this)", formatted);
@@ -386,7 +387,7 @@ public class Target { }";
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "Outer",
                 "Do",
@@ -394,7 +395,7 @@ public class Target { }";
                 "_t",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("Outer.Helper", formatted);
@@ -418,7 +419,7 @@ class B { }";
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "A",
                 "Method1",
@@ -426,7 +427,7 @@ class B { }";
                 "_b",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "B", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "B", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("A.C Method1()", formatted);
@@ -451,7 +452,7 @@ public class B { }";
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "A",
                 "GetNested",
@@ -459,7 +460,7 @@ public class B { }";
                 "_b",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "B", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "B", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("A.Nested GetNested()", formatted);
@@ -485,7 +486,7 @@ public class B { }";
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "A",
                 "GetKind",
@@ -493,7 +494,7 @@ public class B { }";
                 "_b",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "B", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "B", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("A.Kind GetKind()", formatted);
@@ -515,7 +516,7 @@ public class Target { }";
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "A",
                 "Do",
@@ -523,7 +524,7 @@ public class Target { }";
                 "_t",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("internal void Helper()", formatted);
@@ -546,7 +547,7 @@ class Target { }";
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "Source",
                 "Print",
@@ -554,7 +555,7 @@ class Target { }";
                 "_t",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("@this.GetName()", formatted);
@@ -576,7 +577,7 @@ class Target { }";
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "Derived",
                 "Read",
@@ -584,7 +585,7 @@ class Target { }";
                 "_t",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("@this.Value", formatted);
@@ -617,7 +618,7 @@ class Target { }";
             var tree = CSharpSyntaxTree.ParseText(source);
             var root = tree.GetRoot();
 
-            var result = MoveMethodsTool.MoveInstanceMethodAst(
+            var result = MoveMethodAst.MoveInstanceMethodAst(
                 root,
                 "cResRoom",
                 "GetDepositServiceRequestHeaders",
@@ -625,7 +626,7 @@ class Target { }";
                 "_t",
                 "field");
 
-            var finalRoot = MoveMethodsTool.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
+            var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
             var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
 
             Assert.Contains("Username = @this.strCurrentOperatorCode", formatted);

--- a/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RefactorMCP.ConsoleApp.Move;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -18,7 +19,7 @@ public class MoveInstanceMethodTests : TestBase
         await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public class B { }");
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
 
-        var result = await MoveMethodsTool.MoveInstanceMethod(
+        var result = await MoveMethodTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "A",
@@ -51,7 +52,7 @@ public class MoveInstanceMethodTests : TestBase
         await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public static class B { }");
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
 
-        var result = await MoveMethodsTool.MoveInstanceMethod(
+        var result = await MoveMethodTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "A",
@@ -73,7 +74,7 @@ public class MoveInstanceMethodTests : TestBase
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
 
         await Assert.ThrowsAsync<McpException>(() =>
-            MoveMethodsTool.MoveInstanceMethod(
+            MoveMethodTool.MoveInstanceMethod(
                 SolutionPath,
                 testFile,
                 "A",
@@ -92,7 +93,7 @@ public class MoveInstanceMethodTests : TestBase
         await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public class B { }");
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
 
-        var result = await MoveMethodsTool.MoveInstanceMethod(
+        var result = await MoveMethodTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "A",
@@ -104,7 +105,7 @@ public class MoveInstanceMethodTests : TestBase
         Assert.Contains("Successfully moved", result);
 
         await Assert.ThrowsAsync<McpException>(() =>
-            MoveMethodsTool.MoveInstanceMethod(
+            MoveMethodTool.MoveInstanceMethod(
                 SolutionPath,
                 testFile,
                 "A",
@@ -123,7 +124,7 @@ public class MoveInstanceMethodTests : TestBase
         await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public class B { }");
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
-        var result1 = await MoveMethodsTool.MoveInstanceMethod(
+        var result1 = await MoveMethodTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "A",
@@ -132,9 +133,9 @@ public class MoveInstanceMethodTests : TestBase
         Assert.Contains("Successfully moved", result1);
 
         // Clear move tracking and try again
-        MoveMethodsTool.ResetMoveHistory();
+        MoveMethodTool.ResetMoveHistory();
 
-        var result2 = await MoveMethodsTool.MoveInstanceMethod(
+        var result2 = await MoveMethodTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "A",
@@ -152,7 +153,7 @@ public class MoveInstanceMethodTests : TestBase
         await TestUtilities.CreateTestFile(testFile, "public class A { public void Do(){} } public class B { }");
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
-        var result1 = await MoveMethodsTool.MoveInstanceMethod(
+        var result1 = await MoveMethodTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "A",
@@ -162,7 +163,7 @@ public class MoveInstanceMethodTests : TestBase
 
         await LoadSolutionTool.LoadSolution(SolutionPath);
 
-        var result2 = await MoveMethodsTool.MoveInstanceMethod(
+        var result2 = await MoveMethodTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "A",
@@ -181,7 +182,7 @@ public class MoveInstanceMethodTests : TestBase
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
 
         await Assert.ThrowsAsync<McpException>(() =>
-            MoveMethodsTool.MoveInstanceMethod(
+            MoveMethodTool.MoveInstanceMethod(
                 SolutionPath,
                 testFile,
                 "Wrong",
@@ -191,7 +192,7 @@ public class MoveInstanceMethodTests : TestBase
                 null,
                 CancellationToken.None));
 
-        var result = await MoveMethodsTool.MoveInstanceMethod(
+        var result = await MoveMethodTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "A",

--- a/RefactorMCP.Tests/Tools/MoveMethodNamespaceTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMethodNamespaceTests.cs
@@ -1,6 +1,7 @@
 using ModelContextProtocol;
 using System.IO;
 using System.Threading.Tasks;
+using RefactorMCP.ConsoleApp.Move;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -16,7 +17,7 @@ public class MoveMethodNamespaceTests : TestBase
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
 
         var targetFile = Path.Combine(Path.GetDirectoryName(testFile)!, "B.cs");
-        var result = await MoveMethodsTool.MoveInstanceMethod(
+        var result = await MoveMethodTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "A",
@@ -40,7 +41,7 @@ public class MoveMethodNamespaceTests : TestBase
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
 
         var targetFile = Path.Combine(Path.GetDirectoryName(testFile)!, "C.cs");
-        var result = await MoveMethodsTool.MoveInstanceMethod(
+        var result = await MoveMethodTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "A",

--- a/RefactorMCP.Tests/Tools/MoveMethodsFileTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMethodsFileTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using RefactorMCP.ConsoleApp.Move;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -13,7 +14,7 @@ public class MoveMethodsFileTests : TestBase
         var testFile = Path.Combine(TestOutputPath, "StaticFile.cs");
         await TestUtilities.CreateTestFile(testFile, "public class A { public static int Foo(){ return 1; } } public class B { }");
 
-        var result = await MoveMethodsTool.MoveStaticMethodInFile(
+        var result = await MoveMethodFileService.MoveStaticMethodInFile(
             testFile,
             "Foo",
             "B");
@@ -35,7 +36,7 @@ public class MoveMethodsFileTests : TestBase
         var testFile = Path.Combine(TestOutputPath, "StaticSameFile.cs");
         await TestUtilities.CreateTestFile(testFile, "public class A { public static int Foo(){ return 1; } } public class B { }");
 
-        var result = await MoveMethodsTool.MoveStaticMethodInFile(
+        var result = await MoveMethodFileService.MoveStaticMethodInFile(
             testFile,
             "Foo",
             "B",
@@ -55,7 +56,7 @@ public class MoveMethodsFileTests : TestBase
         await TestUtilities.CreateTestFile(testFile, "public class A { public int Bar(){ return 1; } } public class B { }");
 
         var targetFile = Path.Combine(Path.GetDirectoryName(testFile)!, "B.cs");
-        var result = await MoveMethodsTool.MoveInstanceMethodInFile(
+        var result = await MoveMethodFileService.MoveInstanceMethodInFile(
             testFile,
             "A",
             "Bar",
@@ -81,7 +82,7 @@ public class MoveMethodsFileTests : TestBase
         var testFile = Path.Combine(TestOutputPath, "InstanceSameFile.cs");
         await TestUtilities.CreateTestFile(testFile, "public class A { public int Bar(){ return 1; } } public class B { }");
 
-        var result = await MoveMethodsTool.MoveInstanceMethodInFile(
+        var result = await MoveMethodFileService.MoveInstanceMethodInFile(
             testFile,
             "A",
             "Bar",

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Formatting;
+using RefactorMCP.ConsoleApp.Move;
 
 public class MoveMultipleMethodsTests
 {
@@ -25,13 +26,13 @@ public class MoveMultipleMethodsTests
         {
             if (isStatic[i])
             {
-                var moveResult = MoveMethodsTool.MoveStaticMethodAst(root, methodNames[i], targetClasses[i]);
-                root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
+                var moveResult = MoveMethodAst.MoveStaticMethodAst(root, methodNames[i], targetClasses[i]);
+                root = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
             }
             else
             {
-                var moveResult = MoveMethodsTool.MoveInstanceMethodAst(root, sourceClasses[i], methodNames[i], targetClasses[i], accessMembers[i], accessMemberTypes[i]);
-                root = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
+                var moveResult = MoveMethodAst.MoveInstanceMethodAst(root, sourceClasses[i], methodNames[i], targetClasses[i], accessMembers[i], accessMemberTypes[i]);
+                root = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, targetClasses[i], moveResult.MovedMethod, moveResult.Namespace);
             }
         }
 

--- a/RefactorMCP.Tests/Tools/MoveOverrideMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveOverrideMethodTests.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using RefactorMCP.ConsoleApp.Move;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -15,8 +16,8 @@ public class MoveOverrideMethodTests
         var tree = CSharpSyntaxTree.ParseText(source);
         var root = tree.GetRoot();
 
-        var moveResult = MoveMethodsTool.MoveInstanceMethodAst(root, "Derived", "Foo", "Target", "", "");
-        var updatedRoot = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, "Target", moveResult.MovedMethod, moveResult.Namespace);
+        var moveResult = MoveMethodAst.MoveInstanceMethodAst(root, "Derived", "Foo", "Target", "", "");
+        var updatedRoot = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, "Target", moveResult.MovedMethod, moveResult.Namespace);
         var formattedRoot = Formatter.Format(updatedRoot, new AdhocWorkspace());
 
         var targetClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>()

--- a/RefactorMCP.Tests/Tools/MoveProtectedOverrideDependencyTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveProtectedOverrideDependencyTests.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using RefactorMCP.ConsoleApp.Move;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -15,8 +16,8 @@ public class MoveProtectedOverrideDependencyTests
         var tree = CSharpSyntaxTree.ParseText(source);
         var root = tree.GetRoot();
 
-        var moveResult = MoveMethodsTool.MoveInstanceMethodAst(root, "Derived", "Another", "Target", "", "");
-        var updatedRoot = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, "Target", moveResult.MovedMethod, moveResult.Namespace);
+        var moveResult = MoveMethodAst.MoveInstanceMethodAst(root, "Derived", "Another", "Target", "", "");
+        var updatedRoot = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, "Target", moveResult.MovedMethod, moveResult.Namespace);
         var formattedRoot = Formatter.Format(updatedRoot, new AdhocWorkspace());
 
         var derivedClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>().First(c => c.Identifier.ValueText == "Derived");

--- a/RefactorMCP.Tests/Tools/MoveStaticMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveStaticMethodTests.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RefactorMCP.ConsoleApp.Move;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -17,7 +18,7 @@ public class MoveStaticMethodTests : TestBase
         var testFile = Path.Combine(TestOutputPath, "MoveStaticMethod.cs");
         await TestUtilities.CreateTestFile(testFile, "public class SourceClass { public static void Foo(){} } public class TargetClass { } ");
 
-        var result = await MoveMethodsTool.MoveStaticMethod(
+        var result = await MoveMethodTool.MoveStaticMethod(
             SolutionPath,
             testFile,
             "Foo",
@@ -39,7 +40,7 @@ public class MoveStaticMethodTests : TestBase
         var testFile = Path.Combine(TestOutputPath, "MoveStaticWithUsings.cs");
         await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForMoveStaticMethodWithUsings());
 
-        var result = await MoveMethodsTool.MoveStaticMethod(
+        var result = await MoveMethodTool.MoveStaticMethod(
             SolutionPath,
             testFile,
             "PrintList",

--- a/RefactorMCP.Tests/Tools/MoveVirtualMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveVirtualMethodTests.cs
@@ -2,6 +2,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
+using RefactorMCP.ConsoleApp.Move;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -16,8 +17,8 @@ public class MoveVirtualMethodTests
         var tree = CSharpSyntaxTree.ParseText(source);
         var root = tree.GetRoot();
 
-        var moveResult = MoveMethodsTool.MoveInstanceMethodAst(root, "B", "Method1", "ExtractedFromB", "", "");
-        var updatedRoot = MoveMethodsTool.AddMethodToTargetClass(moveResult.NewSourceRoot, "ExtractedFromB", moveResult.MovedMethod, moveResult.Namespace);
+        var moveResult = MoveMethodAst.MoveInstanceMethodAst(root, "B", "Method1", "ExtractedFromB", "", "");
+        var updatedRoot = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, "ExtractedFromB", moveResult.MovedMethod, moveResult.Namespace);
         var formattedRoot = Formatter.Format(updatedRoot, new AdhocWorkspace());
 
         var bClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>().First(c => c.Identifier.ValueText == "B");

--- a/RefactorMCP.Tests/Tools/PublicNestedClassTests.cs
+++ b/RefactorMCP.Tests/Tools/PublicNestedClassTests.cs
@@ -2,6 +2,7 @@ using ModelContextProtocol;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using RefactorMCP.ConsoleApp.Move;
 using Xunit;
 
 namespace RefactorMCP.Tests;
@@ -27,7 +28,7 @@ public class B { }";
         await TestUtilities.CreateTestFile(testFile, code);
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
 
-        var result = await MoveMethodsTool.MoveInstanceMethod(
+        var result = await MoveMethodTool.MoveInstanceMethod(
             SolutionPath,
             testFile,
             "A",


### PR DESCRIPTION
## Summary
- refactor move-method implementation into `RefactorMCP.ConsoleApp.Move`
- expose `MoveMethodAst`, `MoveMethodFileService` and `MoveMethodTool`
- update tooling and tests to use the new types

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_6857c7417bb08327a1a5ef3228172928