### PR TITLE
Add invalid observer tests to ToolsNew

### DIFF
--- a/RefactorMCP.Tests/ToolsNew/AddObserverToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/AddObserverToolTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using ModelContextProtocol;
 using Xunit;
 
 namespace RefactorMCP.Tests.ToolsNew;
@@ -47,5 +48,53 @@ public class Counter
         var fileContent = await File.ReadAllTextAsync(testFile);
         Assert.Contains("public event", fileContent);
         Assert.Contains("Updated?.Invoke()", fileContent);
+    }
+
+    [Fact]
+    public async Task AddObserver_InvalidClassName_ThrowsMcpException()
+    {
+        const string initialCode = """
+public class Counter
+{
+    public void Update() { }
+}
+""";
+
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var testFile = Path.Combine(TestOutputPath, "Observer.cs");
+        await TestUtilities.CreateTestFile(testFile, initialCode);
+
+        McpException ex = await Assert.ThrowsAsync<McpException>(() => AddObserverTool.AddObserver(
+            SolutionPath,
+            testFile,
+            "WrongClass",
+            "Update",
+            "Updated"));
+
+        Assert.Equal("Error adding observer: Error: Class 'WrongClass' not found", ex.Message);
+    }
+
+    [Fact]
+    public async Task AddObserver_InvalidMethodName_ThrowsMcpException()
+    {
+        const string initialCode = """
+public class Counter
+{
+    public void Update() { }
+}
+""";
+
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var testFile = Path.Combine(TestOutputPath, "Observer.cs");
+        await TestUtilities.CreateTestFile(testFile, initialCode);
+
+        McpException ex = await Assert.ThrowsAsync<McpException>(() => AddObserverTool.AddObserver(
+            SolutionPath,
+            testFile,
+            "Counter",
+            "WrongMethod",
+            "Updated"));
+
+        Assert.Equal("Error adding observer: Error: Method 'WrongMethod' not found", ex.Message);
     }
 }


### PR DESCRIPTION
## Summary
- add missing ModelContextProtocol using
- port invalid class/method tests to ToolsNew AddObserverToolTests

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build --logger "console;verbosity=normal"`

------
https://chatgpt.com/codex/tasks/task_e_685a92997fe08327bf5cdeb6b84777ea