### PR TITLE
Fix CleanupUsings removing used usings from other files

### DIFF
--- a/RefactorMCP.ConsoleApp/Tools/CleanupUsingsTool.cs
+++ b/RefactorMCP.ConsoleApp/Tools/CleanupUsingsTool.cs
@@ -43,11 +43,11 @@ public static class CleanupUsingsTool
         if (root == null)
             return $"No content in {document.FilePath}";
 
-        var compilation = await document.Project.GetCompilationAsync();
-        if (compilation == null)
-            return $"Could not compile project for {document.FilePath}";
+        var semanticModel = await document.GetSemanticModelAsync();
+        if (semanticModel == null)
+            return $"Could not get semantic model for {document.FilePath}";
 
-        var diagnostics = compilation.GetDiagnostics();
+        var diagnostics = semanticModel.GetDiagnostics();
         var unused = diagnostics
             .Where(d => d.Id == "CS8019")
             .Select(d => root.FindNode(d.Location.SourceSpan))

--- a/RefactorMCP.Tests/Tools/CleanupUsingsToolTests.cs
+++ b/RefactorMCP.Tests/Tools/CleanupUsingsToolTests.cs
@@ -39,4 +39,54 @@ public class CleanupSample
         var fileContent = await File.ReadAllTextAsync(testFile);
         Assert.Equal(expectedCode, fileContent.Replace("\r\n", "\n"));
     }
+
+    [Fact]
+    public async Task CleanupUsings_DoesNotRemoveUsingsFromOtherFiles()
+    {
+        // FileA has an unused using (System.Text)
+        const string fileACode = """
+using System;
+using System.Text;
+
+public class FileA
+{
+    public void Say() => Console.WriteLine("Hi");
+}
+""";
+
+        // FileB uses System.Text - it should NOT be removed
+        const string fileBCode = """
+using System;
+using System.Text;
+
+public class FileB
+{
+    public void Say() => Console.WriteLine(Encoding.UTF8.EncodingName);
+}
+""";
+
+        // FileB should remain unchanged since System.Text is used
+        const string expectedFileBCode = """
+using System;
+using System.Text;
+
+public class FileB
+{
+    public void Say() => Console.WriteLine(Encoding.UTF8.EncodingName);
+}
+""";
+
+        await LoadSolutionTool.LoadSolution(SolutionPath, null, CancellationToken.None);
+
+        var fileA = Path.Combine(TestOutputPath, "FileA.cs");
+        var fileB = Path.Combine(TestOutputPath, "FileB.cs");
+        await TestUtilities.CreateTestFile(fileA, fileACode);
+        await TestUtilities.CreateTestFile(fileB, fileBCode);
+
+        // Clean up FileB - should NOT remove System.Text even though FileA has it unused
+        var result = await CleanupUsingsTool.CleanupUsings(SolutionPath, fileB);
+
+        var fileBContent = await File.ReadAllTextAsync(fileB);
+        Assert.Equal(expectedFileBCode.Replace("\r\n", "\n"), fileBContent.Replace("\r\n", "\n"));
+    }
 }


### PR DESCRIPTION
## Summary

Fixed a bug where `CleanupUsings` would incorrectly remove usings that were actually used.

## The Problem

`compilation.GetDiagnostics()` returns diagnostics from ALL files in the project. When processing a CS8019 (unused using) diagnostic from file A, `root.FindNode(span)` would find whatever node happens to be at that position in the current file B - potentially removing a used using.

## The Fix

Changed from `compilation.GetDiagnostics()` to `semanticModel.GetDiagnostics()` which is scoped to the specific document. This matches the pattern used by other tools in this project (e.g., `InlineMethodTool`, `IntroduceFieldTool`).

## Test

Added `CleanupUsings_DoesNotRemoveUsingsFromOtherFiles` test that:
- Creates two files: FileA with unused `System.Text`, FileB with used `System.Text`
- Runs CleanupUsings on FileB
- Verifies `System.Text` is NOT removed from FileB

🤖 Generated with [Claude Code](https://claude.com/claude-code)