### PR TITLE
Remove CLI mode and add ListTools tool

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -1,6 +1,6 @@
 # RefactorMCP Examples
 
-This document provides comprehensive examples for all refactoring tools available in RefactorMCP. Each example shows the before/after code and the exact CLI commands to perform the refactoring.
+This document provides comprehensive examples for all refactoring tools available in RefactorMCP. Each example shows the before/after code and the JSON command needed to perform the refactoring.
 
 Using the MCP tools is the preferred method for refactoring large C# files where manual edits become cumbersome.
 
@@ -10,7 +10,7 @@ Using the MCP tools is the preferred method for refactoring large C# files where
 Before performing any refactoring, you need to load a solution. This also clears any cached data so each load starts a fresh session:
 
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --cli load-solution ./RefactorMCP.sln
+dotnet run --project RefactorMCP.ConsoleApp -- --json load-solution '{"solutionPath":"./RefactorMCP.sln"}'
 ```
 
 ### JSON Example
@@ -18,14 +18,8 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli load-solution ./RefactorMCP
 {"tool":"load-solution","solutionPath":"./RefactorMCP.sln"}
 ```
 
-### CLI Mode Usage
-All examples use the CLI syntax:
-```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --cli <command> [arguments]
-```
-
 ### JSON Mode Usage
-Parameters can also be passed as JSON:
+All examples use JSON parameters:
 ```bash
 dotnet run --project RefactorMCP.ConsoleApp -- --json ToolName '{"param":"value"}'
 ```
@@ -786,7 +780,7 @@ Running the command again with the correct `sourceClass` succeeds.
 ### Example
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --cli list-tools
+dotnet run --project RefactorMCP.ConsoleApp -- --json ListTools '{}'
 ```
 
 **Output**:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ For usage examples see [EXAMPLES.md](./EXAMPLES.md).
 - **Create Adapter** – generate an adapter class wrapping an existing method.
 - **Add Observer** – introduce an event and raise it from a method.
 - **Use Interface** – change a method parameter type to one of its implemented interfaces.
+- **List Tools** – display all available refactoring tools as kebab-case names.
 
 Metrics and summaries are also available via the `metrics://` and `summary://` resource schemes.
 

--- a/RefactorMCP.ConsoleApp/RefactorMCP.ConsoleApp.csproj
+++ b/RefactorMCP.ConsoleApp/RefactorMCP.ConsoleApp.csproj
@@ -16,7 +16,6 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.0" />
     <PackageReference Include="ModelContextProtocol" Version="0.2.0-preview.3" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
 
 </Project>

--- a/RefactorMCP.ConsoleApp/Tools/ListTools.cs
+++ b/RefactorMCP.ConsoleApp/Tools/ListTools.cs
@@ -1,0 +1,37 @@
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+[McpServerToolType]
+public static class ListTools
+{
+    [McpServerTool, Description("List all available refactoring tools")]
+    public static string ListToolsCommand()
+    {
+        var toolNames = typeof(LoadSolutionTool).Assembly
+            .GetTypes()
+            .Where(t => t.GetCustomAttributes(typeof(McpServerToolTypeAttribute), false).Any())
+            .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
+            .Where(m => m.GetCustomAttributes(typeof(McpServerToolAttribute), false).Any())
+            .Select(m => ToKebabCase(m.Name))
+            .OrderBy(n => n)
+            .ToArray();
+
+        return string.Join('\n', toolNames);
+    }
+
+    private static string ToKebabCase(string name)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < name.Length; i++)
+        {
+            var c = name[i];
+            if (char.IsUpper(c) && i > 0)
+                sb.Append('-');
+            sb.Append(char.ToLowerInvariant(c));
+        }
+        return sb.ToString();
+    }
+}

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -9,7 +9,7 @@ This extension exposes [RefactorMCP](../README.md) tools to Visual Studio Code.
 
 ### Available Tools
 
-Output of `list-tools`:
+Output of `ListTools`:
 
 ```
 cleanup-usings

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -11,25 +11,6 @@ function getWorkspaceFolder(): string | undefined {
     return folder.uri.fsPath;
 }
 
-function runCli(command: string, args: string[]): Thenable<string> {
-    const config = vscode.workspace.getConfiguration();
-    const dotnetPath = config.get<string>('refactorMcp.dotnetPath', 'dotnet');
-    const workspaceFolder = getWorkspaceFolder();
-    if (!workspaceFolder) {
-        return Promise.reject('No workspace');
-    }
-    const projectPath = path.join(workspaceFolder, 'RefactorMCP.ConsoleApp');
-    const commandArgs = ['run', '--project', projectPath, '--', '--cli', command, ...args];
-    return new Promise((resolve, reject) => {
-        execFile(dotnetPath, commandArgs, { cwd: workspaceFolder }, (err, stdout, stderr) => {
-            if (err) {
-                reject(stderr || err.message);
-            } else {
-                resolve(stdout);
-            }
-        });
-    });
-}
 
 function runJson(toolName: string, json: string): Thenable<string> {
     const config = vscode.workspace.getConfiguration();
@@ -53,11 +34,11 @@ function runJson(toolName: string, json: string): Thenable<string> {
 
 async function getAvailableTools(): Promise<string[]> {
     try {
-        const output = await runCli('list-tools', []);
+        const output = await runJson('ListTools', '{}');
         return output
             .split(/\r?\n/)
             .map(l => l.trim())
-            .filter(l => l && !l.startsWith('Available'));
+            .filter(l => l.length > 0);
     } catch {
         return [];
     }


### PR DESCRIPTION
## Summary
- drop `--cli` support from the console app
- provide a JSON-based `ListTools` utility
- update VS Code extension to use `ListTools`
- document the change and add examples

## Testing
- `dotnet test RefactorMCP.sln`

------
https://chatgpt.com/codex/tasks/task_e_6859df980d94832792067f6a769ffb1a