### PR TITLE
Enable parallel test execution

### DIFF
--- a/RefactorMCP.Tests/AssemblyInfo.cs
+++ b/RefactorMCP.Tests/AssemblyInfo.cs
@@ -1,2 +1,4 @@
 using Xunit;
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
+// Enable test parallelization to speed up the suite. TestBase creates isolated
+// output directories for each test instance so parallel execution is safe.
+// The default xUnit settings will run tests in parallel within each assembly.

--- a/RefactorMCP.Tests/Tools/TestBase.cs
+++ b/RefactorMCP.Tests/Tools/TestBase.cs
@@ -7,11 +7,15 @@ public abstract class TestBase : IDisposable
 {
     protected static readonly string SolutionPath = TestUtilities.GetSolutionPath();
     protected static readonly string ExampleFilePath = Path.Combine(Path.GetDirectoryName(SolutionPath)!, "RefactorMCP.Tests", "ExampleCode.cs");
-    protected static readonly string TestOutputPath =
+    private static readonly string TestOutputRoot =
         Path.Combine(Path.GetDirectoryName(SolutionPath)!, "RefactorMCP.Tests", "TestOutput");
+
+    protected string TestOutputPath { get; }
 
     protected TestBase()
     {
+        Directory.CreateDirectory(TestOutputRoot);
+        TestOutputPath = Path.Combine(TestOutputRoot, Guid.NewGuid().ToString());
         Directory.CreateDirectory(TestOutputPath);
     }
 


### PR DESCRIPTION
## Summary
- allow tests to run concurrently by removing the parallelization block
- isolate per-test output folders

## Testing
- `dotnet format --no-restore`
- `dotnet test --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_685a8a5bc0788327bd9f4754c0fcc3c4