### PR TITLE
Default ctor injection for multiple method moves

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -40,7 +40,7 @@ public static partial class MoveMultipleMethodsTool
                 document.FilePath!,
                 sourceClass,
                 methodName,
-                Array.Empty<string>(),
+                new[] { "this" },
                 Array.Empty<string>(),
                 targetClass,
                 accessMember,

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsConstructorInjectionTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsConstructorInjectionTests.cs
@@ -1,0 +1,36 @@
+using ModelContextProtocol;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public class MoveMultipleMethodsConstructorInjectionTests : TestBase
+{
+    [Fact]
+    public async Task MoveMultipleMethods_ConstructorInjection_UsesThis()
+    {
+        UnloadSolutionTool.ClearSolutionCache();
+        var testFile = Path.Combine(TestOutputPath, "MultiCtor.cs");
+        var code = "public class cA{ public int Value=>1; public int Get(){ return Value; } public int Add(int x){ return x + Value; } } public class B{ }";
+        await TestUtilities.CreateTestFile(testFile, code);
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);
+        var project = solution.Projects.First();
+        RefactoringHelpers.AddDocumentToProject(project, testFile);
+
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+            SolutionPath,
+            testFile,
+            "cA",
+            new[] { "Get", "Add" },
+            "B");
+
+        Assert.Contains("Successfully moved", result);
+        var targetPath = Path.Combine(Path.GetDirectoryName(testFile)!, "B.cs");
+        var content = await File.ReadAllTextAsync(targetPath);
+        Assert.Contains("private readonly cA _a", content);
+    }
+}


### PR DESCRIPTION
## Summary
- inject `this` via constructor when moving multiple instance methods
- add test verifying constructor injection for multiple methods

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build -v n`

------
https://chatgpt.com/codex/tasks/task_e_68596226a6f4832791ffba43f390ac28