### PR TITLE
Fix MoveMultipleMethods parameter injection

### DIFF
--- a/RefactorMCP.ConsoleApp/Move/MoveMethodAst.cs
+++ b/RefactorMCP.ConsoleApp/Move/MoveMethodAst.cs
@@ -465,7 +465,8 @@ public static partial class MoveMethodAst
                 callsOtherMethods,
                 isRecursive,
                 instanceMembers,
-                otherMethodNames);
+                otherMethodNames,
+                thisParameterName);
         }
 
         if (injectedParameters.Count > 0)
@@ -514,9 +515,11 @@ public static partial class MoveMethodAst
         bool callsOtherMethods,
         bool isRecursive,
         HashSet<string> instanceMembers,
-        HashSet<string> otherMethodNames)
+        HashSet<string> otherMethodNames,
+        string parameterName)
     {
-        var parameterName = "@this";
+        if (string.IsNullOrEmpty(parameterName))
+            parameterName = "@this";
 
         if (usesInstanceMembers)
         {


### PR DESCRIPTION
## Summary
- ensure `MoveMultipleMethodsTool` always keeps the injected `this` parameter

## Testing
- `dotnet build --no-restore -c Release`
- `dotnet test --no-build -c Release --verbosity minimal`
- `dotnet format --no-restore --verify-no-changes`


------
https://chatgpt.com/codex/tasks/task_e_6859c54be90c83278f976f55b46b62f3