### PR TITLE
Add SyntaxWalker tests

### DIFF
--- a/RefactorMCP.Tests/Roslyn/Walkers/AccessMemberTypeWalkerTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Walkers/AccessMemberTypeWalkerTests.cs
@@ -1,0 +1,25 @@
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using RefactorMCP.ConsoleApp.SyntaxWalkers;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void AccessMemberTypeWalker_DetectsFieldAndProperty()
+    {
+        const string code = "class C { int f; string P { get; } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+
+        var fieldWalker = new AccessMemberTypeWalker("f");
+        fieldWalker.Visit(root);
+        Assert.Equal("field", fieldWalker.MemberType);
+
+        var propWalker = new AccessMemberTypeWalker("P");
+        propWalker.Visit(root);
+        Assert.Equal("property", propWalker.MemberType);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Walkers/ComplexityWalkerTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Walkers/ComplexityWalkerTests.cs
@@ -1,0 +1,22 @@
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RefactorMCP.ConsoleApp.SyntaxWalkers;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void ComplexityWalker_ComputesComplexityAndDepth()
+    {
+        const string code = "class C { void M() { if(true){ for(int i=0;i<1;i++){ } } } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var method = tree.GetRoot().DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+        var walker = new ComplexityWalker();
+        walker.Visit(method);
+        Assert.Equal(3, walker.Complexity);
+        Assert.Equal(2, walker.MaxDepth);
+    }
+}

--- a/RefactorMCP.Tests/Roslyn/Walkers/MethodAnalysisWalkerTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Walkers/MethodAnalysisWalkerTests.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using RefactorMCP.ConsoleApp.SyntaxWalkers;
+using Xunit;
+
+namespace RefactorMCP.Tests;
+
+public partial class RoslynTransformationTests
+{
+    [Fact]
+    public void MethodAnalysisWalker_DetectsUsageAndCalls()
+    {
+        const string code = @"class C { int x; void A(){ x = 1; B(); } void B(){} }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+        var methodA = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First(m => m.Identifier.ValueText == "A");
+        var instanceMembers = new HashSet<string> { "x" };
+        var methodNames = new HashSet<string> { "A", "B" };
+        var walker = new MethodAnalysisWalker(instanceMembers, methodNames, "A");
+        walker.Visit(methodA);
+        Assert.True(walker.UsesInstanceMembers);
+        Assert.True(walker.CallsOtherMethods);
+        Assert.False(walker.IsRecursive);
+    }
+
+    [Fact]
+    public void MethodAnalysisWalker_DetectsRecursion()
+    {
+        const string code = @"class C { void A(){ A(); } }";
+        var tree = CSharpSyntaxTree.ParseText(code);
+        var root = tree.GetRoot();
+        var methodA = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
+        var methodNames = new HashSet<string> { "A" };
+        var walker = new MethodAnalysisWalker(new HashSet<string>(), methodNames, "A");
+        walker.Visit(methodA);
+        Assert.True(walker.IsRecursive);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for AccessMemberTypeWalker, ComplexityWalker, and MethodAnalysisWalker
- organize SyntaxWalker tests in a dedicated folder

## Testing
- `dotnet format --no-restore --verbosity normal`
- `dotnet build --no-restore`
- `dotnet test --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_685b0a09f9c8832782859ddbde2c7dce