### PR TITLE
Add SafeDelete tool tests

### DIFF
--- a/RefactorMCP.Tests/ToolsNew/SafeDeleteToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/SafeDeleteToolTests.cs
@@ -36,4 +36,73 @@ public class Sample
         var fileContent = await File.ReadAllTextAsync(testFile);
         Assert.Equal(expectedCode, fileContent.Replace("\r\n", "\n"));
     }
+
+    [Fact]
+    public async Task SafeDeleteMethod_RemovesUnusedMethod()
+    {
+        const string initialCode = """
+public class Sample
+{
+    private void UnusedHelper()
+    {
+        int tempValue = 0;
+    }
+}
+""";
+
+        const string expectedCode = """
+public class Sample
+{
+}
+""";
+
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var testFile = Path.Combine(TestOutputPath, "SafeDeleteMethod.cs");
+        await TestUtilities.CreateTestFile(testFile, initialCode);
+
+        var result = await SafeDeleteTool.SafeDeleteMethod(
+            SolutionPath,
+            testFile,
+            "UnusedHelper");
+
+        Assert.Contains("Successfully deleted method", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.Equal(expectedCode, fileContent.Replace("\r\n", "\n"));
+    }
+
+    [Fact]
+    public async Task SafeDeleteVariable_RemovesUnusedLocal()
+    {
+        const string initialCode = """
+public class Sample
+{
+    public void DoWork()
+    {
+        int tempValue = 0;
+    }
+}
+""";
+
+        const string expectedCode = """
+public class Sample
+{
+    public void DoWork()
+    {
+    }
+}
+""";
+
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+        var testFile = Path.Combine(TestOutputPath, "SafeDeleteVariable.cs");
+        await TestUtilities.CreateTestFile(testFile, initialCode);
+
+        var result = await SafeDeleteTool.SafeDeleteVariable(
+            SolutionPath,
+            testFile,
+            "5:9-5:26");
+
+        Assert.Contains("Successfully deleted variable", result);
+        var fileContent = await File.ReadAllTextAsync(testFile);
+        Assert.Equal(expectedCode, fileContent.Replace("\r\n", "\n"));
+    }
 }


### PR DESCRIPTION
## Summary
- port SafeDelete tests for deleting an unused method and unused local
- add new inline-code tests in ToolsNew

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build`

------
https://chatgpt.com/codex/tasks/task_e_685a93b314788327a5db2440320f8336