### PR TITLE
Add SyntaxWalker tests

### DIFF
--- a/RefactorMCP.Tests/SyntaxWalkers/AccessMemberTypeWalkerTests.cs
+++ b/RefactorMCP.Tests/SyntaxWalkers/AccessMemberTypeWalkerTests.cs
@@ -1,0 +1,28 @@
+using Microsoft.CodeAnalysis.CSharp;
+using RefactorMCP.ConsoleApp.SyntaxWalkers;
+using Xunit;
+
+namespace RefactorMCP.Tests.SyntaxWalkers;
+
+public class AccessMemberTypeWalkerTests
+{
+    [Fact]
+    public void AccessMemberTypeWalker_FindsField()
+    {
+        var code = @"class C { int _a; int P { get; set; } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var walker = new AccessMemberTypeWalker("_a");
+        walker.Visit(tree.GetRoot());
+        Assert.Equal("field", walker.MemberType);
+    }
+
+    [Fact]
+    public void AccessMemberTypeWalker_FindsProperty()
+    {
+        var code = @"class C { int _a; int P { get; set; } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var walker = new AccessMemberTypeWalker("P");
+        walker.Visit(tree.GetRoot());
+        Assert.Equal("property", walker.MemberType);
+    }
+}

--- a/RefactorMCP.Tests/SyntaxWalkers/ComplexityWalkerTests.cs
+++ b/RefactorMCP.Tests/SyntaxWalkers/ComplexityWalkerTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.CodeAnalysis.CSharp;
+using RefactorMCP.ConsoleApp.SyntaxWalkers;
+using Xunit;
+
+namespace RefactorMCP.Tests.SyntaxWalkers;
+
+public class ComplexityWalkerTests
+{
+    [Fact]
+    public void ComplexityWalker_ComputesComplexityAndDepth()
+    {
+        var code = @"class C
+{
+    void M()
+    {
+        if (true)
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                if (false) { }
+            }
+        }
+    }
+}";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var walker = new ComplexityWalker();
+        walker.Visit(tree.GetRoot());
+        Assert.Equal(4, walker.Complexity);
+        Assert.Equal(3, walker.MaxDepth);
+    }
+}

--- a/RefactorMCP.Tests/SyntaxWalkers/MethodCollectorWalkerTests.cs
+++ b/RefactorMCP.Tests/SyntaxWalkers/MethodCollectorWalkerTests.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp;
+using RefactorMCP.ConsoleApp.SyntaxWalkers;
+using Xunit;
+
+namespace RefactorMCP.Tests.SyntaxWalkers;
+
+public class MethodCollectorWalkerTests
+{
+    [Fact]
+    public void MethodCollectorWalker_CollectsSpecifiedMethods()
+    {
+        var code = @"class A { void X(){} void Y(){} } class B { void X(){} }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var walker = new MethodCollectorWalker(new HashSet<string> { "A.X", "B.X" });
+        walker.Visit(tree.GetRoot());
+        Assert.Contains("A.X", walker.Methods.Keys);
+        Assert.Contains("B.X", walker.Methods.Keys);
+        Assert.DoesNotContain("A.Y", walker.Methods.Keys);
+    }
+}

--- a/RefactorMCP.Tests/SyntaxWalkers/MethodMetricsWalkerTests.cs
+++ b/RefactorMCP.Tests/SyntaxWalkers/MethodMetricsWalkerTests.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using RefactorMCP.ConsoleApp.SyntaxWalkers;
+using Xunit;
+
+namespace RefactorMCP.Tests.SyntaxWalkers;
+
+public class MethodMetricsWalkerTests
+{
+    [Fact]
+    public void MethodMetricsWalker_DetectsParameterObjectOpportunity()
+    {
+        var code = @"class C { void Foo(int a, int b, int c, int d, int e) { } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var walker = new MethodMetricsWalker(null);
+        walker.Visit(tree.GetRoot());
+        Assert.Contains("Method 'Foo' has 5 parameters", walker.Suggestions.First());
+    }
+
+    [Fact]
+    public void MethodMetricsWalker_SuggestsMakeStaticWhenNoInstanceUsage()
+    {
+        var code = @"class C { private int x; void Foo() { int y = 0; } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var refs = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES"))!
+            .Split(Path.PathSeparator)
+            .Select(p => MetadataReference.CreateFromFile(p));
+        var compilation = CSharpCompilation.Create(
+            "test",
+            new[] { tree },
+            refs,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var model = compilation.GetSemanticModel(tree);
+        var walker = new MethodMetricsWalker(model);
+        walker.Visit(tree.GetRoot());
+        Assert.Contains("Method 'Foo' does not access instance state", walker.Suggestions.First());
+    }
+}

--- a/RefactorMCP.Tests/SyntaxWalkers/PrivateFieldInfoWalkerTests.cs
+++ b/RefactorMCP.Tests/SyntaxWalkers/PrivateFieldInfoWalkerTests.cs
@@ -1,0 +1,20 @@
+using Microsoft.CodeAnalysis.CSharp;
+using RefactorMCP.ConsoleApp.SyntaxWalkers;
+using Xunit;
+
+namespace RefactorMCP.Tests.SyntaxWalkers;
+
+public class PrivateFieldInfoWalkerTests
+{
+    [Fact]
+    public void PrivateFieldInfoWalker_CollectsPrivateFields()
+    {
+        var code = @"class C { private int a; string b; private string c; }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var walker = new PrivateFieldInfoWalker();
+        walker.Visit(tree.GetRoot());
+        Assert.Equal(2, walker.Infos.Count);
+        Assert.Contains("a", walker.Infos.Keys);
+        Assert.Contains("c", walker.Infos.Keys);
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated SyntaxWalkers folder to the test project
- cover ComplexityWalker, MethodMetricsWalker, MethodCollectorWalker, AccessMemberTypeWalker and PrivateFieldInfoWalker

## Testing
- `dotnet format --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685b0a013cec8327a0b44b77cdfa69a9