### PR TITLE
Use shared workspace in tests

### DIFF
--- a/RefactorMCP.Tests/AssemblyInfo.cs
+++ b/RefactorMCP.Tests/AssemblyInfo.cs
@@ -1,4 +1,5 @@
 using Xunit;
-// Enable test parallelization to speed up the suite. TestBase creates isolated
-// output directories for each test instance so parallel execution is safe.
-// The default xUnit settings will run tests in parallel within each assembly.
+
+// Tests share a single AdhocWorkspace via RefactoringHelpers.SharedWorkspace.
+// Running them in parallel causes interference, so we disable parallelization.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/RefactorMCP.Tests/Roslyn/AstTransformationsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/AstTransformationsTests.cs
@@ -60,7 +60,7 @@ public partial class RoslynTransformationTests
     {
         var invocation = SyntaxFactory.ParseExpression("M()") as InvocationExpressionSyntax;
         var expr = SyntaxFactory.IdentifierName("x");
-        var generator = SyntaxGenerator.GetGenerator(new AdhocWorkspace(), LanguageNames.CSharp);
+        var generator = SyntaxGenerator.GetGenerator(RefactoringHelpers.SharedWorkspace, LanguageNames.CSharp);
         var updated = AstTransformations.AddArgument(invocation!, expr, generator);
 
         Assert.Equal("M(x)", updated.NormalizeWhitespace().ToFullString());

--- a/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
+++ b/RefactorMCP.Tests/Roslyn/MoveMethodsTests.cs
@@ -38,7 +38,7 @@ namespace RefactorMCP.Tests.Roslyn
                 }
             }
 
-            var workspace = new AdhocWorkspace();
+            var workspace = RefactoringHelpers.SharedWorkspace;
             var formattedRoot = Formatter.Format(root, workspace);
             return formattedRoot.ToFullString();
         }
@@ -205,7 +205,7 @@ public class TargetClass
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("public static int GetValue(int value)", formatted);
             Assert.Contains("return value + 2", formatted);
@@ -237,7 +237,7 @@ public class TargetClass
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("public static int GetValue(int value, int n = 5)", formatted);
             Assert.Contains("TargetClass.GetValue(_value, n)", formatted);
@@ -267,7 +267,7 @@ public class TargetClass
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("public void Say()", formatted);
             Assert.DoesNotContain("@this", formatted);
@@ -304,7 +304,7 @@ public class TargetClass
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "TargetClass", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("resProduct.Modified += @this.Child_Modified", formatted);
         }
@@ -340,7 +340,7 @@ class Target { }";
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("@this.Name", formatted);
         }
@@ -367,7 +367,7 @@ public class Extracted { }";
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Extracted", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("Extracted.MethodBefore(this)", formatted);
             Assert.Contains("new T(@this)", formatted);
@@ -396,7 +396,7 @@ public class Target { }";
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("Outer.Helper", formatted);
         }
@@ -428,7 +428,7 @@ class B { }";
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "B", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("A.C Method1()", formatted);
             Assert.Contains("new A.C", formatted);
@@ -461,7 +461,7 @@ public class B { }";
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "B", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("A.Nested GetNested()", formatted);
             Assert.Contains("new A.Nested()", formatted);
@@ -495,7 +495,7 @@ public class B { }";
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "B", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("A.Kind GetKind()", formatted);
             Assert.Contains("A.Kind.A", formatted);
@@ -525,7 +525,7 @@ public class Target { }";
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("internal void Helper()", formatted);
         }
@@ -556,7 +556,7 @@ class Target { }";
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("@this.GetName()", formatted);
         }
@@ -586,7 +586,7 @@ class Target { }";
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("@this.Value", formatted);
         }
@@ -627,7 +627,7 @@ class Target { }";
                 "field");
 
             var finalRoot = MoveMethodAst.AddMethodToTargetClass(result.NewSourceRoot, "Target", result.MovedMethod, result.Namespace);
