### PR TITLE
Add separate tools for moving multiple methods

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -456,7 +456,7 @@ class Target { }
 
 **Command**:
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods-instance \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   Helper \
@@ -469,13 +469,25 @@ dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
 Move methods to a separate file using the `targetFile` property or by passing a default path:
 
 ```bash
-dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods \
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods-instance \
   "./RefactorMCP.sln" \
   "./RefactorMCP.Tests/ExampleCode.cs" \
   Helper \
   A \
   Target \
   "./Target.cs"
+```
+
+### Static Parameter Injection
+Move the same methods but convert them to static members with an explicit `this` parameter:
+
+```bash
+dotnet run --project RefactorMCP.ConsoleApp -- --cli move-multiple-methods-static \
+  "./RefactorMCP.sln" \
+  "./RefactorMCP.Tests/ExampleCode.cs" \
+  Helper \
+  "A,B" \
+  Target
 ```
 
 **After**:
@@ -798,6 +810,8 @@ convert-to-static-with-parameters - Transform instance method to static
 convert-to-static-with-instance - Transform instance method to static with instance parameter
 move-static-method - Move a static method to another class
 move-instance-method - Move an instance method to another class
+move-multiple-methods-instance - Move several methods and keep them as instance methods
+move-multiple-methods-static - Move several methods and convert them to static with a `this` parameter
 transform-setter-to-init - Convert property setter to init-only setter
 safe-delete - Safely delete a field, parameter, or variable
 
@@ -1279,10 +1293,10 @@ When a tool needs to create a new file, the namespace uses the file-scoped style
 ```
 
 ### Overloaded Methods Example
-`move-multiple-methods` now works when the source class contains overloaded methods:
+`move-multiple-methods-static` now works when the source class contains overloaded methods:
 
 ```json
