### PR TITLE
Add missing tests for MakeFieldReadonly tool

### DIFF
--- a/RefactorMCP.Tests/ToolsNew/MakeFieldReadonlyToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/MakeFieldReadonlyToolTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using ModelContextProtocol;
 using Xunit;
 
 namespace RefactorMCP.Tests.ToolsNew;
@@ -38,5 +39,49 @@ public class Sample
         Assert.Contains("Successfully made field", result);
         var fileContent = await File.ReadAllTextAsync(testFile);
         Assert.Equal(expectedCode, fileContent.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public async Task MakeFieldReadonly_FieldWithoutInitializer_AddsReadonly()
+    {
+        const string initialCode = """
+public class Sample
+{
+    private string description;
+}
+""";
+
+        const string expectedCode = """
+public class Sample
+{
+    private readonly string description;
+}
+""";
+
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var testFile = Path.Combine(TestOutputPath, "ReadonlyNoInit.cs");
+        await TestUtilities.CreateTestFile(testFile, initialCode);
+
+        var result = await MakeFieldReadonlyTool.MakeFieldReadonly(
+            SolutionPath,
+            testFile,
+            "description");
+
+        Assert.Contains("Successfully made field 'description' readonly", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.Equal(expectedCode, fileContent.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public async Task MakeFieldReadonly_InvalidIdentifier_ReturnsError()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+
+        McpException ex = await Assert.ThrowsAsync<McpException>(() => MakeFieldReadonlyTool.MakeFieldReadonly(
+            SolutionPath,
+            ExampleFilePath,
+            "nonexistent"));
+
+        Assert.Equal("Error: Error: No field named 'nonexistent' found", ex.Message);
     }
 }


### PR DESCRIPTION
## Summary
- port tests for fields without initializers and invalid identifiers from the older suite
- assert expected error message when a field is not found

## Testing
- `dotnet format --no-restore -v diag`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685a932b065c832789f41e1b082cdc5d