-            var formatted = Formatter.Format(finalRoot, new AdhocWorkspace()).ToFullString();
+            var formatted = Formatter.Format(finalRoot, RefactoringHelpers.SharedWorkspace).ToFullString();
 
             Assert.Contains("Username = @this.strCurrentOperatorCode", formatted);
             Assert.Contains("SiteId = @this.ConnectedSiteID", formatted);

--- a/RefactorMCP.Tests/Roslyn/Rewriters/ExtractMethodRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ExtractMethodRewriterTests.cs
@@ -19,7 +19,7 @@ public partial class RoslynTransformationTests
         var method = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First();
         var firstStmt = method.Body!.Statements.First();
         var rewriter = new ExtractMethodRewriter(method, root.DescendantNodes().OfType<ClassDeclarationSyntax>().First(), new List<StatementSyntax> { firstStmt }, "NewMethod");
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, RefactoringHelpers.SharedWorkspace);
         var text = newRoot.ToFullString();
         Assert.Contains("private void NewMethod()", text);
         Assert.Contains("NewMethod();", text);

--- a/RefactorMCP.Tests/Roslyn/Rewriters/FieldIntroductionRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/FieldIntroductionRewriterTests.cs
@@ -23,7 +23,7 @@ public partial class RoslynTransformationTests
             .AddModifiers(SyntaxFactory.Token(SyntaxKind.PrivateKeyword));
         var classNode = root.DescendantNodes().OfType<ClassDeclarationSyntax>().First();
         var rewriter = new FieldIntroductionRewriter(expr, fieldRef, fieldDecl, classNode);
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, RefactoringHelpers.SharedWorkspace);
         var text = newRoot.ToFullString();
         Assert.Contains("private int value", text);
         Assert.Contains("return value", text);

--- a/RefactorMCP.Tests/Roslyn/Rewriters/FieldRemovalRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/FieldRemovalRewriterTests.cs
@@ -14,7 +14,7 @@ public partial class RoslynTransformationTests
         var tree = CSharpSyntaxTree.ParseText("class A{int x;}");
         var root = tree.GetRoot();
         var rewriter = new FieldRemovalRewriter("x");
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, RefactoringHelpers.SharedWorkspace);
         Assert.Equal("class A { }", newRoot.ToFullString().Trim());
     }
 }

--- a/RefactorMCP.Tests/Roslyn/Rewriters/InlineInvocationRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/InlineInvocationRewriterTests.cs
@@ -17,7 +17,7 @@ public partial class RoslynTransformationTests
         var root = tree.GetRoot();
         var helper = root.DescendantNodes().OfType<MethodDeclarationSyntax>().First(m => m.Identifier.ValueText == "Helper");
         var rewriter = new InlineInvocationRewriter(helper);
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, RefactoringHelpers.SharedWorkspace);
         var callMethod = newRoot.DescendantNodes().OfType<MethodDeclarationSyntax>().First(m => m.Identifier.ValueText == "Call");
         var text = callMethod.Body!.Statements.ToFullString();
         Assert.Contains("Console.WriteLine(\"Hi\");", text);

--- a/RefactorMCP.Tests/Roslyn/Rewriters/MethodRemovalRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/MethodRemovalRewriterTests.cs
@@ -14,7 +14,7 @@ public partial class RoslynTransformationTests
         var tree = CSharpSyntaxTree.ParseText("class A{void M(){}}");
         var root = tree.GetRoot();
         var rewriter = new MethodRemovalRewriter("M");
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, RefactoringHelpers.SharedWorkspace);
         Assert.Equal("class A { }", newRoot.ToFullString().Trim());
     }
 }

--- a/RefactorMCP.Tests/Roslyn/Rewriters/ParameterIntroductionRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ParameterIntroductionRewriterTests.cs
@@ -19,9 +19,9 @@ public partial class RoslynTransformationTests
         var expr = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1));
         var parameter = SyntaxFactory.Parameter(SyntaxFactory.Identifier("p")).WithType(SyntaxFactory.ParseTypeName("int"));
         var paramRef = SyntaxFactory.IdentifierName("p");