-{"tool":"move-multiple-methods","solutionPath":"./RefactorMCP.sln","filePath":"./RefactorMCP.Tests/ExampleCode.cs","sourceClass":"Helper","methodNames":["A","A"],"targetClass":"Target","targetFilePath":"./Target.cs"}
+{"tool":"move-multiple-methods-static","solutionPath":"./RefactorMCP.sln","filePath":"./RefactorMCP.Tests/ExampleCode.cs","sourceClass":"Helper","methodNames":["A","A"],"targetClass":"Target","targetFilePath":"./Target.cs"}
 ```
 
 ### JSON Example

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ For usage examples see [EXAMPLES.md](./EXAMPLES.md).
 - **Convert to Static** – make instance methods static using parameters or an instance argument.
 - **Move Static Method** – relocate a static method and keep a wrapper in the original class.
 - **Move Instance Method** – move one or more instance methods to another class and delegate from the source. If a moved method no longer accesses instance members, it is made static automatically. Provide a `methodNames` list along with optional `constructor-injections` and `parameter-injections` to control dependencies.
+- **Move Multiple Methods (instance)** – move several methods and keep them as instance members of the target class. The source instance is injected via the constructor when required.
+- **Move Multiple Methods (static)** – move multiple methods and convert them to static, adding a `this` parameter.
 - **Make Static Then Move** – convert an instance method to static and relocate it to another class in one step.
 - **Move Type to Separate File** – move a top-level type into its own file named after the type.
 - **Make Field Readonly** – move initialization into constructors and mark the field readonly.

--- a/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMultipleMethods.Tool.cs
@@ -23,6 +23,7 @@ public static partial class MoveMultipleMethodsTool
         string sourceClass,
         string methodName,
         bool isStatic,
+        bool ctorInjection,
         string targetClass,
         string accessMember,
         string accessMemberType,
@@ -36,12 +37,14 @@ public static partial class MoveMultipleMethodsTool
         }
         else
         {
+            var ctor = ctorInjection ? new[] { "this" } : Array.Empty<string>();
+            var param = ctorInjection ? Array.Empty<string>() : new[] { "this" };
             message = await MoveMethodFileService.MoveInstanceMethodInFile(
                 document.FilePath!,
                 sourceClass,
                 methodName,
-                Array.Empty<string>(),
-                new[] { "this" },
+                ctor,
+                param,
                 targetClass,
                 accessMember,
                 accessMemberType,
@@ -76,14 +79,116 @@ public static partial class MoveMultipleMethodsTool
         return (message, updatedDoc);
     }
 
+    private static Task<string> MoveMultipleMethodsInternal(
+        string solutionPath,
+        string filePath,
+        string sourceClass,
+        string[] methodNames,
+        string targetClass,
+        string? targetFilePath,
+        bool ctorInjection,
+        CancellationToken cancellationToken)
+        => MoveMultipleMethodsCore(solutionPath, filePath, sourceClass, methodNames, targetClass, targetFilePath, ctorInjection, cancellationToken);
+
+    private static async Task<string> MoveMultipleMethodsCore(
+        string solutionPath,
+        string filePath,
+        string sourceClass,
+        string[] methodNames,
+        string targetClass,
+        string? targetFilePath,
+        bool ctorInjection,
+        CancellationToken cancellationToken)
+    {
+        if (methodNames.Length == 0)
+            throw new McpException("Error: No method names provided");
+
+        var dupes = methodNames.GroupBy(m => m).Where(g => g.Count() > 1).Select(g => g.Key).ToList();
+        if (dupes.Count > 0)
+            return $"Error: Duplicate method names are not supported: {string.Join(", ", dupes)}";
+
+        foreach (var methodName in methodNames)
+            MoveMethodTool.EnsureNotAlreadyMoved(filePath, methodName);
+
+        var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath, cancellationToken);
+        var document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
+        if (document == null)
+            throw new McpException("Error: Could not find document in solution and AST fallback is disabled.");
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken) ?? throw new McpException("Error: Could not get syntax root");
+
+        var collector = new ClassCollectorWalker();
+        collector.Visit(root);
+        if (!collector.Classes.TryGetValue(sourceClass, out var sourceClassNode))
+            throw new McpException($"Error: Source class '{sourceClass}' not found");
+
+        var visitor = new MethodAndMemberVisitor();
+        visitor.Visit(sourceClassNode);
+        var accessMemberName = MoveMethodAst.GenerateAccessMemberName(visitor.Members.Keys, targetClass);
+
+        var staticWalker = new MethodStaticWalker(methodNames);
+        staticWalker.Visit(sourceClassNode);
+
+        var memberWalker = new AccessMemberTypeWalker(accessMemberName);
+        memberWalker.Visit(sourceClassNode);
+        var instanceMemberType = memberWalker.MemberType ?? "field";
+
+        var isStatic = new bool[methodNames.Length];
+        var accessMemberTypes = new string[methodNames.Length];
+        for (int i = 0; i < methodNames.Length; i++)
+        {
+            var methodName = methodNames[i];
+            if (!staticWalker.IsStaticMap.TryGetValue(methodName, out var isStaticMethod))
+                return $"Error: No method named '{methodName}' in class '{sourceClass}'";
+
+            isStatic[i] = isStaticMethod;
+            accessMemberTypes[i] = isStaticMethod ? string.Empty : instanceMemberType;
+        }
+
+        var orderedIndices = OrderOperations(root, Enumerable.Repeat(sourceClass, methodNames.Length).ToArray(), methodNames);
+
+        var results = new List<string>();
+        var moved = new List<(string file, string method)>();
+        var currentDoc = document;
+        var targetPath = targetFilePath ?? Path.Combine(Path.GetDirectoryName(document.FilePath!)!, $"{targetClass}.cs");
+
+        foreach (var idx in orderedIndices)
+        {
+            try
+            {
+                var result = await MoveSingleMethod(
+                    currentDoc,
+                    sourceClass,
+                    methodNames[idx],
+                    isStatic[idx],
+                    ctorInjection,
+                    targetClass,
+                    accessMemberName,
+                    accessMemberTypes[idx],
+                    targetPath,
+                    cancellationToken);
+                currentDoc = result.updatedDocument;
+                moved.Add((document.FilePath!, methodNames[idx]));
+                results.Add(result.message);
+            }
+            catch (Exception ex)
+            {
+                results.Add($"Error moving method '{methodNames[idx]}': {ex.Message}");
+            }
+        }
+
+        foreach (var (file, method) in moved)
+            MoveMethodTool.MarkMoved(file, method);
+
+        return string.Join("\n", results);
+    }
+
 
 
     // Solution/Document operations that use the AST layer
 
-    [McpServerTool, Description("Move multiple methods from a source class to a target class, automatically ordering by dependencies. " +
-        "Wrapper methods remain at the original locations to delegate to the moved implementations." +
-        "The target class will be automatically created if it doesn't exist.")]
-    public static async Task<string> MoveMultipleMethods(
+    [McpServerTool, Description("Move multiple methods to a target class and transform them to static with an injected 'this' parameter.")]
+    public static Task<string> MoveMultipleMethodsStatic(
         [Description("Absolute path to the solution file (.sln)")] string solutionPath,
         [Description("Path to the C# file containing the methods")] string filePath,
         [Description("Name of the source class containing the methods")] string sourceClass,
@@ -91,111 +196,16 @@ public static partial class MoveMultipleMethodsTool
         [Description("Name of the target class")] string targetClass,
         [Description("Path to the target file (optional, target class will be automatically created if it doesnt exist or its unspecified)")] string? targetFilePath = null,
         CancellationToken cancellationToken = default)
-    {
-        try
-        {
-            if (methodNames.Length == 0)
-                throw new McpException("Error: No method names provided");
+        => MoveMultipleMethodsInternal(solutionPath, filePath, sourceClass, methodNames, targetClass, targetFilePath, false, cancellationToken);
 
-            var dupes = methodNames
-                .GroupBy(m => m)
-                .Where(g => g.Count() > 1)
-                .Select(g => g.Key)
-                .ToList();
-            if (dupes.Count > 0)
-                return $"Error: Duplicate method names are not supported: {string.Join(", ", dupes)}";
-
-            // Check upfront if any methods have already been moved
-            foreach (var methodName in methodNames)
-                MoveMethodTool.EnsureNotAlreadyMoved(filePath, methodName);
-
-            var solution = await RefactoringHelpers.GetOrLoadSolution(solutionPath, cancellationToken);
-            var document = RefactoringHelpers.GetDocumentByPath(solution, filePath);
-
-            if (document != null)
-            {
-                var root = await document.GetSyntaxRootAsync(cancellationToken);
-                if (root == null)
-                    throw new McpException("Error: Could not get syntax root");
-
-                var collector = new ClassCollectorWalker();
-                collector.Visit(root);
-                var classNodes = collector.Classes;
-
-                if (!classNodes.TryGetValue(sourceClass, out var sourceClassNode))
-                    throw new McpException($"Error: Source class '{sourceClass}' not found");
-
-                var visitor = new MethodAndMemberVisitor();
-                visitor.Visit(sourceClassNode);
-
-                var accessMemberName = MoveMethodAst.GenerateAccessMemberName(visitor.Members.Keys, targetClass);
-
-                var staticWalker = new MethodStaticWalker(methodNames);
-                staticWalker.Visit(sourceClassNode);
-
-                var memberWalker = new AccessMemberTypeWalker(accessMemberName);
-                memberWalker.Visit(sourceClassNode);
-                var instanceMemberType = memberWalker.MemberType ?? "field";
-
-                var isStatic = new bool[methodNames.Length];
-                var accessMemberTypes = new string[methodNames.Length];
-
-                for (int i = 0; i < methodNames.Length; i++)
-                {
-                    var methodName = methodNames[i];
-                    if (!staticWalker.IsStaticMap.TryGetValue(methodName, out var isStaticMethod))
-                        return $"Error: No method named '{methodName}' in class '{sourceClass}'";
-
-                    isStatic[i] = isStaticMethod;
-                    accessMemberTypes[i] = isStaticMethod ? string.Empty : instanceMemberType;
-                }
-
-                var sourceClasses = Enumerable.Repeat(sourceClass, methodNames.Length).ToArray();
-                var orderedIndices = OrderOperations(root, sourceClasses, methodNames);
-
-                var results = new List<string>();
-                var moved = new List<(string file, string method)>();
-                var currentDoc = document;
-                var targetPath = targetFilePath ?? Path.Combine(Path.GetDirectoryName(document.FilePath!)!, $"{targetClass}.cs");
-
-                foreach (var idx in orderedIndices)
-                {
-                    try
-                    {
-                        var result = await MoveSingleMethod(
-                            currentDoc,
-                            sourceClass,
-                            methodNames[idx],
-                            isStatic[idx],
-                            targetClass,
-                            accessMemberName,
-                            accessMemberTypes[idx],
-                            targetPath,
-                            cancellationToken);
-                        currentDoc = result.updatedDocument;
-                        moved.Add((document.FilePath!, methodNames[idx]));
-                        results.Add(result.message);
-                    }
-                    catch (Exception ex)
-                    {
-                        results.Add($"Error moving method '{methodNames[idx]}': {ex.Message}");
-                        // Don't add to moved list if the operation failed
-                    }
-                }
-
-                foreach (var (file, method) in moved)
-                    MoveMethodTool.MarkMoved(file, method);
-
-                return string.Join("\n", results);
-            }
-
-            // Fallback to AST-based approach for single-file mode or cross-file operations
-            // This path is no longer needed after unification
-            throw new McpException("Error: Could not find document in solution and AST fallback is disabled.");
-        }
-        catch (Exception ex)
-        {
-            throw new McpException($"Error moving multiple methods: {ex.Message}", ex);
-        }
-    }
+    [McpServerTool, Description("Move multiple methods and keep them as instance methods in the target class. The source instance is injected via the constructor if needed.")]
+    public static Task<string> MoveMultipleMethodsInstance(
+        [Description("Absolute path to the solution file (.sln)")] string solutionPath,
+        [Description("Path to the C# file containing the methods")] string filePath,
+        [Description("Name of the source class containing the methods")] string sourceClass,
+        [Description("Names of the methods to move")] string[] methodNames,
+        [Description("Name of the target class")] string targetClass,
+        [Description("Path to the target file (optional, target class will be automatically created if it doesnt exist or its unspecified)")] string? targetFilePath = null,
+        CancellationToken cancellationToken = default)
+        => MoveMultipleMethodsInternal(solutionPath, filePath, sourceClass, methodNames, targetClass, targetFilePath, true, cancellationToken);
 }

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsBugTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsBugTests.cs
@@ -28,7 +28,7 @@ public class Target { }";
         var project = solution.Projects.First();
         RefactoringHelpers.AddDocumentToProject(project, testFile);
 
-        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethodsStatic(
             SolutionPath,
             testFile,
             "Outer",

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsConstructorInjectionTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsConstructorInjectionTests.cs
@@ -21,7 +21,7 @@ public class MoveMultipleMethodsConstructorInjectionTests : TestBase
         var project = solution.Projects.First();
         RefactoringHelpers.AddDocumentToProject(project, testFile);
 
-        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethodsInstance(
             SolutionPath,
             testFile,
             "cA",
@@ -46,7 +46,7 @@ public class MoveMultipleMethodsConstructorInjectionTests : TestBase
         var project = solution.Projects.First();
         RefactoringHelpers.AddDocumentToProject(project, testFile);
 
-        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethodsStatic(
             SolutionPath,
             testFile,
             "cA",

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsDuplicateTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsDuplicateTests.cs
@@ -21,7 +21,7 @@ public class MoveMultipleMethodsDuplicateTests : TestBase
         var project = solution.Projects.First();
         RefactoringHelpers.AddDocumentToProject(project, testFile);
 
-        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethodsStatic(
             SolutionPath,
             testFile,
             "Source",

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsToolTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsToolTests.cs
@@ -18,7 +18,7 @@ public class MoveMultipleMethodsToolTests : TestBase
         var project = solution.Projects.First();
         RefactoringHelpers.AddDocumentToProject(project, testFile);
 
-        var error = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var error = await MoveMultipleMethodsTool.MoveMultipleMethodsStatic(
             SolutionPath,
             testFile,
             "Calculator",
@@ -26,7 +26,7 @@ public class MoveMultipleMethodsToolTests : TestBase
             "MathUtilities");
         Assert.Contains("Error:", error);
 
-        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethodsStatic(
             SolutionPath,
             testFile,
             "Calculator",

--- a/RefactorMCP.Tests/ToolsNew/MoveMultipleMethodsBugToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/MoveMultipleMethodsBugToolTests.cs
@@ -28,7 +28,7 @@ public class Target { }";
         var project = solution.Projects.First();
         RefactoringHelpers.AddDocumentToProject(project, testFile);
 
-        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethodsStatic(
             SolutionPath,
             testFile,
             "Outer",

--- a/RefactorMCP.Tests/ToolsNew/MoveMultipleMethodsConstructorInjectionToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/MoveMultipleMethodsConstructorInjectionToolTests.cs
@@ -21,7 +21,7 @@ public class MoveMultipleMethodsConstructorInjectionToolTests : RefactorMCP.Test
         var project = solution.Projects.First();
         RefactoringHelpers.AddDocumentToProject(project, testFile);
 
-        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethodsInstance(
             SolutionPath,
             testFile,
             "cA",
@@ -46,7 +46,7 @@ public class MoveMultipleMethodsConstructorInjectionToolTests : RefactorMCP.Test
         var project = solution.Projects.First();
         RefactoringHelpers.AddDocumentToProject(project, testFile);
 
-        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethodsStatic(
             SolutionPath,
             testFile,
             "cA",

--- a/RefactorMCP.Tests/ToolsNew/MoveMultipleMethodsDuplicateToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/MoveMultipleMethodsDuplicateToolTests.cs
@@ -21,7 +21,7 @@ public class MoveMultipleMethodsDuplicateToolTests : RefactorMCP.Tests.TestBase
         var project = solution.Projects.First();
         RefactoringHelpers.AddDocumentToProject(project, testFile);
 
-        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethodsStatic(
             SolutionPath,
             testFile,
             "Source",

--- a/RefactorMCP.Tests/ToolsNew/MoveMultipleMethodsToolToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/MoveMultipleMethodsToolToolTests.cs
@@ -20,7 +20,7 @@ public class MoveMultipleMethodsToolToolTests : RefactorMCP.Tests.TestBase
         var project = solution.Projects.First();
         RefactoringHelpers.AddDocumentToProject(project, testFile);
 
-        var error = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var error = await MoveMultipleMethodsTool.MoveMultipleMethodsStatic(
             SolutionPath,
             testFile,
             "Calculator",
@@ -28,7 +28,7 @@ public class MoveMultipleMethodsToolToolTests : RefactorMCP.Tests.TestBase
             "MathUtilities");
         Assert.Contains("Error:", error);
 
-        var result = await MoveMultipleMethodsTool.MoveMultipleMethods(
+        var result = await MoveMultipleMethodsTool.MoveMultipleMethodsStatic(
             SolutionPath,
             testFile,
             "Calculator",


### PR DESCRIPTION
## Summary
- support two variants for moving multiple methods
- document the new commands
- update tests for the renamed tools

## Testing
- `dotnet format --no-restore`
- `dotnet build --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685bcfcc260c8327bb7c038047268741