### PR TITLE
Add CancellationToken support to server tools

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/AddObserverTool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/AddObserverTool.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.ComponentModel;
+using System.Threading;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
@@ -20,7 +21,8 @@ public static class AddObserverTool
         [Description("Path to the C# file")] string filePath,
         [Description("Name of the class containing the method")] string className,
         [Description("Name of the method to raise the event from")] string methodName,
-        [Description("Name of the event to create")] string eventName)
+        [Description("Name of the event to create")] string eventName,
+        CancellationToken cancellationToken = default)
     {
         try
         {

--- a/RefactorMCP.ConsoleApp/Tools/AnalyzeRefactoringOpportunities.cs
+++ b/RefactorMCP.ConsoleApp/Tools/AnalyzeRefactoringOpportunities.cs
@@ -4,6 +4,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using RefactorMCP.ConsoleApp.SyntaxRewriters;
 using System.ComponentModel;
+using System.Threading;
 
 [McpServerToolType, McpServerPromptType]
 public static class AnalyzeRefactoringOpportunitiesTool
@@ -11,12 +12,13 @@ public static class AnalyzeRefactoringOpportunitiesTool
     [McpServerPrompt, Description("Analyze a C# file for refactoring opportunities like long methods or unused code")]
     public static async Task<string> AnalyzeRefactoringOpportunities(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
-        [Description("Path to the C# file")] string filePath)
+        [Description("Path to the C# file")] string filePath,
+        CancellationToken cancellationToken = default)
     {
         try
         {
-            var (syntaxTree, model, solution) = await LoadSyntaxTreeAndModel(solutionPath, filePath);
-            var root = await syntaxTree.GetRootAsync();
+            var (syntaxTree, model, solution) = await LoadSyntaxTreeAndModel(solutionPath, filePath, cancellationToken);
+            var root = await syntaxTree.GetRootAsync(cancellationToken);
 
             var walker = new RefactoringOpportunityWalker(model, solution);
             walker.Visit(root);
@@ -34,23 +36,23 @@ public static class AnalyzeRefactoringOpportunitiesTool
         }
     }
 
-    private static async Task<(SyntaxTree tree, SemanticModel? model, Solution? solution)> LoadSyntaxTreeAndModel(string solutionPath, string filePath)
+    private static async Task<(SyntaxTree tree, SemanticModel? model, Solution? solution)> LoadSyntaxTreeAndModel(string solutionPath, string filePath, CancellationToken cancellationToken)
     {
-        var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
+        var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath, cancellationToken);
         var document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
         if (document != null)
         {
-            var tree = await document.GetSyntaxTreeAsync();
+            var tree = await document.GetSyntaxTreeAsync(cancellationToken);
             if (tree == null)
             {
-                var (text, _) = await RefactoringHelpers.ReadFileWithEncodingAsync(filePath);
+                var (text, _) = await RefactoringHelpers.ReadFileWithEncodingAsync(filePath, cancellationToken);
                 tree = CSharpSyntaxTree.ParseText(text);
             }
-            var model = await document.GetSemanticModelAsync();
+            var model = await document.GetSemanticModelAsync(cancellationToken);
             return (tree, model, solution);
         }
 
-        var (fileText, _) = await RefactoringHelpers.ReadFileWithEncodingAsync(filePath);
+        var (fileText, _) = await RefactoringHelpers.ReadFileWithEncodingAsync(filePath, cancellationToken);
         var syntaxTree = CSharpSyntaxTree.ParseText(fileText);
         return (syntaxTree, null, null);
     }