-        var generator = SyntaxGenerator.GetGenerator(new AdhocWorkspace(), LanguageNames.CSharp);
+        var generator = SyntaxGenerator.GetGenerator(RefactoringHelpers.SharedWorkspace, LanguageNames.CSharp);
         var rewriter = new ParameterIntroductionRewriter(expr, "M", parameter, paramRef, generator);
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, RefactoringHelpers.SharedWorkspace);
         var text = newRoot.ToFullString();
         Assert.Contains("void M(int p)", text);
         Assert.Contains("Console.WriteLine(p)", text);

--- a/RefactorMCP.Tests/Roslyn/Rewriters/ParameterRemovalRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ParameterRemovalRewriterTests.cs
@@ -13,9 +13,9 @@ public partial class RoslynTransformationTests
     {
         var tree = CSharpSyntaxTree.ParseText("class A{void M(int a,int b){}} class B{void Call(){new A().M(1,2);}} ");
         var root = tree.GetRoot();
-        var generator = SyntaxGenerator.GetGenerator(new AdhocWorkspace(), LanguageNames.CSharp);
+        var generator = SyntaxGenerator.GetGenerator(RefactoringHelpers.SharedWorkspace, LanguageNames.CSharp);
         var rewriter = new ParameterRemovalRewriter("M", 1, generator);
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, RefactoringHelpers.SharedWorkspace);
         var text = newRoot.ToFullString();
         Assert.Contains("void M(int a)", text);
         Assert.Contains("M(1)", text);

--- a/RefactorMCP.Tests/Roslyn/Rewriters/ReadonlyFieldRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/ReadonlyFieldRewriterTests.cs
@@ -15,7 +15,7 @@ public partial class RoslynTransformationTests
         var root = tree.GetRoot();
         var init = SyntaxFactory.LiteralExpression(SyntaxKind.NumericLiteralExpression, SyntaxFactory.Literal(1));
         var rewriter = new ReadonlyFieldRewriter("x", init);
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, RefactoringHelpers.SharedWorkspace);
         var text = newRoot.ToFullString();
         Assert.Contains("readonly int x", text);
         Assert.Contains("x = 1;", text);

--- a/RefactorMCP.Tests/Roslyn/Rewriters/VariableIntroductionRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/VariableIntroductionRewriterTests.cs
@@ -24,7 +24,7 @@ public partial class RoslynTransformationTests
         var callStmt = root.DescendantNodes().OfType<ExpressionStatementSyntax>().First();
         var block = callStmt.Ancestors().OfType<BlockSyntax>().First();
         var rewriter = new VariableIntroductionRewriter(expr, varRef, varDecl, callStmt, block);
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, RefactoringHelpers.SharedWorkspace);
         var text = newRoot.ToFullString();
         Assert.Contains("var sum = 1 + 2;", text);
         Assert.Contains("Console.WriteLine(sum);", text);

--- a/RefactorMCP.Tests/Roslyn/Rewriters/VariableRemovalRewriterTests.cs
+++ b/RefactorMCP.Tests/Roslyn/Rewriters/VariableRemovalRewriterTests.cs
@@ -17,7 +17,7 @@ public partial class RoslynTransformationTests
         var root = tree.GetRoot();
         var varNode = root.DescendantNodes().OfType<VariableDeclaratorSyntax>().First();
         var rewriter = new VariableRemovalRewriter("x", varNode.Span);
-        var newRoot = Formatter.Format(rewriter.Visit(root)!, new AdhocWorkspace());
+        var newRoot = Formatter.Format(rewriter.Visit(root)!, RefactoringHelpers.SharedWorkspace);
         Assert.Equal("void M() { }", newRoot.ToFullString().Trim());
     }
 }

--- a/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveInstanceMethodTests.cs
@@ -433,7 +433,7 @@ public class SourceClass
 }
 
 public class Target { }";
-        
+
         await TestUtilities.CreateTestFile(testFile, code);
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
         var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);
@@ -452,7 +452,7 @@ public class Target { }";
     }
 
     [Fact]
