### PR TITLE
Normalize tool name matching for kebab-case inputs

### DIFF
--- a/RefactorMCP.ConsoleApp/Program.cs
+++ b/RefactorMCP.ConsoleApp/Program.cs
@@ -11,7 +11,6 @@ using ModelContextProtocol.Server;
 using System;
 using System.ComponentModel;
 using System.Reflection;
-using System.Text;
 using System.Text.Json;
 using System.Runtime.CompilerServices;
 
@@ -76,7 +75,7 @@ static async Task RunJsonMode(string[] args)
         .Where(t => t.GetCustomAttributes(typeof(McpServerToolTypeAttribute), false).Length > 0)
         .SelectMany(t => t.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static))
         .FirstOrDefault(m => m.GetCustomAttributes(typeof(McpServerToolAttribute), false).Length > 0 &&
-                             m.Name.Equals(toolName, StringComparison.OrdinalIgnoreCase));
+                             ToolNameHelper.Matches(toolName, m));
 
     if (method == null)
     {
@@ -149,26 +148,12 @@ static string ListAvailableTools()
         .Where(t => t.GetCustomAttributes(typeof(McpServerToolTypeAttribute), false).Length > 0)
         .SelectMany(t => t.GetMethods(System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static))
         .Where(m => m.GetCustomAttributes(typeof(McpServerToolAttribute), false).Length > 0)
-        .Select(m => ToKebabCase(m.Name))
+        .Select(m => ToolNameHelper.ToKebabCase(m.Name))
         .OrderBy(n => n)
         .ToArray();
 
     return "Available refactoring tools:\n" + string.Join("\n", toolNames);
 
-}
-
-
-static string ToKebabCase(string name)
-{
-    var sb = new StringBuilder();
-    for (int i = 0; i < name.Length; i++)
-    {
-        var c = name[i];
-        if (char.IsUpper(c) && i > 0)
-            sb.Append('-');
-        sb.Append(char.ToLowerInvariant(c));
-    }
-    return sb.ToString();
 }
 
 static object? ConvertInput(string value, Type targetType)

--- a/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodReferenceRewriter.cs
+++ b/RefactorMCP.ConsoleApp/SyntaxRewriters/MethodReferenceRewriter.cs
@@ -21,8 +21,8 @@ internal class MethodReferenceRewriter : CSharpSyntaxRewriter
             var parent = node.Parent;
             // Don't rewrite identifiers inside conditional access expressions (?.member)
             // or when they're already part of member access expressions or invocations
-            if (parent is not InvocationExpressionSyntax && 
-                parent is not MemberAccessExpressionSyntax && 
+            if (parent is not InvocationExpressionSyntax &&
+                parent is not MemberAccessExpressionSyntax &&
                 parent is not MemberBindingExpressionSyntax)
             {
                 var memberAccess = SyntaxFactory.MemberAccessExpression(

--- a/RefactorMCP.ConsoleApp/ToolCallLogger.cs
+++ b/RefactorMCP.ConsoleApp/ToolCallLogger.cs
@@ -129,7 +129,7 @@ internal static class ToolCallLogger
             .Where(t => t.GetCustomAttributes(typeof(McpServerToolTypeAttribute), false).Length > 0)
             .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.Static))
             .FirstOrDefault(m => m.GetCustomAttributes(typeof(McpServerToolAttribute), false).Length > 0 &&
-                                 m.Name.Equals(toolName, StringComparison.OrdinalIgnoreCase));
+                                 ToolNameHelper.Matches(toolName, m));
     }
 
     private static object? ConvertInput(string value, Type targetType)
@@ -152,4 +152,3 @@ internal static class ToolCallLogger
         public DateTime Timestamp { get; set; }
     }
 }
-

