### PR TITLE
Expand IntroduceField tool tests

### DIFF
--- a/RefactorMCP.Tests/ToolsNew/IntroduceFieldToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/IntroduceFieldToolTests.cs
@@ -51,4 +51,55 @@ public class Sample
         Assert.Contains("_avg", fileContent);
         Assert.Contains("values.Sum()", fileContent);
     }
+
+    [Fact]
+    public async Task IntroduceField_SupportsAccessModifiers()
+    {
+        const string code = """
+using System.Linq;
+
+public class Sample
+{
+    public double GetAverage(int[] values)
+    {
+        return values.Sum() / (double)values.Length;
+    }
+}
+""";
+        var modifiers = new[] { "public", "protected", "internal" };
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        foreach (var modifier in modifiers)
+        {
+            var file = Path.Combine(TestOutputPath, $"Access_{modifier}.cs");
+            await TestUtilities.CreateTestFile(file, code);
+
+            var result = await IntroduceFieldTool.IntroduceField(
+                SolutionPath,
+                file,
+                "6:16-6:57",
+                $"_{modifier}Field",
+                modifier);
+
+            Assert.Contains($"Successfully introduced {modifier} field", result);
+            var content = await File.ReadAllTextAsync(file);
+            Assert.Contains($"_{modifier}Field", content);
+        }
+    }
+
+    [Fact]
+    public async Task IntroduceField_FieldNameAlreadyExists_ReturnsError()
+    {
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var testFile = Path.Combine(TestOutputPath, "DuplicateField.cs");
+        await TestUtilities.CreateTestFile(testFile, TestUtilities.GetSampleCodeForIntroduceField());
+
+        var result = await IntroduceFieldTool.IntroduceField(
+            SolutionPath,
+            testFile,
+            "36:20-36:56",
+            "numbers",
+            "private");
+
+        Assert.Equal("Error: Field 'numbers' already exists", result);
+    }
 }


### PR DESCRIPTION
## Summary
- extend IntroduceFieldToolTests with coverage for access modifiers
- add test for duplicate field name scenario

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685a9398ff008327841e803f3683d6cf