-    public async Task MoveInstanceMethod_WithThisQualifierInNamedArgs_ShouldSucceed()  
+    public async Task MoveInstanceMethod_WithThisQualifierInNamedArgs_ShouldSucceed()
     {
         UnloadSolutionTool.ClearSolutionCache();
         var testFile = Path.GetFullPath(Path.Combine(TestOutputPath, "ThisQualifierNamed.cs"));
@@ -496,7 +496,7 @@ public class SourceClass
 }
 
 public class Target { }";
-        
+
         await TestUtilities.CreateTestFile(testFile, code);
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
         var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);
@@ -513,7 +513,7 @@ public class Target { }";
         Assert.Contains("Successfully moved", result);
     }
 
-    [Fact] 
+    [Fact]
     public async Task MoveInstanceMethod_WithMixedInstanceMembersAndNamedArgs_ShouldSucceed()
     {
         UnloadSolutionTool.ClearSolutionCache();
@@ -564,7 +564,7 @@ public class SourceClass
 }
 
 public class Target { }";
-        
+
         await TestUtilities.CreateTestFile(testFile, code);
         await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
         var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsTests.cs
@@ -36,7 +36,7 @@ public class MoveMultipleMethodsTests
             }
         }
 
-        var workspace = new AdhocWorkspace();
+        var workspace = RefactoringHelpers.SharedWorkspace;
         var formattedRoot = Formatter.Format(root, workspace);
         return formattedRoot.ToFullString();
     }
@@ -215,7 +215,7 @@ public class DepositManager
         var result = MoveMethodAst.MoveInstanceMethodAst(
             root,
             "cResRoom",
-            "CreatePostingItem", 
+            "CreatePostingItem",
             "DepositManager",
             "instance",
             "instance"
@@ -261,7 +261,7 @@ public class DepositManager
         // The main verification is that no exception is thrown
         var result = MoveMethodAst.MoveInstanceMethodAst(
             root,
-            "cResRoom", 
+            "cResRoom",
             "AddDepositFromDepositTransaction",
             "DepositManager",
             "instance",
@@ -315,7 +315,7 @@ public class DepositManager
             root,
             "cResRoom",
             "GenerateInvoice",
-            "DepositManager", 
+            "DepositManager",
             "instance",
             "instance"
         );
@@ -369,7 +369,7 @@ public class TargetManager { }";
 
         // Verify the operation succeeded without throwing exceptions
         Assert.NotNull(result);
-        
+
         // The main success criteria is that no InvalidCastException was thrown
         // This test reproduces the exact casting bug that was happening with
         // named arguments containing member access expressions like _dbContextFactory

--- a/RefactorMCP.Tests/Tools/MoveOverrideMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveOverrideMethodTests.cs
@@ -18,7 +18,7 @@ public class MoveOverrideMethodTests
 
         var moveResult = MoveMethodAst.MoveInstanceMethodAst(root, "Derived", "Foo", "Target", "", "");
         var updatedRoot = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, "Target", moveResult.MovedMethod, moveResult.Namespace);
-        var formattedRoot = Formatter.Format(updatedRoot, new AdhocWorkspace());
+        var formattedRoot = Formatter.Format(updatedRoot, RefactoringHelpers.SharedWorkspace);
 
         var targetClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>()
             .First(c => c.Identifier.ValueText == "Target");

--- a/RefactorMCP.Tests/Tools/MoveProtectedOverrideDependencyTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveProtectedOverrideDependencyTests.cs
@@ -18,7 +18,7 @@ public class MoveProtectedOverrideDependencyTests
 
         var moveResult = MoveMethodAst.MoveInstanceMethodAst(root, "Derived", "Another", "Target", "", "");
         var updatedRoot = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, "Target", moveResult.MovedMethod, moveResult.Namespace);
-        var formattedRoot = Formatter.Format(updatedRoot, new AdhocWorkspace());
+        var formattedRoot = Formatter.Format(updatedRoot, RefactoringHelpers.SharedWorkspace);
 
         var derivedClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>().First(c => c.Identifier.ValueText == "Derived");
         var method = derivedClass.Members.OfType<MethodDeclarationSyntax>().First(m => m.Identifier.ValueText == "DoIt");