--- a/RefactorMCP.ConsoleApp/Tools/ClassLengthMetrics.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ClassLengthMetrics.cs
@@ -6,23 +6,25 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.ComponentModel;
+using System.Threading;
 
 [McpServerToolType, McpServerPromptType]
 public static class ClassLengthMetricsTool
 {
     [McpServerPrompt, Description("List all classes in the solution with their line counts")]
     public static async Task<string> ListClassLengths(
-        [Description("Absolute path to the solution file (.sln)")] string solutionPath)
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        CancellationToken cancellationToken = default)
     {
         try
         {
-            var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath);
+            var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath, cancellationToken);
             var classes = new List<(string name, int lines)>();
             foreach (var doc in solution.Projects.SelectMany(p => p.Documents))
             {
-                var tree = await doc.GetSyntaxTreeAsync();
+                var tree = await doc.GetSyntaxTreeAsync(cancellationToken);
                 if (tree == null) continue;
-                var root = await tree.GetRootAsync();
+                var root = await tree.GetRootAsync(cancellationToken);
                 foreach (var cls in root.DescendantNodes().OfType<ClassDeclarationSyntax>())
                 {
                     var span = tree.GetLineSpan(cls.Span);

--- a/RefactorMCP.ConsoleApp/Tools/CleanupUsings.cs
+++ b/RefactorMCP.ConsoleApp/Tools/CleanupUsings.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
 using System.IO;
 using System;
+using System.Threading;
 
 [McpServerToolType]
 public static class CleanupUsingsTool
@@ -15,7 +16,8 @@ public static class CleanupUsingsTool
     [McpServerTool, Description("Remove unused using directives from a C# file (preferred for large C# file refactoring)")]
     public static async Task<string> CleanupUsings(
         [Description("Absolute path to the solution file (.sln)")] string? solutionPath,
-        [Description("Path to the C# file")] string filePath)
+        [Description("Path to the C# file")] string filePath,
+        CancellationToken cancellationToken = default)
     {
         try
         {

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToExtensionMethod.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading;
 
 [McpServerToolType]
 public static class ConvertToExtensionMethodTool
@@ -18,7 +19,8 @@ public static class ConvertToExtensionMethodTool
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file")] string filePath,
         [Description("Name of the instance method to convert")] string methodName,
-        [Description("Name of the extension class - optional, class will be automatically created if it doesn't exist or us unspecified")] string? extensionClass = null)
+        [Description("Name of the extension class - optional, class will be automatically created if it doesn't exist or us unspecified")] string? extensionClass = null,
+        CancellationToken cancellationToken = default)
     {
         try
         {

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithInstance.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading;
 
 [McpServerToolType]
 public static class ConvertToStaticWithInstanceTool
@@ -60,7 +61,8 @@ public static class ConvertToStaticWithInstanceTool
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file")] string filePath,
         [Description("Name of the method to convert")] string methodName,
-        [Description("Name for the instance parameter")] string instanceParameterName = "instance")
+        [Description("Name for the instance parameter")] string instanceParameterName = "instance",
+        CancellationToken cancellationToken = default)
     {
         try
         {

--- a/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ConvertToStaticWithParameters.cs
@@ -8,6 +8,7 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Text;
 using System.Linq;
 using System.Collections.Generic;
+using System.Threading;
 
 [McpServerToolType]
 public static class ConvertToStaticWithParametersTool
@@ -112,7 +113,8 @@ public static class ConvertToStaticWithParametersTool
     public static async Task<string> ConvertToStaticWithParameters(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file")] string filePath,
-        [Description("Name of the method to convert")] string methodName)
+        [Description("Name of the method to convert")] string methodName,
+        CancellationToken cancellationToken = default)
     {
         try
         {

--- a/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MakeFieldReadonly.cs
@@ -6,6 +6,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Formatting;
 using System.Linq;
+using System.Threading;
 
 [McpServerToolType]
 public static class MakeFieldReadonlyTool
@@ -14,7 +15,8 @@ public static class MakeFieldReadonlyTool
     public static async Task<string> MakeFieldReadonly(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file")] string filePath,
-        [Description("Name of the field to make readonly")] string fieldName)
+        [Description("Name of the field to make readonly")] string fieldName,
+        CancellationToken cancellationToken = default)
     {
         try
         {

--- a/RefactorMCP.ConsoleApp/Tools/UnloadSolution.cs
+++ b/RefactorMCP.ConsoleApp/Tools/UnloadSolution.cs
@@ -2,13 +2,15 @@ using ModelContextProtocol.Server;
 using Microsoft.Extensions.Caching.Memory;
 using System.ComponentModel;
 using System.IO;
+using System.Threading;
 
 [McpServerToolType]
 public static class UnloadSolutionTool
 {
     [McpServerTool, Description("Unload a solution and remove it from the cache")]
     public static string UnloadSolution(
-        [Description("Absolute path to the solution file (.sln)")] string solutionPath)
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        CancellationToken cancellationToken = default)
     {
         if (RefactoringHelpers.SolutionCache.TryGetValue(solutionPath, out _))
         {
@@ -20,7 +22,8 @@ public static class UnloadSolutionTool
     }
 
     [McpServerTool, Description("Clear all cached solutions")]
-    public static string ClearSolutionCache()
+    public static string ClearSolutionCache(
+        CancellationToken cancellationToken = default)
     {
         RefactoringHelpers.ClearAllCaches();
         return "Cleared all cached solutions";


### PR DESCRIPTION
## Summary
- add `CancellationToken` parameter to many `[McpServerTool]` methods
- propagate the token through Roslyn operations
- fix compile error in `MoveClassToFile`

## Testing
- `dotnet format --no-restore`
- `dotnet build`
- `dotnet test --no-build` *(fails: VSTestTask returned false without logging an error)*

------
https://chatgpt.com/codex/tasks/task_e_68582c2785e48327a4b88dc72c78a76b