### PR TITLE
Add MoveStaticMethodTool compilation test

### DIFF
--- a/RefactorMCP.Tests/ToolsNew/MoveStaticMethodToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/MoveStaticMethodToolTests.cs
@@ -1,6 +1,8 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using RefactorMCP.ConsoleApp.Move;
 using Xunit;
 
@@ -54,5 +56,38 @@ public class TargetClass
         var targetFile = Path.Combine(TestOutputPath, "TargetClass.cs");
         var targetContent = await File.ReadAllTextAsync(targetFile);
         Assert.Contains("static int Foo", targetContent);
+    }
+
+    [Fact]
+    public async Task MoveStaticMethod_AddsUsingsAndCompiles()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var testFile = Path.Combine(TestOutputPath, "MoveStaticWithUsings.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForMoveStaticMethodWithUsings());
+
+        var result = await MoveMethodTool.MoveStaticMethod(
+            SolutionPath,
+            testFile,
+            "PrintList",
+            "UtilClass");
+
+        Assert.Contains("Successfully moved static method", result);
+        var targetFile = Path.Combine(TestOutputPath, "UtilClass.cs");
+        var fileContent = await File.ReadAllTextAsync(targetFile);
+        Assert.Contains("using System", fileContent);
+        Assert.Contains("using System.Collections.Generic", fileContent);
+
+        var syntaxTree = CSharpSyntaxTree.ParseText(fileContent);
+        var refs = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))!
+            .Split(Path.PathSeparator)
+            .Select(p => MetadataReference.CreateFromFile(p));
+        var compilation = CSharpCompilation.Create(
+            "test",
+            new[] { syntaxTree },
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        var diagnostics = compilation.GetDiagnostics();
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
     }
 }


### PR DESCRIPTION
## Summary
- port compilation verification from MoveStaticMethodTests to `ToolsNew`
- verify that moved static method file contains needed usings and compiles

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build --verbosity minimal` *(failed: Test run did not complete)*

------
https://chatgpt.com/codex/tasks/task_e_685a92a3074c832784216a1c45520235