--- a/RefactorMCP.Tests/Tools/MoveVirtualMethodTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveVirtualMethodTests.cs
@@ -19,7 +19,7 @@ public class MoveVirtualMethodTests
 
         var moveResult = MoveMethodAst.MoveInstanceMethodAst(root, "B", "Method1", "ExtractedFromB", "", "");
         var updatedRoot = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, "ExtractedFromB", moveResult.MovedMethod, moveResult.Namespace);
-        var formattedRoot = Formatter.Format(updatedRoot, new AdhocWorkspace());
+        var formattedRoot = Formatter.Format(updatedRoot, RefactoringHelpers.SharedWorkspace);
 
         var bClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>().First(c => c.Identifier.ValueText == "B");
         Assert.Contains("BaseMethod1", bClass.ToFullString());

--- a/RefactorMCP.Tests/ToolsNew/MoveOverrideMethodToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/MoveOverrideMethodToolTests.cs
@@ -19,7 +19,7 @@ public class MoveOverrideMethodToolTests
 
         var moveResult = MoveMethodAst.MoveInstanceMethodAst(root, "Derived", "Foo", "Target", "", "");
         var updatedRoot = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, "Target", moveResult.MovedMethod, moveResult.Namespace);
-        var formattedRoot = Formatter.Format(updatedRoot, new AdhocWorkspace());
+        var formattedRoot = Formatter.Format(updatedRoot, RefactoringHelpers.SharedWorkspace);
 
         var targetClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>()
             .First(c => c.Identifier.ValueText == "Target");

--- a/RefactorMCP.Tests/ToolsNew/MoveProtectedOverrideDependencyToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/MoveProtectedOverrideDependencyToolTests.cs
@@ -19,7 +19,7 @@ public class MoveProtectedOverrideDependencyToolTests
 
         var moveResult = MoveMethodAst.MoveInstanceMethodAst(root, "Derived", "Another", "Target", "", "");
         var updatedRoot = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, "Target", moveResult.MovedMethod, moveResult.Namespace);
-        var formattedRoot = Formatter.Format(updatedRoot, new AdhocWorkspace());
+        var formattedRoot = Formatter.Format(updatedRoot, RefactoringHelpers.SharedWorkspace);
 
         var derivedClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>().First(c => c.Identifier.ValueText == "Derived");
         var method = derivedClass.Members.OfType<MethodDeclarationSyntax>().First(m => m.Identifier.ValueText == "DoIt");

--- a/RefactorMCP.Tests/ToolsNew/MoveVirtualMethodToolTests.cs
+++ b/RefactorMCP.Tests/ToolsNew/MoveVirtualMethodToolTests.cs
@@ -20,7 +20,7 @@ public class MoveVirtualMethodToolTests
 
         var moveResult = MoveMethodAst.MoveInstanceMethodAst(root, "B", "Method1", "ExtractedFromB", "", "");
         var updatedRoot = MoveMethodAst.AddMethodToTargetClass(moveResult.NewSourceRoot, "ExtractedFromB", moveResult.MovedMethod, moveResult.Namespace);
-        var formattedRoot = Formatter.Format(updatedRoot, new AdhocWorkspace());
+        var formattedRoot = Formatter.Format(updatedRoot, RefactoringHelpers.SharedWorkspace);
 
         var bClass = formattedRoot.DescendantNodes().OfType<ClassDeclarationSyntax>().First(c => c.Identifier.ValueText == "B");
         Assert.Contains("BaseMethod1", bClass.ToFullString());


### PR DESCRIPTION
## Summary
- reuse `RefactoringHelpers.SharedWorkspace` in tests instead of allocating `AdhocWorkspace`
- disable xUnit test parallelization to avoid shared workspace conflicts

## Testing
- `dotnet format --no-restore`
- `dotnet build --no-restore`
- `dotnet test --no-build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_686949ad65008327b80509e15313dc9f