--- a/RefactorMCP.ConsoleApp/ToolNameHelper.cs
+++ b/RefactorMCP.ConsoleApp/ToolNameHelper.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+
+internal static class ToolNameHelper
+{
+    public static bool Matches(string toolName, MethodInfo method)
+    {
+        if (string.IsNullOrWhiteSpace(toolName))
+            return false;
+
+        return method.Name.Equals(toolName, StringComparison.OrdinalIgnoreCase)
+               || ToKebabCase(method.Name).Equals(toolName, StringComparison.OrdinalIgnoreCase)
+               || method.Name.Equals(ToPascalCase(toolName), StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string ToKebabCase(string name)
+    {
+        var sb = new StringBuilder();
+        for (int i = 0; i < name.Length; i++)
+        {
+            var c = name[i];
+            if (char.IsUpper(c) && i > 0)
+                sb.Append('-');
+            sb.Append(char.ToLowerInvariant(c));
+        }
+        return sb.ToString();
+    }
+
+    public static string ToPascalCase(string name)
+    {
+        if (!name.Contains('-'))
+            return name;
+
+        var parts = name.Split('-', StringSplitOptions.RemoveEmptyEntries);
+        return string.Concat(parts.Select(part =>
+            part.Length == 0
+                ? string.Empty
+                : char.ToUpperInvariant(part[0]) + part.Substring(1)));
+    }
+}

--- a/RefactorMCP.ConsoleApp/Tools/MoveMethodAst.cs
+++ b/RefactorMCP.ConsoleApp/Tools/MoveMethodAst.cs
@@ -116,19 +116,19 @@ public static partial class MoveMethodAst
             nodes.Add(method.Body);
         if (method.ExpressionBody != null)
             nodes.Add(method.ExpressionBody);
-        
+
         var allNodes = nodes.SelectMany(n => n.DescendantNodes());
-        
+
         // Check for direct identifier usage
         var hasIdentifierUsage = allNodes
             .OfType<IdentifierNameSyntax>()
             .Any(id => id.Identifier.ValueText == parameterName);
-            
+
         // Check for usage in member access expressions (e.g., parameterName.SomeProperty)
         var hasMemberAccessUsage = allNodes
             .OfType<MemberAccessExpressionSyntax>()
             .Any(ma => ma.Expression is IdentifierNameSyntax id && id.Identifier.ValueText == parameterName);
-            
+
         return hasIdentifierUsage || hasMemberAccessUsage;
     }
 

--- a/RefactorMCP.Tests/Tools/MoveMultipleMethodsToolTests.cs
+++ b/RefactorMCP.Tests/Tools/MoveMultipleMethodsToolTests.cs
@@ -56,7 +56,7 @@ public class Target { }
         var solution = await RefactoringHelpers.GetOrLoadSolution(SolutionPath);
         var project = solution.Projects.First();
         RefactoringHelpers.AddDocumentToProject(project, testFile);
-        
+
         var result = await MoveMultipleMethodsTool.MoveMultipleMethodsStatic(
             SolutionPath,
             testFile,


### PR DESCRIPTION
### Motivation

- Runtime JSON-mode invocation and playback used different name matching logic, causing inconsistent behavior for kebab-case tool names. 
- Introduce a single normalization/lookup helper so both execution and playback accept PascalCase and kebab-case consistently.

### Description

- Add `ToolNameHelper` with `Matches`, `ToKebabCase`, and `ToPascalCase` to centralize tool-name normalization and comparison. 
- Update `Program.cs` (JSON mode) to use `ToolNameHelper.Matches` for method resolution and to list tools via `ToolNameHelper.ToKebabCase`. 
- Update `ToolCallLogger.cs` playback lookup to use `ToolNameHelper.Matches`. 
- Remove the duplicate local `ToKebabCase` implementation and apply minor whitespace/formatting fixes from `dotnet format`.

### Testing

- Ran `dotnet format`, which completed successfully. 
- Ran `dotnet test`, which failed with compilation errors: `SafeDeleteTool` does not contain a definition for `SafeDelete` (tests did not complete green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971d0889a888327bf6de525ad8c6664)